### PR TITLE
Fix release image build by adding the missing BUILD_IMG variable.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,10 @@ jobs:
       - name: Build image and push to Docker Hub and GitHub image registry
         uses: docker/build-push-action@v4
         with:
+          build-args: |
+            BUILD_IMG=golang:1.20.4
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/k0sproject/k0smotron:${{ needs.release.outputs.image_tag }}
             quay.io/k0sproject/k0smotron:${{ needs.release.outputs.image_tag }}


### PR DESCRIPTION
Without the build param the build fails like in: https://github.com/k0sproject/k0smotron/actions/runs/5133543923/jobs/9236272409

Also dropped armv7, I don't think anyone wants to run k0smotron on armv7. :smile:

