### PR TITLE
Cluster API provider label

### DIFF
--- a/api/bootstrap/v1beta1/k0s_template_types.go
+++ b/api/bootstrap/v1beta1/k0s_template_types.go
@@ -28,6 +28,7 @@ func init() {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
+// +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=bootstrap-k0smotron"
 
 type K0sWorkerConfigTemplate struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/bootstrap/v1beta1/k0s_types.go
+++ b/api/bootstrap/v1beta1/k0s_types.go
@@ -33,6 +33,7 @@ func init() {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
+// +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=bootstrap-k0smotron"
 
 type K0sWorkerConfig struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -109,6 +110,7 @@ type K0sWorkerConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
+// +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=bootstrap-k0smotron"
 
 type K0sControllerConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/controlplane/v1beta1/k0s_types.go
+++ b/api/controlplane/v1beta1/k0s_types.go
@@ -31,6 +31,7 @@ func init() {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
+// +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=control-plane-k0smotron"
 
 type K0sControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/controlplane/v1beta1/k0smotron_types.go
+++ b/api/controlplane/v1beta1/k0smotron_types.go
@@ -30,6 +30,7 @@ func init() {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
+// +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=control-plane-k0smotron"
 
 type K0smotronControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/infrastructure/v1beta1/remote_machine_template_types.go
+++ b/api/infrastructure/v1beta1/remote_machine_template_types.go
@@ -30,6 +30,7 @@ func init() {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
+// +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=infrastructure-k0smotron"
 
 type RemoteMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/infrastructure/v1beta1/remote_machine_types.go
+++ b/api/infrastructure/v1beta1/remote_machine_types.go
@@ -31,6 +31,7 @@ func init() {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
+// +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=infrastructure-k0smotron"
 
 type RemoteCluster struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -64,6 +65,7 @@ type RemoteClusterList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
+// +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=infrastructure-k0smotron"
 
 type RemoteMachine struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -130,6 +132,7 @@ type RemoteMachineList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
+// +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=infrastructure-k0smotron"
 
 type PooledRemoteMachine struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: bootstrap-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: k0scontrollerconfigs.bootstrap.cluster.x-k8s.io
 spec:

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: bootstrap-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: k0sworkerconfigs.bootstrap.cluster.x-k8s.io
 spec:

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: bootstrap-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: k0sworkerconfigtemplates.bootstrap.cluster.x-k8s.io
 spec:

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: control-plane-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: k0scontrolplanes.controlplane.cluster.x-k8s.io
 spec:

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: control-plane-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: k0smotroncontrolplanes.controlplane.cluster.x-k8s.io
 spec:

--- a/config/clusterapi/infrastructure/bases/infrastructure.cluster.x-k8s.io_pooledremotemachines.yaml
+++ b/config/clusterapi/infrastructure/bases/infrastructure.cluster.x-k8s.io_pooledremotemachines.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: infrastructure-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: pooledremotemachines.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/clusterapi/infrastructure/bases/infrastructure.cluster.x-k8s.io_remoteclusters.yaml
+++ b/config/clusterapi/infrastructure/bases/infrastructure.cluster.x-k8s.io_remoteclusters.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: infrastructure-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: remoteclusters.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/clusterapi/infrastructure/bases/infrastructure.cluster.x-k8s.io_remotemachines.yaml
+++ b/config/clusterapi/infrastructure/bases/infrastructure.cluster.x-k8s.io_remotemachines.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: infrastructure-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: remotemachines.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/clusterapi/infrastructure/bases/infrastructure.cluster.x-k8s.io_remotemachinetemplates.yaml
+++ b/config/clusterapi/infrastructure/bases/infrastructure.cluster.x-k8s.io_remotemachinetemplates.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: infrastructure-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: remotemachinetemplates.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: bootstrap-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: k0scontrollerconfigs.bootstrap.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: bootstrap-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: k0sworkerconfigs.bootstrap.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: bootstrap-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: k0sworkerconfigtemplates.bootstrap.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: control-plane-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: k0scontrolplanes.controlplane.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: control-plane-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: k0smotroncontrolplanes.controlplane.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_pooledremotemachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_pooledremotemachines.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: infrastructure-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: pooledremotemachines.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_remoteclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_remoteclusters.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: infrastructure-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: remoteclusters.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_remotemachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_remotemachines.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: infrastructure-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: remotemachines.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_remotemachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_remotemachinetemplates.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   labels:
+    cluster.x-k8s.io/provider: infrastructure-k0smotron
     cluster.x-k8s.io/v1beta1: v1beta1
   name: remotemachinetemplates.infrastructure.cluster.x-k8s.io
 spec:


### PR DESCRIPTION
Fixes #407 

As Cluster API docs say:
```
Labels

The components YAML components should be labeled with cluster.x-k8s.io/provider and the name of the provider. This will enable an easier transition from kubectl apply to clusterctl.
```

https://cluster-api.sigs.k8s.io/clusterctl/provider-contract#labels