### PR TITLE
Publish docs fix after mkdocs update

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -96,8 +96,7 @@ jobs:
           make release IMG=quay.io/k0sproject/k0smotron:${STABLE}
           cp install.yaml /tmp/install.yaml
           git checkout gh-pages
-          cp /tmp/install.yaml stable/install.yaml 
           cp /tmp/install.yaml ${STABLE}/install.yaml 
-          git add ${STABLE}/install.yaml stable/install.yaml && git update-index --refresh
+          git add ${STABLE}/install.yaml && git update-index --refresh
           git diff-index --quiet HEAD -- || git commit -m "Update install.yaml to ${STABLE}"
           git push origin gh-pages


### PR DESCRIPTION
Before, a `stable` used to be a dir and now it's a symlink, this causes [the issue](https://github.com/k0sproject/k0smotron/actions/runs/7411894832/job/20167468375#step:11:72) with git:
```
fatal: pathspec 'stable/install.yaml' is beyond a symbolic link
```