### PR TITLE
Fix different CA's in HA setup.

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -183,17 +183,6 @@ func (r *ClusterReconciler) generateStatefulSet(kmc *km.Cluster) (apps.StatefulS
 	}
 
 	switch kmc.Spec.Persistence.Type {
-	case "emptyDir":
-		statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, v1.Volume{
-			Name: kmc.GetVolumeName(),
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{},
-			},
-		})
-		statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
-			Name:      kmc.GetVolumeName(),
-			MountPath: "/var/lib/k0s",
-		})
 	case "hostPath":
 		statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, v1.Volume{
 			Name: kmc.GetVolumeName(),
@@ -227,6 +216,19 @@ func (r *ClusterReconciler) generateStatefulSet(kmc *km.Cluster) (apps.StatefulS
 
 		statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
 			Name:      kmc.Spec.Persistence.PersistentVolumeClaim.Name,
+			MountPath: "/var/lib/k0s",
+		})
+	case "emptyDir":
+		fallthrough
+	default:
+		statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, v1.Volume{
+			Name: kmc.GetVolumeName(),
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+			},
+		})
+		statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
+			Name:      kmc.GetVolumeName(),
 			MountPath: "/var/lib/k0s",
 		})
 	}

--- a/inttest/ha-controller/ha_controller_test.go
+++ b/inttest/ha-controller/ha_controller_test.go
@@ -140,5 +140,5 @@ func (s *HAControllerSuite) getPod(ctx context.Context, kc *kubernetes.Clientset
 	s.Require().NoError(err, "failed to list kmc-test pods")
 	s.Require().Equal(3, len(pods.Items), "expected 1 kmc-test pod, got %d", len(pods.Items))
 
-	return pods.Items[0]
+	return pods.Items[2]
 }


### PR DESCRIPTION
Due to the bug, currently can end up with different CA certificates on each control plane. The PR fixes the bug, creating CA in advance and mounting them to the statefulset

Fixes #467 
