### PR TITLE
[DOCS] Move the common Monitoring section out of the Standalone section --signoff

### DIFF
--- a/api/k0smotron.io/v1beta1/jointoken_types.go
+++ b/api/k0smotron.io/v1beta1/jointoken_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -46,8 +47,9 @@ type ClusterRef struct {
 
 // JoinTokenRequestStatus defines the observed state of K0smotronJoinTokenRequest
 type JoinTokenRequestStatus struct {
-	ReconciliationStatus string `json:"reconciliationStatus"`
-	TokenID              string `json:"tokenID,omitempty"`
+	ReconciliationStatus string    `json:"reconciliationStatus"`
+	TokenID              string    `json:"tokenID,omitempty"`
+	ClusterUID           types.UID `json:"clusterUID,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/k0smotron.io_jointokenrequests.yaml
+++ b/config/crd/bases/k0smotron.io_jointokenrequests.yaml
@@ -68,6 +68,12 @@ spec:
           status:
             description: JoinTokenRequestStatus defines the observed state of K0smotronJoinTokenRequest
             properties:
+              clusterUID:
+                description: UID is a type that holds unique ID values, including
+                  UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being
+                  a type captures intent and helps make sure that UIDs and names do
+                  not get conflated.
+                type: string
               reconciliationStatus:
                 type: string
               tokenID:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,9 +1,13 @@
-# Control Plane Monitoring
+# Control plane monitoring
 
-K0smotron provides a mechanism to expose child cluster control plane metrics to a Prometheus instance running in the parent cluster. 
-This allows you to monitor the control plane components of the child cluster as the usual Kubernetes workload, using the same Prometheus instance that is used to monitor the parent cluster.
+For the standalone and TBA use cases, K0smotron provides a mechanism to expose
+control plane metrics of a managed cluster to a Prometheus instance running
+in the management cluster. This allows you to monitor the control plane
+components of the managed cluster as a usual Kubernetes workload using the same
+Prometheus instance that is used to monitor the management cluster.
 
-To enable the monitoring for the k0smotron cluster you need to set `spec.enableMonitoring=true` in the `Cluster` resource:
+To enable monitoring for the k0smotron cluster, set `spec.enableMonitoring=true`
+in the `Cluster` resource:
 
 ```yaml
 apiVersion: k0smotron.io/v1beta1
@@ -14,8 +18,12 @@ spec:
   enableMonitoring: true
 ``` 
 
-This will add two sidecar containers to the control plane pods:
-- `monitoring-agent` - a container that will scrape the metrics from the control plane components.
-- `monitoring-proxy` - a container with a proxy that will expose the metrics scraped by the `monitoring-agent` to the parent cluster.
+Once done, two sidecar containers are added to the control plane pods:
 
-All metrics contain the `k0smotron_cluster` label with the name of the cluster.
+* `monitoring-agent` - a container that scrapes metrics from the control plane
+  components.
+* `monitoring-proxy` - a container with a proxy that exposes metrics scraped by
+  `monitoring-agent` to the management cluster.
+
+All metrics contain the `k0smotron_cluster` label with the name of the managed
+cluster.

--- a/inttest/jointoken/jointoken_test.go
+++ b/inttest/jointoken/jointoken_test.go
@@ -139,7 +139,7 @@ func (s *JoinTokenSuite) WaitForSecret(ctx context.Context, clients kubernetes.I
 	return watch.FromClient[*corev1.SecretList, corev1.Secret](clients.CoreV1().Secrets(namespace)).
 		WithObjectName(name).
 		Until(ctx, func(secret *corev1.Secret) (done bool, err error) {
-			if secret.Data["token"] != nil {
+			if secret.Data["token"] != nil && secret.Labels["k0smotron.io/cluster-uid"] != "" {
 				return true, nil
 			}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,6 @@ nav:
       - Configuration: configuration.md
       - Join nodes: join-nodes.md
       - HA control planes: ha.md
-      - Monitoring: monitoring.md
     - Cluster API:
       - Overview: cluster-api.md
       - Control Plane: capi-controlplane.md
@@ -35,6 +34,7 @@ nav:
         - OpenStack: capi-openstack.md
         - Docker: capi-docker.md
         - vSphere: capi-vsphere.md
+    - Monitoring: monitoring.md
   - FAQ: faq.md
   - Reference:
     - Custom resources: resource-reference.md


### PR DESCRIPTION
Reason: monitoring applies not only to the Standalone mode but also
to the TBA one.

Signed-off-by: ologvinova <ologvinova@ologvinovas-MacBook-Pro.local>