### PR TITLE
Create draft release automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,15 @@ jobs:
         id: branch_name
         run: |
           echo TAG_NAME="${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        id: create_release
+        uses: shogo82148/actions-create-release@v1.4.4
+        with:
+          release_name: ${{ steps.branch_name.outputs.TAG_NAME }}
+          draft: true # So we can manually edit before publishing
+          prerelease: ${{ contains(github.ref, '-') }}
+
       - name: Prepare image tags
         id: image_tag
         env:


### PR DESCRIPTION
Currently, we have to create a new release manually before the tag. With this change, the draft release will be automatically created for a new tag