### PR TITLE
[CAPI] cloud init customization

### DIFF
--- a/api/bootstrap/v1beta1/k0s_types.go
+++ b/api/bootstrap/v1beta1/k0s_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/k0sproject/k0smotron/internal/cloudinit"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -58,6 +59,31 @@ type K0sWorkerConfigSpec struct {
 	// For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
 	// +kubebuilder:validation:Optional
 	Version string `json:"version,omitempty"`
+
+	// Files specifies extra files to be passed to user_data upon creation.
+	// +kubebuilder:validation:Optional
+	Files []cloudinit.File `json:"files,omitempty"`
+
+	// Args specifies extra arguments to be passed to k0s worker.
+	// See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+	Args []string `json:"args,omitempty"`
+
+	// PreStartCommands specifies commands to be run before starting k0s worker.
+	// +kubebuilder:validation:Optional
+	PreStartCommands []string `json:"preStartCommands,omitempty"`
+
+	// PostStartCommands specifies commands to be run after starting k0s worker.
+	// +kubebuilder:validation:Optional
+	PostStartCommands []string `json:"postStartCommands,omitempty"`
+
+	// PreInstallK0s specifies whether k0s binary is pre-installed on the node.
+	// +kubebuilder:validation:Optional
+	PreInstalledK0s bool `json:"preInstalledK0s,omitempty"`
+
+	// DownloadURL specifies the URL to download k0s binary from.
+	// If specified the version field is ignored and what ever version is downloaded from the URL is used.
+	// +kubebuilder:validation:Optional
+	DownloadURL string `json:"downloadURL,omitempty"`
 }
 
 type JoinTokenSecretRef struct {

--- a/api/bootstrap/v1beta1/zz_generated.deepcopy.go
+++ b/api/bootstrap/v1beta1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/k0sproject/k0smotron/internal/cloudinit"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -106,6 +107,26 @@ func (in *K0sWorkerConfigSpec) DeepCopyInto(out *K0sWorkerConfigSpec) {
 		in, out := &in.JoinTokenSecretRef, &out.JoinTokenSecretRef
 		*out = new(JoinTokenSecretRef)
 		**out = **in
+	}
+	if in.Files != nil {
+		in, out := &in.Files, &out.Files
+		*out = make([]cloudinit.File, len(*in))
+		copy(*out, *in)
+	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.PreStartCommands != nil {
+		in, out := &in.PreStartCommands, &out.PreStartCommands
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.PostStartCommands != nil {
+		in, out := &in.PostStartCommands, &out.PostStartCommands
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -34,6 +34,30 @@ spec:
             type: object
           spec:
             properties:
+              args:
+                description: 'Args specifies extra arguments to be passed to k0s worker.
+                  See: https://docs.k0sproject.io/stable/advanced/worker-configuration/'
+                items:
+                  type: string
+                type: array
+              downloadURL:
+                description: DownloadURL specifies the URL to download k0s binary
+                  from. If specified the version field is ignored and what ever version
+                  is downloaded from the URL is used.
+                type: string
+              files:
+                description: Files specifies extra files to be passed to user_data
+                  upon creation.
+                items:
+                  properties:
+                    content:
+                      type: string
+                    path:
+                      type: string
+                    permissions:
+                      type: string
+                  type: object
+                type: array
               joinTokenSecretRef:
                 description: JoinTokenSecretRef is a reference to a secret that contains
                   the join token. This should be only set in the case you want to
@@ -50,6 +74,22 @@ spec:
                 - key
                 - name
                 type: object
+              postStartCommands:
+                description: PostStartCommands specifies commands to be run after
+                  starting k0s worker.
+                items:
+                  type: string
+                type: array
+              preInstalledK0s:
+                description: PreInstallK0s specifies whether k0s binary is pre-installed
+                  on the node.
+                type: boolean
+              preStartCommands:
+                description: PreStartCommands specifies commands to be run before
+                  starting k0s worker.
+                items:
+                  type: string
+                type: array
               version:
                 description: 'Version is the version of k0s to use. In case this is
                   not set, the latest version is used. Make sure the version is compatible

--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -25,14 +25,14 @@ import (
 // Very basic type definitions to generate cloud-init yaml
 
 type CloudInit struct {
-	Files   []File   `yaml:"write_files"`
-	RunCmds []string `yaml:"runcmd"`
+	Files   []File   `yaml:"write_files,omitempty" json:"write_files,omitempty"`
+	RunCmds []string `yaml:"runcmd" json:"runcmd,omitempty"`
 }
 
 type File struct {
-	Path        string `yaml:"path"`
-	Content     string `yaml:"content"`
-	Permissions string `yaml:"permissions"`
+	Path        string `yaml:"path" json:"path,omitempty"`
+	Content     string `yaml:"content" json:"content,omitempty"`
+	Permissions string `yaml:"permissions" json:"permissions,omitempty"`
 }
 
 func (c *CloudInit) AsBytes() ([]byte, error) {

--- a/internal/controller/bootstrap/bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/bootstrap_controller_test.go
@@ -1,0 +1,106 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"testing"
+
+	bootstrapv1 "github.com/k0sproject/k0smotron/api/bootstrap/v1beta1"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_createInstallCmd(t *testing.T) {
+	base := "k0s install worker --token-file /etc/k0s.token"
+	tests := []struct {
+		name   string
+		config *bootstrapv1.K0sWorkerConfig
+		want   string
+	}{
+		{
+			name:   "with default config",
+			config: &bootstrapv1.K0sWorkerConfig{},
+			want:   base,
+		},
+		{
+			name: "with args",
+			config: &bootstrapv1.K0sWorkerConfig{
+				Spec: bootstrapv1.K0sWorkerConfigSpec{
+					Args: []string{"--debug", "--labels=k0sproject.io/foo=bar"},
+				},
+			},
+			want: base + " --debug --labels=k0sproject.io/foo=bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, createInstallCmd(tt.config))
+		})
+	}
+}
+
+func Test_createDownloadCommands(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *bootstrapv1.K0sWorkerConfig
+		want   []string
+	}{
+		{
+			name:   "with default config",
+			config: &bootstrapv1.K0sWorkerConfig{},
+			want: []string{
+				"curl -sSfL https://get.k0s.sh | sh",
+			},
+		},
+		{
+			name: "with pre-installed k0s",
+			config: &bootstrapv1.K0sWorkerConfig{
+				Spec: bootstrapv1.K0sWorkerConfigSpec{
+					PreInstalledK0s: true,
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "with custom version",
+			config: &bootstrapv1.K0sWorkerConfig{
+				Spec: bootstrapv1.K0sWorkerConfigSpec{
+					Version: "v1.2.3",
+				},
+			},
+			want: []string{
+				"curl -sSfL https://get.k0s.sh | K0S_VERSION=v1.2.3 sh",
+			},
+		},
+		{
+			name: "with custom download URL",
+			config: &bootstrapv1.K0sWorkerConfig{
+				Spec: bootstrapv1.K0sWorkerConfigSpec{
+					DownloadURL: "https://example.com/k0s",
+				},
+			},
+			want: []string{
+				"curl -sSfL https://example.com/k0s -o /usr/local/bin/k0s",
+				"chmod +x /usr/local/bin/k0s",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, createDownloadCommands(tt.config))
+		})
+	}
+}


### PR DESCRIPTION
### Add more configurable items in `K0sWorkerConfig`
Files: Extra files create via cloud-init
Pre/Post commands: Executed pre and post k0s install and start
Args: Extra args passed to `k0s worker` command
DownloadURL: If k0s needs to be downloaded from custom URL instead of via get.k0s.sh
PreInstalledK0s: If k0s does not need to be downloaded at all


fixes #126 