### PR TITLE
[DOCS] Move Monitoring to the main TOC

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,9 +1,14 @@
-# Control Plane Monitoring
+# Control plane monitoring
 
-K0smotron provides a mechanism to expose child cluster control plane metrics to a Prometheus instance running in the parent cluster. 
-This allows you to monitor the control plane components of the child cluster as the usual Kubernetes workload, using the same Prometheus instance that is used to monitor the parent cluster.
+For the standalone and Cluster API in-cluster use cases, k0smotron provides
+a mechanism to expose control plane metrics of a managed cluster to
+a Prometheus instance running in the management cluster. This allows you to
+monitor the control plane components of the managed cluster as a usual
+Kubernetes workload using the same Prometheus instance that is used to monitor
+the management cluster.
 
-To enable the monitoring for the k0smotron cluster you need to set `spec.enableMonitoring=true` in the `Cluster` resource:
+To enable monitoring for a k0smotron cluster, set `spec.enableMonitoring=true`
+in the `Cluster` resource:
 
 ```yaml
 apiVersion: k0smotron.io/v1beta1
@@ -14,8 +19,12 @@ spec:
   enableMonitoring: true
 ``` 
 
-This will add two sidecar containers to the control plane pods:
-- `monitoring-agent` - a container that will scrape the metrics from the control plane components.
-- `monitoring-proxy` - a container with a proxy that will expose the metrics scraped by the `monitoring-agent` to the parent cluster.
+Once done, two sidecar containers are added to the control plane pods:
 
-All metrics contain the `k0smotron_cluster` label with the name of the cluster.
+* `monitoring-agent` - a container that scrapes metrics from the control plane
+  components.
+* `monitoring-proxy` - a container with a proxy that exposes metrics scraped by
+  `monitoring-agent` to the management cluster.
+
+All metrics contain the `k0smotron_cluster` label with the name of the managed
+cluster.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,6 @@ nav:
       - Join a worker node: join-nodes.md
       - Configuration: configuration.md
       - HA control planes: ha.md
-      - Monitoring: monitoring.md
     - Cluster API:
       - Overview: cluster-api.md
       - Control Plane: capi-controlplane.md
@@ -35,6 +34,7 @@ nav:
         - OpenStack: capi-openstack.md
         - Docker: capi-docker.md
         - vSphere: capi-vsphere.md
+    - Monitoring: monitoring.md
   - FAQ: faq.md
   - Troubleshooting: troubleshooting.md
   - Reference:


### PR DESCRIPTION
Reason: the Monitoring section also applies to the Cluster API in-cluster use case.

Signed-off-by: ologvinova <ologvinova@mirantis.com>