### PR TITLE
JoinTokenRequest owned by Cluster

### DIFF
--- a/internal/controller/k0smotron.io/jointokenrequest_controller.go
+++ b/internal/controller/k0smotron.io/jointokenrequest_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -91,6 +92,26 @@ func (r *JoinTokenRequestReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if !controllerutil.ContainsFinalizer(&jtr, finalizerName) {
 		controllerutil.AddFinalizer(&jtr, finalizerName)
+	}
+
+	var ownerRefFound bool
+	for _, or := range jtr.OwnerReferences {
+		if or.Kind == "Cluster" {
+			ownerRefFound = true
+		}
+	}
+	if !ownerRefFound {
+		jtr.OwnerReferences = append(jtr.OwnerReferences, metav1.OwnerReference{
+			APIVersion:         km.GroupVersion.String(),
+			Kind:               "Cluster",
+			Name:               jtr.Spec.ClusterRef.Name,
+			BlockOwnerDeletion: pointer.Bool(true),
+			Controller:         pointer.Bool(true),
+		})
+
+		if err := r.Client.Patch(ctx, &jtr, client.Apply, patchOpts...); err != nil {
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
+		}
 	}
 
 	if jtr.Status.TokenID != "" {

--- a/inttest/jointoken/jointoken_test.go
+++ b/inttest/jointoken/jointoken_test.go
@@ -61,6 +61,17 @@ func (s *JoinTokenSuite) TestK0sGetsUp() {
 	s.createJoinTokenRequest(s.Context(), kc)
 
 	s.Require().NoError(s.WaitForSecret(s.Context(), kc, "jtr-test", "jtr-test"))
+
+	s.T().Log("removing cluster")
+	s.deleteK0smotronCluster(s.Context(), kc)
+
+	s.T().Log("checking if JoinTokenRequest is deleted")
+	res := kc.RESTClient().Get().AbsPath("/apis/k0smotron.io/v1beta1/namespaces/jtr-test/jointokenrequests/jtr-test").Do(s.Context())
+	s.Require().NoError(res.Error())
+
+	var statusCode int
+	res.StatusCode(&statusCode)
+	s.Require().Equal(404, statusCode)
 }
 
 func TestJoinTokenSuite(t *testing.T) {
@@ -107,6 +118,11 @@ func (s *JoinTokenSuite) createK0smotronCluster(ctx context.Context, kc *kuberne
 `)
 
 	res := kc.RESTClient().Post().AbsPath("/apis/k0smotron.io/v1beta1/namespaces/kmc-test/clusters").Body(kmc).Do(ctx)
+	s.Require().NoError(res.Error())
+}
+
+func (s *JoinTokenSuite) deleteK0smotronCluster(ctx context.Context, kc *kubernetes.Clientset) {
+	res := kc.RESTClient().Delete().AbsPath("/apis/k0smotron.io/v1beta1/namespaces/kmc-test/clusters/kmc-test").Do(ctx)
 	s.Require().NoError(res.Error())
 }
 


### PR DESCRIPTION
Fixes #346 

Not yet sure that it's needed, because JoinTokenRequest is a separate CRD, not directly connected to the Cluster.