### PR TITLE
Ensure compatible versions are used between CP and workers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,7 +84,7 @@ jobs:
   smoketest:
     name: Smoke test
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-8core
     strategy:
       fail-fast: false
       matrix:
@@ -117,7 +117,7 @@ jobs:
   capi-smokes:
     name: Cluster API smoke tests
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-8core
     strategy:
       fail-fast: false
       matrix:

--- a/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
+++ b/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
@@ -249,6 +249,7 @@ metadata:
 spec:
   replicas: 3
   k0sConfigSpec:
+    version: v1.27.1+k0s.0
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: ClusterConfig

--- a/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
+++ b/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
@@ -19,7 +19,6 @@ package capicontolplanedockertunneling
 import (
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"net/url"
 	"os"
@@ -28,6 +27,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	k0stestutil "github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0smotron/inttest/util"
@@ -245,6 +246,7 @@ metadata:
 spec:
   replicas: 1
   k0sConfigSpec:
+    version: v1.27.1+k0s.0
     tunneling:
       enabled: true
       mode: proxy

--- a/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
+++ b/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
@@ -238,6 +238,7 @@ metadata:
 spec:
   replicas: 1
   k0sConfigSpec:
+    version: v1.27.1+k0s.0
     tunneling:
       enabled: true
     k0s:

--- a/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
+++ b/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
@@ -195,6 +195,7 @@ metadata:
 spec:
   replicas: 1
   k0sConfigSpec:
+    version: v1.28.2+k0s.0
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: ClusterConfig

--- a/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
+++ b/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
@@ -136,7 +136,7 @@ func (s *CAPIControlPlaneDockerSuite) applyClusterObjects() {
 
 func (s *CAPIControlPlaneDockerSuite) deleteCluster() {
 	// Exec via kubectl
-	out, err := exec.Command("kubectl", "delete", "-f", s.clusterYamlsPath).CombinedOutput()
+	out, err := exec.Command("kubectl", "delete", "cluster", "docker-test-cluster").CombinedOutput()
 	s.Require().NoError(err, "failed to delete cluster objects: %s", string(out))
 }
 

--- a/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
@@ -238,6 +238,7 @@ metadata:
 spec:
   replicas: 3
   k0sConfigSpec:
+    version: v1.27.2+k0s.0
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: ClusterConfig


### PR DESCRIPTION
Currently in some tests the CP gets created with "latest" (e.g. 1.28.2) and workers as 1.27.1, the workers will never get up since they cannot find the proper kubelet configs etc. as k0s assumes same minor version in the initial node bootstrap.

