### PR TITLE
Add yaml inline separator for proper installation of the K0smotronControlPlane

### DIFF
--- a/docs/capi-remote.md
+++ b/docs/capi-remote.md
@@ -34,6 +34,7 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: RemoteCluster
     name: remote-test
+---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0smotronControlPlane
 metadata:


### PR DESCRIPTION
Hi,

PR is to fix the yaml format of _Cluster API - Remote machine_ provider first example manifest.