### PR TITLE
Monitoring

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -74,6 +74,7 @@ jobs:
           - check-ha-controller
           - check-ha-controller-secret
           - check-jointoken
+          - check-monitoring
 
     steps:
       - name: Check out code into the Go module directory
@@ -92,7 +93,7 @@ jobs:
       - name: Run inttest
         run: |
           make -C inttest ${{ matrix.smoke-suite }}
-  
+
   capi-smokes:
     name: Cluster API smoke tests
     needs: build
@@ -120,14 +121,14 @@ jobs:
         run: |
           docker network create kind --opt com.docker.network.bridge.enable_ip_masquerade=true
 
-      
+
       - name: Download kind
         uses: supplypike/setup-bin@v3
         with:
           name: kind
           version: v0.19.0
           uri: https://github.com/kubernetes-sigs/kind/releases/download/v0.19.0/kind-linux-amd64
-          
+
       - name: Setup KinD cluster
         run: |
           kind create cluster --config config/samples/capi/docker/kind.yaml
@@ -154,4 +155,3 @@ jobs:
           kind get kubeconfig > kind.conf
           export KUBECONFIG=$(realpath kind.conf)
           KEEP_AFTER_TEST=true make -C inttest check-capi-docker
-      

--- a/api/k0smotron.io/v1beta1/k0smotroncluster_types.go
+++ b/api/k0smotron.io/v1beta1/k0smotroncluster_types.go
@@ -88,6 +88,10 @@ type ClusterSpec struct {
 	// be specified as a single string, e.g. --some-flag=argument
 	//+kubebuilder:validation:Optional
 	ControlPlaneFlags []string `json:"controllerPlaneFlags,omitempty"`
+	// EnableMonitoring enables prometheus sidecar that scrapes metrics from the child cluster system components and expose
+	// them as usual kubernetes pod metrics.
+	//+kubebuilder:validation:Optional
+	EnableMonitoring bool `json:"enableMonitoring,omitempty"`
 }
 
 // K0smotronClusterStatus defines the observed state of K0smotronCluster
