### PR TITLE
K0smotron pod affinities

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -77,6 +77,28 @@ func (r *ClusterReconciler) generateStatefulSet(kmc *km.Cluster) (apps.StatefulS
 					Labels: labels,
 				},
 				Spec: v1.PodSpec{
+					Affinity: &v1.Affinity{PodAntiAffinity: &v1.PodAntiAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+							{
+								Weight: 100,
+								PodAffinityTerm: v1.PodAffinityTerm{
+									TopologyKey: "topology.kubernetes.io/zone",
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: defaultClusterLabels(kmc),
+									},
+								},
+							},
+							{
+								Weight: 50,
+								PodAffinityTerm: v1.PodAffinityTerm{
+									TopologyKey: "kubernetes.io/hostname",
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: defaultClusterLabels(kmc),
+									},
+								},
+							},
+						},
+					}},
 					Volumes: []v1.Volume{{
 						Name: kmc.GetEntrypointConfigMapName(),
 						VolumeSource: v1.VolumeSource{

--- a/internal/controller/k0smotron.io/util.go
+++ b/internal/controller/k0smotron.io/util.go
@@ -18,8 +18,15 @@ package k0smotronio
 
 import km "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
 
+func defaultClusterLabels(kmc *km.Cluster) map[string]string {
+	return map[string]string{
+		"app":     "k0smotron",
+		"cluster": kmc.Name,
+	}
+}
+
 func labelsForCluster(kmc *km.Cluster) map[string]string {
-	labels := map[string]string{"app": "k0smotron", "cluster": kmc.Name}
+	labels := defaultClusterLabels(kmc)
 	for k, v := range kmc.Labels {
 		labels[k] = v
 	}


### PR DESCRIPTION
Fixes #383 

The PR adds antiAffinity for the k0smotron statefulset:
- To schedule pods in different availability zones
- To schedule pods on different nodes in the same zone (or if the zone label is empty)