### PR TITLE
Using k8s versions everywhere

### DIFF
--- a/api/bootstrap/v1beta1/k0s_types.go
+++ b/api/bootstrap/v1beta1/k0s_types.go
@@ -25,6 +25,10 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const (
+	K0sSuffixAnnotation = "k0smotron.io/k0s-suffix"
+)
+
 func init() {
 	SchemeBuilder.Register(&K0sWorkerConfig{}, &K0sWorkerConfigList{})
 	SchemeBuilder.Register(&K0sControllerConfig{}, &K0sControllerConfigList{})

--- a/api/controlplane/v1beta1/k0s_types.go
+++ b/api/controlplane/v1beta1/k0s_types.go
@@ -46,9 +46,8 @@ type K0sControlPlaneSpec struct {
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:default=1
 	Replicas int32 `json:"replicas,omitempty"`
-	// K0sVersion defines the k0s version to be deployed. If empty k0smotron
-	// will pick it automatically.
-	K0sVersion string `json:"k0sVersion"`
+	// Version defines the kubernetes version to be deployed
+	Version string `json:"version"`
 }
 
 type K0sBootstrapConfigSpec struct {

--- a/api/k0smotron.io/v1beta1/k0smotroncluster_types.go
+++ b/api/k0smotron.io/v1beta1/k0smotroncluster_types.go
@@ -27,6 +27,10 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const (
+	K0sSuffixAnnotation = "k0smotron.io/k0s-suffix"
+)
+
 // ClusterSpec defines the desired state of K0smotronCluster
 type ClusterSpec struct {
 	// Replicas is the desired number of replicas of the k0s control planes.
@@ -39,10 +43,10 @@ type ClusterSpec struct {
 	// will pick it automatically. Must not include the image tag.
 	//+kubebuilder:default=k0sproject/k0s
 	K0sImage string `json:"k0sImage,omitempty"`
-	// K0sVersion defines the k0s version to be deployed. If empty k0smotron
+	// Version defines the k0s version to be deployed. If empty k0smotron
 	// will pick it automatically.
 	//+kubebuilder:validation:Optional
-	K0sVersion string `json:"k0sVersion,omitempty"`
+	Version string `json:"version,omitempty"`
 	// ExternalAddress defines k0s external address. See https://docs.k0sproject.io/stable/configuration/#specapi
 	// Will be detected automatically for service type LoadBalancer.
 	//+kubebuilder:validation:Optional

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -116,10 +116,6 @@ spec:
                         type: integer
                     type: object
                 type: object
-              k0sVersion:
-                description: K0sVersion defines the k0s version to be deployed. If
-                  empty k0smotron will pick it automatically.
-                type: string
               machineTemplate:
                 properties:
                   infrastructureRef:
@@ -188,10 +184,13 @@ spec:
                 default: 1
                 format: int32
                 type: integer
+              version:
+                description: Version defines the kubernetes version to be deployed
+                type: string
             required:
             - k0sConfigSpec
-            - k0sVersion
             - machineTemplate
+            - version
             type: object
           status:
             properties:

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -80,10 +80,6 @@ spec:
                   k0smotron will pick it automatically. Must not include the image
                   tag.
                 type: string
-              k0sVersion:
-                description: K0sVersion defines the k0s version to be deployed. If
-                  empty k0smotron will pick it automatically.
-                type: string
               kineDataSourceSecretName:
                 description: KineDataSourceSecretName defines the name of kine datasource
                   URL secret. KineDataSourceURL or KineDataSourceSecretName are required
@@ -2120,6 +2116,10 @@ spec:
                 required:
                 - type
                 type: object
+              version:
+                description: Version defines the k0s version to be deployed. If empty
+                  k0smotron will pick it automatically.
+                type: string
             type: object
           status:
             properties:

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -116,10 +116,6 @@ spec:
                         type: integer
                     type: object
                 type: object
-              k0sVersion:
-                description: K0sVersion defines the k0s version to be deployed. If
-                  empty k0smotron will pick it automatically.
-                type: string
               machineTemplate:
                 properties:
                   infrastructureRef:
@@ -188,10 +184,13 @@ spec:
                 default: 1
                 format: int32
                 type: integer
+              version:
+                description: Version defines the kubernetes version to be deployed
+                type: string
             required:
             - k0sConfigSpec
-            - k0sVersion
             - machineTemplate
+            - version
             type: object
           status:
             properties:

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -80,10 +80,6 @@ spec:
                   k0smotron will pick it automatically. Must not include the image
                   tag.
                 type: string
-              k0sVersion:
-                description: K0sVersion defines the k0s version to be deployed. If
-                  empty k0smotron will pick it automatically.
-                type: string
               kineDataSourceSecretName:
                 description: KineDataSourceSecretName defines the name of kine datasource
                   URL secret. KineDataSourceURL or KineDataSourceSecretName are required
@@ -2120,6 +2116,10 @@ spec:
                 required:
                 - type
                 type: object
+              version:
+                description: Version defines the k0s version to be deployed. If empty
+                  k0smotron will pick it automatically.
+                type: string
             type: object
           status:
             properties:

--- a/config/crd/bases/k0smotron.io_clusters.yaml
+++ b/config/crd/bases/k0smotron.io_clusters.yaml
@@ -84,10 +84,6 @@ spec:
                   k0smotron will pick it automatically. Must not include the image
                   tag.
                 type: string
-              k0sVersion:
-                description: K0sVersion defines the k0s version to be deployed. If
-                  empty k0smotron will pick it automatically.
-                type: string
               kineDataSourceSecretName:
                 description: KineDataSourceSecretName defines the name of kine datasource
                   URL secret. KineDataSourceURL or KineDataSourceSecretName are required
@@ -2124,6 +2120,10 @@ spec:
                 required:
                 - type
                 type: object
+              version:
+                description: Version defines the k0s version to be deployed. If empty
+                  k0smotron will pick it automatically.
+                type: string
             type: object
           status:
             description: K0smotronClusterStatus defines the observed state of K0smotronCluster

--- a/config/samples/capi/capi-controlplane-hetzner.yaml
+++ b/config/samples/capi/capi-controlplane-hetzner.yaml
@@ -24,7 +24,7 @@ kind: K0smotronControlPlane # This would somehow map to k0smotron
 metadata:
   name: cp-test
 spec:
-  k0sVersion: v1.27.2-k0s.0
+  version: v1.27.2
   persistence:
     type: emptyDir
   service:
@@ -66,7 +66,7 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: HCloudMachine
     name: cp-test-0
-  
+
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HCloudMachine
@@ -83,7 +83,7 @@ kind: K0sWorkerConfig
 metadata:
   name: cp-test-0
 spec:
-  
+
 ---
 # You also need a Hetzner token secret
 # apiVersion: v1

--- a/config/samples/capi/docker/cluster-with-machinedeployment.yaml
+++ b/config/samples/capi/docker/cluster-with-machinedeployment.yaml
@@ -26,7 +26,7 @@ kind: K0smotronControlPlane
 metadata:
   name: docker-md-test
 spec:
-  k0sVersion: v1.27.2-k0s.0
+  version: v1.27.2
   persistence:
     type: emptyDir
   service:
@@ -77,7 +77,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.2+k0s.0
+      version: v1.27.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/config/samples/capi/docker/docker-cluster.yaml
+++ b/config/samples/capi/docker/docker-cluster.yaml
@@ -26,7 +26,7 @@ kind: K0smotronControlPlane
 metadata:
   name: docker-test
 spec:
-  k0sVersion: v1.27.2-k0s.0
+  version: v1.27.2
   persistence:
     type: emptyDir
   service:
@@ -62,7 +62,7 @@ metadata:
   name: docker-test-0
   namespace: default
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.27.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachine

--- a/docs/join-nodes.md
+++ b/docs/join-nodes.md
@@ -54,8 +54,8 @@ curl -sSLf https://get.k0s.sh | sudo sh
 
 The download script accepts the following environment variables:
 
-| Variable                    | Purpose                                                              |
-|:----------------------------|:---------------------------------------------------------------------|
+| Variable                                       | Purpose                                           |
+|:-----------------------------------------------|:--------------------------------------------------|
 | `K0S_VERSION=v{{{ extra.k8s_version }}}+k0s.0` | Select the version of k0s to be installed         |
 | `DEBUG=true`                                   | Output commands and their arguments at execution. |
 

--- a/docs/resource-reference.md
+++ b/docs/resource-reference.md
@@ -91,6 +91,13 @@ Resource Types:
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>version</b></td>
+        <td>string</td>
+        <td>
+          Version is the version of k0s to use. In case this is not set, the latest version is used. Make sure the version is compatible with the k0s version running on the control plane. For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
@@ -144,13 +151,6 @@ Resource Types:
         <td>object</td>
         <td>
           Tunneling defines the tunneling configuration for the cluster.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>version</b></td>
-        <td>string</td>
-        <td>
-          Version is the version of k0s to use. In case this is not set, the latest version is used. Make sure the version is compatible with the k0s version running on the control plane. For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -368,6 +368,13 @@ Tunneling defines the tunneling configuration for the cluster.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>version</b></td>
+        <td>string</td>
+        <td>
+          Version is the version of k0s to use. In case this is not set, the latest version is used. Make sure the version is compatible with the k0s version running on the control plane. For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
@@ -414,13 +421,6 @@ Tunneling defines the tunneling configuration for the cluster.
         <td>[]string</td>
         <td>
           PreStartCommands specifies commands to be run before starting k0s worker.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>version</b></td>
-        <td>string</td>
-        <td>
-          Version is the version of k0s to use. In case this is not set, the latest version is used. Make sure the version is compatible with the k0s version running on the control plane. For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -660,6 +660,13 @@ JoinTokenSecretRef is a reference to a secret that contains the join token. This
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>version</b></td>
+        <td>string</td>
+        <td>
+          Version is the version of k0s to use. In case this is not set, the latest version is used. Make sure the version is compatible with the k0s version running on the control plane. For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
@@ -706,13 +713,6 @@ JoinTokenSecretRef is a reference to a secret that contains the join token. This
         <td>[]string</td>
         <td>
           PreStartCommands specifies commands to be run before starting k0s worker.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>version</b></td>
-        <td>string</td>
-        <td>
-          Version is the version of k0s to use. In case this is not set, the latest version is used. Make sure the version is compatible with the k0s version running on the control plane. For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1088,12 +1088,12 @@ Resource Types:
         </td>
         <td>true</td>
       </tr><tr>
-        <td><b>k0sVersion</b></td>
+        <td><b>version</b></td>
         <td>string</td>
         <td>
-          K0sVersion defines the k0s version to be deployed. If empty k0smotron will pick it automatically.<br/>
+          Version defines the kubernetes version to be deployed<br/>
         </td>
-        <td>false</td>
+        <td>true</td>
       </tr><tr>
         <td><b>replicas</b></td>
         <td>integer</td>
@@ -1178,13 +1178,6 @@ Resource Types:
         <td>object</td>
         <td>
           Tunneling defines the tunneling configuration for the cluster.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>version</b></td>
-        <td>string</td>
-        <td>
-          Version is the version of k0s to use. In case this is not set, the latest version is used. Make sure the version is compatible with the k0s version running on the control plane. For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1606,13 +1599,6 @@ ClusterSpec defines the desired state of K0smotronCluster
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>k0sVersion</b></td>
-        <td>string</td>
-        <td>
-          K0sVersion defines the k0s version to be deployed. If empty k0smotron will pick it automatically.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b>kineDataSourceSecretName</b></td>
         <td>string</td>
         <td>
@@ -1662,6 +1648,13 @@ ClusterSpec defines the desired state of K0smotronCluster
         <td>object</td>
         <td>
           Service defines the service configuration.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>version</b></td>
+        <td>string</td>
+        <td>
+          Version defines the k0s version to be deployed. If empty k0smotron will pick it automatically.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5745,13 +5738,6 @@ ClusterSpec defines the desired state of K0smotronCluster
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>k0sVersion</b></td>
-        <td>string</td>
-        <td>
-          K0sVersion defines the k0s version to be deployed. If empty k0smotron will pick it automatically.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b>kineDataSourceSecretName</b></td>
         <td>string</td>
         <td>
@@ -5801,6 +5787,13 @@ ClusterSpec defines the desired state of K0smotronCluster
         <td>object</td>
         <td>
           Service defines the service configuration.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>version</b></td>
+        <td>string</td>
+        <td>
+          Version defines the k0s version to be deployed. If empty k0smotron will pick it automatically.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9396,6 +9389,13 @@ K0smotronClusterStatus defines the observed state of K0smotronCluster
           <br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>ready</b></td>
+        <td>boolean</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/internal/controller/bootstrap/bootstrap_controller.go
+++ b/internal/controller/bootstrap/bootstrap_controller.go
@@ -50,6 +50,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	defaultK0sSuffix = "k0s.0"
+)
+
 type Controller struct {
 	client.Client
 	Scheme     *runtime.Scheme
@@ -315,7 +319,12 @@ func createDownloadCommands(config *bootstrapv1.K0sWorkerConfig) []string {
 
 	// Figure out version to download if download URL is not set
 	if config.Spec.Version != "" {
-		return []string{fmt.Sprintf("curl -sSfL https://get.k0s.sh | K0S_VERSION=%s sh", config.Spec.Version)}
+		k0sSuffix := config.Annotations[bootstrapv1.K0sSuffixAnnotation]
+		if k0sSuffix == "" {
+			k0sSuffix = defaultK0sSuffix
+		}
+		k0sVersion := fmt.Sprintf("%s+%s", config.Spec.Version, k0sSuffix)
+		return []string{fmt.Sprintf("curl -sSfL https://get.k0s.sh | K0S_VERSION=%s sh", k0sVersion)}
 	}
 
 	return []string{"curl -sSfL https://get.k0s.sh | sh"}

--- a/internal/controller/bootstrap/bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/bootstrap_controller_test.go
@@ -82,7 +82,7 @@ func Test_createDownloadCommands(t *testing.T) {
 				},
 			},
 			want: []string{
-				"curl -sSfL https://get.k0s.sh | K0S_VERSION=v1.2.3 sh",
+				"curl -sSfL https://get.k0s.sh | K0S_VERSION=v1.2.3+k0s.0 sh",
 			},
 		},
 		{

--- a/internal/controller/controlplane/helper.go
+++ b/internal/controller/controlplane/helper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Masterminds/semver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -43,8 +42,6 @@ func (c *K0sController) deleteMachine(ctx context.Context, name string, kcp *cpv
 }
 
 func (c *K0sController) generateMachine(_ context.Context, name string, cluster *clusterv1.Cluster, kcp *cpv1beta1.K0sControlPlane, infraRef corev1.ObjectReference) *clusterv1.Machine {
-	ver := semver.MustParse(kcp.Spec.K0sVersion)
-	v := fmt.Sprintf("%d.%d.%d", ver.Major(), ver.Minor(), ver.Patch())
 	return &clusterv1.Machine{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: clusterv1.GroupVersion.String(),
@@ -60,7 +57,7 @@ func (c *K0sController) generateMachine(_ context.Context, name string, cluster 
 			},
 		},
 		Spec: clusterv1.MachineSpec{
-			Version:     &v,
+			Version:     &kcp.Spec.Version,
 			ClusterName: cluster.Name,
 			Bootstrap: clusterv1.Bootstrap{
 				ConfigRef: &corev1.ObjectReference{

--- a/internal/controller/k0smotron.io/k0smotroncluster_controller.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_controller.go
@@ -33,7 +33,8 @@ import (
 )
 
 const (
-	defaultK0SVersion = "v1.27.2-k0s.0"
+	defaultK0SVersion = "v1.27.2"
+	defaultK0SSuffix  = "k0s.0"
 )
 
 var patchOpts []client.PatchOption = []client.PatchOption{

--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -44,14 +44,19 @@ func (r *ClusterReconciler) findStatefulSetPod(ctx context.Context, statefulSet 
 }
 
 func (r *ClusterReconciler) generateStatefulSet(kmc *km.Cluster) (apps.StatefulSet, error) {
-	k0sVersion := kmc.Spec.K0sVersion
-	if k0sVersion == "" {
-		k0sVersion = defaultK0SVersion
+	if kmc.Spec.Version == "" {
+		kmc.Spec.Version = defaultK0SVersion
 	}
+
+	k0sSuffix := kmc.Annotations[km.K0sSuffixAnnotation]
+	if k0sSuffix == "" {
+		k0sSuffix = defaultK0SSuffix
+	}
+
+	k0sVersion := fmt.Sprintf("%s-%s", kmc.Spec.Version, k0sSuffix)
 
 	if kmc.Spec.Replicas > 1 && (kmc.Spec.KineDataSourceURL == "" && kmc.Spec.KineDataSourceSecretName == "") {
 		return apps.StatefulSet{}, errors.New("kineDataSourceURL can't be empty if replicas > 1")
-
 	}
 
 	labels := labelsForCluster(kmc)

--- a/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
+++ b/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
@@ -248,7 +248,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 3
-  k0sVersion: v1.27.1+k0s.0
+  version: v1.27.1
   k0sConfigSpec:
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
@@ -300,7 +300,7 @@ metadata:
   namespace: default
 spec:
   # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
+  version: v1.27.1
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:
@@ -326,7 +326,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 1
-  k0sVersion: v1.27.1+k0s.0
+  version: v1.27.1
   k0sConfigSpec:
     args:
       - --enable-worker

--- a/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
+++ b/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
@@ -245,7 +245,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 1
-  k0sVersion: v1.27.1+k0s.0
+  version: v1.27.1
   k0sConfigSpec:
     tunneling:
       enabled: true
@@ -300,7 +300,7 @@ metadata:
   namespace: default
 spec:
   # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
+  version: v1.27.1
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
+++ b/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
@@ -237,7 +237,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 1
-  k0sVersion: v1.27.1+k0s.0
+  version: v1.27.1
   k0sConfigSpec:
     tunneling:
       enabled: true
@@ -291,7 +291,7 @@ metadata:
   namespace: default
 spec:
   # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
+  version: v1.27.1
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
+++ b/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
@@ -194,7 +194,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 1
-  k0sVersion: v1.27.2+k0s.0
+  version: v1.27.2
   k0sConfigSpec:
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1

--- a/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
@@ -237,7 +237,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 3
-  k0sVersion: v1.27.2+k0s.0
+  version: v1.27.2
   k0sConfigSpec:
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
@@ -289,7 +289,7 @@ metadata:
   namespace: default
 spec:
   # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
+  version: v1.27.1
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/inttest/capi-docker/capi_docker_test.go
+++ b/inttest/capi-docker/capi_docker_test.go
@@ -214,7 +214,7 @@ kind: K0smotronControlPlane
 metadata:
   name: docker-test
 spec:
-  k0sVersion: v1.27.2-k0s.0
+  version: v1.27.2
   persistence:
     type: pvc
     persistentVolumeClaim:
@@ -265,7 +265,7 @@ metadata:
   namespace: default
 spec:
   # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
+  version: v1.27.1
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/inttest/capi-remote-machine/capi_remote_machine_test.go
+++ b/inttest/capi-remote-machine/capi_remote_machine_test.go
@@ -274,7 +274,7 @@ metadata:
   name: remote-test
   namespace: default
 spec:
-  k0sVersion: v1.27.2-k0s.0
+  version: v1.27.2
   persistence:
     type: emptyDir
   service:
@@ -310,7 +310,7 @@ metadata:
   name: remote-test-0
   namespace: default
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.27.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: RemoteMachine


### PR DESCRIPTION
Currently, we are using different ways to set up a version, which is confusing. In the PR we are switching to using a Kubernetes version (eg, v1.27.2) instead of k0s version (eg, v1.27.2+k0s.0)

Fixes #333