@@ -176,6 +180,10 @@ func (kmc *Cluster) GetAdminConfigSecretName() string {
 
 func (kmc *Cluster) GetEntrypointConfigMapName() string {
 	return fmt.Sprintf("kmc-entrypoint-%s-config", kmc.Name)
+}
+
+func (kmc *Cluster) GetMonitoringConfigMapName() string {
+	return fmt.Sprintf("kmc-prometheus-%s-config", kmc.Name)
 }
 
 func (kmc *Cluster) GetConfigMapName() string {

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -59,6 +59,11 @@ spec:
                 items:
                   type: string
                 type: array
+              enableMonitoring:
+                description: EnableMonitoring enables prometheus sidecar that scrapes
+                  metrics from the child cluster system components and expose them
+                  as usual kubernetes pod metrics.
+                type: boolean
               externalAddress:
                 description: ExternalAddress defines k0s external address. See https://docs.k0sproject.io/stable/configuration/#specapi
                   Will be detected automatically for service type LoadBalancer.

--- a/config/crd/bases/k0smotron.io_clusters.yaml
+++ b/config/crd/bases/k0smotron.io_clusters.yaml
@@ -63,6 +63,11 @@ spec:
                 items:
                   type: string
                 type: array
+              enableMonitoring:
+                description: EnableMonitoring enables prometheus sidecar that scrapes
+                  metrics from the child cluster system components and expose them
+                  as usual kubernetes pod metrics.
+                type: boolean
               externalAddress:
                 description: ExternalAddress defines k0s external address. See https://docs.k0sproject.io/stable/configuration/#specapi
                   Will be detected automatically for service type LoadBalancer.

--- a/internal/controller/k0smotron.io/k0smotroncluster_controller.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_controller.go
@@ -100,6 +100,13 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}
 
+	if kmc.Spec.EnableMonitoring {
+		if err := r.reconcileMonitoringCM(ctx, kmc); err != nil {
+			r.updateStatus(ctx, kmc, "Failed reconciling prometheus configmap")
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
+		}
+	}
+
 	logger.Info("Reconciling statefulset")
 	if err := r.reconcileStatefulSet(ctx, kmc); err != nil {
 		r.updateStatus(ctx, kmc, fmt.Sprintf("Failed reconciling statefulset, %+v", err))

--- a/internal/controller/k0smotron.io/k0smotroncluster_monitoring_config.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_monitoring_config.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k0smotronio
+
+import (
+	"bytes"
+	"context"
+	"text/template"
+
+	km "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var prometheusConfigTmpl *template.Template
+
+func init() {
+	prometheusConfigTmpl = template.Must(template.New("prometheus.yml").Parse(prometheusConfigTemplate))
+}
+
+func (r *ClusterReconciler) generateMonitoringCM(kmc *km.Cluster) (v1.ConfigMap, error) {
+	var entrypointBuf bytes.Buffer
+	err := prometheusConfigTmpl.Execute(&entrypointBuf, kmc)
+	if err != nil {
+		return v1.ConfigMap{}, err
+	}
+
+	cm := v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        kmc.GetMonitoringConfigMapName(),
+			Namespace:   kmc.Namespace,
+			Labels:      labelsForCluster(kmc),
+			Annotations: annotationsForCluster(kmc),
+		},
+		Data: map[string]string{
+			"prometheus.yml": entrypointBuf.String(),
+			"nginx.conf":     nginxConf,
+		},
+	}
+
+	_ = ctrl.SetControllerReference(kmc, &cm, r.Scheme)
+	return cm, nil
+}
+
+func (r *ClusterReconciler) reconcileMonitoringCM(ctx context.Context, kmc km.Cluster) error {
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling monitoring configmap")
+
+	cm, err := r.generateMonitoringCM(&kmc)
+	if err != nil {
+		return err
+	}
+
+	return r.Client.Patch(ctx, &cm, client.Apply, patchOpts...)
+}
+
+const prometheusConfigTemplate = `
+global:
+  scrape_interval:     10s
+  evaluation_interval: 10s
+scrape_configs:
+  - job_name: "k0smotron_cluster_metrics"
+    scheme: https
+    tls_config: 
+      insecure_skip_verify: true
+      cert_file: /var/lib/k0s/pki/admin.crt
+      key_file: /var/lib/k0s/pki/admin.key 
+    static_configs:
+      - targets: ["localhost:{{ .Spec.Service.APIPort }}"]
+        labels:
+          component: kube-apiserver
+          k0smotron_cluster: "{{ .Name }}"
+      - targets: ["localhost:10259"]
+        labels:
+          component: kube-scheduler
+          k0smotron_cluster: "{{ .Name }}"
+      - targets: ["localhost:10257"]
+        labels:
+          component: kube-controller-manager
+          k0smotron_cluster: "{{ .Name }}"
+  - job_name: "k0smotron_etcd_metrics"
+    scheme: https
+    tls_config: 
+      insecure_skip_verify: true
+      cert_file: /var/lib/k0s/pki/etcd/ca.crt
+      key_file: /var/lib/k0s/pki/etcd/ca.key
+    static_configs:
+      - targets: ["localhost:2379"]
+        labels:
+          component: etcd
+          k0smotron_cluster: "{{ .Name }}"
+`
+
+const nginxConf = `
+worker_processes  2;
+error_log  /dev/stdout warn;
+pid        /var/run/nginx.pid;
+
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+
+http {
+   server {
+      access_log /dev/stdout;
+      listen 8090;
+      location /metrics {
+         set $lbr "{";
+         set $rbr "}";
+         set $q "'";
+         rewrite ^(.*)$ /federate?match[]=${lbr}job!=${q}${q}${rbr} break;
+         proxy_pass http://localhost:9090/;
+      }
+   }
+}
+`

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -37,11 +37,12 @@ func PodExecCmdOutput(ctx context.Context, client kubernetes.Interface, config *
 	}
 	req := client.CoreV1().RESTClient().Post().Resource("pods").Name(podName).Namespace(namespace).SubResource("exec")
 	option := &v1.PodExecOptions{
-		Command: cmd,
-		Stdin:   false,
-		Stdout:  true,
-		Stderr:  true,
-		TTY:     false,
+		Command:   cmd,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+		Container: "controller",
 	}
 	req.VersionedParams(option, scheme.ParameterCodec)
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -32,3 +32,5 @@ $(smoketests): ../k0smotron-image-bundle.tar ../install.yaml .footloose-alpine.s
 
 clean:
 	rm -rf .*.stamp
+
+check-monitoring: TIMEOUT=7m

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -11,3 +11,4 @@ smoketests := \
     check-ha-controller-secret \
     check-jointoken \
     check-capi-docker \
+    check-monitoring \

--- a/inttest/capi-docker/capi_docker_test.go
+++ b/inttest/capi-docker/capi_docker_test.go
@@ -198,6 +198,7 @@ metadata:
   name:  docker-test-0
   namespace: default
 spec:
+  version: "v1.27.1"
   clusterName: docker-test
   bootstrap:
     configRef:

--- a/inttest/ha-controller-secret/ha_controller_secret_test.go
+++ b/inttest/ha-controller-secret/ha_controller_secret_test.go
@@ -75,10 +75,11 @@ func (s *HAControllerSecretSuite) TestK0sGetsUp() {
 	defer fw.Close()
 
 	<-fw.ReadyChan
-
-	s.T().Log("waiting for node to be ready")
+	s.T().Log("portforward ready")
+	s.T().Log("getting child clientset")
 	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test-secret", "kmc-test", 30443)
 	s.Require().NoError(err)
+	s.T().Log("waiting for node to be ready")
 	s.Require().NoError(s.WaitForNodeReady(s.K0smotronNode(0), kmcKC))
 }
 

--- a/inttest/monitoring/monitoring_test.go
+++ b/inttest/monitoring/monitoring_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/k0sproject/k0smotron/inttest/util"
+)
+
+type MonitoringSuite struct {
+	common.FootlooseSuite
+}
+
+func (s *MonitoringSuite) TestK0sGetsUp() {
+	s.T().Log("starting k0s")
+	s.PutFile(s.ControllerNode(0), "/tmp/k0s.yaml", k0sConfig)
+	s.Require().NoError(s.InitController(0, "--disable-components=metrics-server --config=/tmp/k0s.yaml"))
+	s.Require().NoError(s.RunWorkers())
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+	rc, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	err = s.WaitForNodeReady(s.WorkerNode(0), kc)
+	s.NoError(err)
+
+	s.Require().NoError(s.ImportK0smotronImages(s.Context()))
+
+	s.T().Log("deploying k0smotron operator")
+	s.Require().NoError(util.InstallK0smotronOperator(s.Context(), kc, rc))
+	s.Require().NoError(common.WaitForDeployment(s.Context(), kc, "k0smotron-controller-manager", "k0smotron"))
+
+	s.T().Log("deploying k0smotron cluster")
+	s.createK0smotronCluster(s.Context(), kc)
+	s.Require().NoError(common.WaitForStatefulSet(s.Context(), kc, "kmc-kmc-test", "kmc-test"))
+
+	s.T().Log("Generating k0smotron join token")
+	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test")
+	s.Require().NoError(err)
+
+	s.T().Log("joining worker to k0smotron cluster")
+	s.Require().NoError(s.RunWithToken(s.K0smotronNode(0), token))
+
+	s.Require().NoError(common.WaitForDeployment(s.Context(), kc, "prometheus-server", "default"))
+
+	s.T().Log("Starting portforward")
+	fw, err := util.GetPortForwarder(rc, "kmc-kmc-test-0", "kmc-test", 30443)
+	s.Require().NoError(err)
+
+	go fw.Start(s.Require().NoError)
+	defer fw.Close()
+
+	<-fw.ReadyChan
+
+	localPort, err := fw.LocalPort()
+	s.Require().NoError(err)
+	s.T().Log("waiting for node to be ready")
+
+	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test", "kmc-test", localPort)
+	s.Require().NoError(err)
+
+	s.Require().NoError(s.WaitForNodeReady(s.K0smotronNode(0), kmcKC))
+
+	err = wait.PollUntilContextTimeout(s.Context(), time.Second, time.Second*30, true, func(_ context.Context) (done bool, err error) {
+		b, err := kc.RESTClient().
+			Get().
+			AbsPath("/api/v1/namespaces/default/services/prometheus-server:http/proxy/api/v1/query").
+			Param("query", "workqueue_work_duration_seconds_count").
+			DoRaw(s.Context())
+		if err != nil {
+			return true, err
+		}
+
+		out := string(b)
+
+		return strings.Contains(out, `"k0smotron_cluster":"kmc-test"`), nil
+	})
+	s.Require().NoError(err)
+}
+
+func TestMonitoringSuite(t *testing.T) {
+	s := MonitoringSuite{
+		common.FootlooseSuite{
+			ControllerCount:                 1,
+			WorkerCount:                     1,
+			K0smotronWorkerCount:            1,
+			K0smotronImageBundleMountPoints: []string{"/dist/bundle.tar"},
+		},
+	}
+	suite.Run(t, &s)
+}
+
+func (s *MonitoringSuite) createK0smotronCluster(ctx context.Context, kc *kubernetes.Clientset) {
+	// create K0smotron namespace
+	_, err := kc.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kmc-test",
+		},
+	}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+
+	kmc := []byte(`
+	{
+		"apiVersion": "k0smotron.io/v1beta1",
+		"kind": "Cluster",
+		"metadata": {
+		  "name": "kmc-test",
+		  "namespace": "kmc-test"
+		},
+		"spec": {
+			"enableMonitoring": true,
+			"service":{
+				"type": "NodePort"
+			}
+		}
+	  }
+`)
+
+	res := kc.RESTClient().Post().AbsPath("/apis/k0smotron.io/v1beta1/namespaces/kmc-test/clusters").Body(kmc).Do(ctx)
+	s.Require().NoError(res.Error())
+}
+
+const k0sConfig = `
+spec:
+    extensions:
+        helm:
+          repositories:
+          - name: prometheus-community
+            url: https://prometheus-community.github.io/helm-charts
+          charts:
+          - name: prometheus
+            chartname: prometheus-community/prometheus
+            version: "22.6.3"
+            values: |
+              server:
+                persistentVolume:
+                  enabled: false
+              kube-state-metrics:
+                enabled: false
+              prometheus-node-exporter:
+                enabled: false
+              prometheus-pushgateway:
+                enabled: false
+              alertmanager:
+                enabled: false
+            namespace: default
+`

--- a/inttest/util/util.go
+++ b/inttest/util/util.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/k0sproject/k0s/inttest/common"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -39,6 +38,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/k0sproject/k0smotron/internal/exec"
 )
 
 func InstallK0smotronOperator(ctx context.Context, kc *kubernetes.Clientset, rc *rest.Config) error {
@@ -128,7 +129,7 @@ func CreateResources(ctx context.Context, resources []*unstructured.Unstructured
 }
 
 func GetJoinToken(kc *kubernetes.Clientset, rc *rest.Config, name string, namespace string) (string, error) {
-	output, err := common.PodExecCmdOutput(kc, rc, name, namespace, "k0s token create --role=worker")
+	output, err := exec.PodExecCmdOutput(context.TODO(), kc, rc, name, namespace, "k0s token create --role=worker")
 	if err != nil {
 		return "", fmt.Errorf("failed to get join token: %s", err)
 	}


### PR DESCRIPTION
Exposing control-plane metrics for Prometheus-like scrappers.
The feature adds two sidecars to the k0s pod: Prometheus to scrape metrics from the k0s system components and nginx proxy to make them accessible for the mothership's scraper.

Disabled by default.

Fixes #125 