### PR TITLE
Fix Machine owner reference created by K0sControlPlane

### DIFF
--- a/internal/controller/controlplane/helper.go
+++ b/internal/controller/controlplane/helper.go
@@ -19,7 +19,7 @@ import (
 func (c *K0sController) createMachine(ctx context.Context, name string, cluster *clusterv1.Cluster, kcp *cpv1beta1.K0sControlPlane, infraRef corev1.ObjectReference) (*clusterv1.Machine, error) {
 	machine := c.generateMachine(ctx, name, cluster, kcp, infraRef)
 
-	_ = ctrl.SetControllerReference(cluster, machine, c.Scheme)
+	_ = ctrl.SetControllerReference(kcp, machine, c.Scheme)
 
 	return machine, c.Client.Patch(ctx, machine, client.Apply, &client.PatchOptions{
 		FieldManager: "k0smotron",


### PR DESCRIPTION
That change sets `Machine`s owner reference, created by a `K0sControlPlane`, to the `K0sControlPlane` (before owner was `Cluster` resource, which breaks the logic)

Additionally, it was not working good with CAPV -- deletion of `Machine`s with `Cluster` set as owner was not successful