### PR TITLE
Revert "Bump markdown from 3.3.7 to 3.4.4 in /docs"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ colorama==0.4.6
 ghp-import==2.1.0
 idna==3.4
 Jinja2==3.1.2
-Markdown==3.4.4
+Markdown==3.3.7
 MarkupSafe==2.1.3
 mdx-truly-sane-lists==1.3
 mergedeep==1.3.4


### PR DESCRIPTION
Reverts #204 
mkdocs 1.4.3 requires Markdown <3.4. This is fixed in upstream but until the new release is made we can't merge this.