### PR TITLE
Pin Markdown to 3.3 as 3.4 is not compatible with mkdocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ colorama==0.4.6
 ghp-import==2.1.0
 idna==3.4
 Jinja2==3.1.2
-Markdown==3.3
+Markdown==3.3.7
 MarkupSafe==2.1.3
 mdx-truly-sane-lists==1.3
 mergedeep==1.3.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ colorama==0.4.6
 ghp-import==2.1.0
 idna==3.4
 Jinja2==3.1.2
-Markdown==3.4.3
+Markdown==3.3
 MarkupSafe==2.1.3
 mdx-truly-sane-lists==1.3
 mergedeep==1.3.4


### PR DESCRIPTION
The latest MkDocs pins this to <3.4 for compatibility reasons.

Pin Python-Markdown version to <3.4, thus excluding its latest release that breaks too many external extensions (https://github.com/mkdocs/mkdocs/issues/2893)