### PR TITLE
Fix test flakynes by waiting to see the kubeconfig

### DIFF
--- a/inttest/ha-controller-secret/ha_controller_secret_test.go
+++ b/inttest/ha-controller-secret/ha_controller_secret_test.go
@@ -75,10 +75,11 @@ func (s *HAControllerSecretSuite) TestK0sGetsUp() {
 	defer fw.Close()
 
 	<-fw.ReadyChan
-
-	s.T().Log("waiting for node to be ready")
+	s.T().Log("portforward ready")
+	s.T().Log("getting child clientset")
 	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test-secret", "kmc-test", 30443)
 	s.Require().NoError(err)
+	s.T().Log("waiting for node to be ready")
 	s.Require().NoError(s.WaitForNodeReady(s.K0smotronNode(0), kmcKC))
 }
 


### PR DESCRIPTION
The secret needs to be in place BEFORE attempting to get the child cluster client.

Currently some of the tests are flaky with:
```
    basic_test.go:78:
        	Error Trace:	/home/runner/work/k0smotron/k0smotron/inttest/basic/basic_test.go:78
        	Error:      	Received unexpected error:
        	            	secrets "kmc-test-kubeconfig" not found
        	Test:       	TestBasicSuite/TestK0sGetsUp
```