### PR TITLE
Resource reference updated with the latest changes

### DIFF
--- a/docs/resource-reference.md
+++ b/docs/resource-reference.md
@@ -14778,6 +14778,13 @@ JoinTokenRequestStatus defines the observed state of K0smotronJoinTokenRequest
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>clusterUID</b></td>
+        <td>string</td>
+        <td>
+          UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>tokenID</b></td>
         <td>string</td>
         <td>


### PR DESCRIPTION
Now the CI is red because of merging old PR without this lint check. Making it up to date