### PR TITLE
Fix Typo in Usage Overview

### DIFF
--- a/docs/usage-overview.md
+++ b/docs/usage-overview.md
@@ -1,4 +1,4 @@
-# k0smotrong usage
+# k0smotron usage
 
 k0smotron can be use either as a "standalone" manager for Kubernetes control planes or as a Cluster API provider for several ClusterAPI "roles".
 


### PR DESCRIPTION
Remove additional "g" at k0smorton in usage overview doc.