### PR TITLE
Check for deletion timestamp on controller

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_controller.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_controller.go
@@ -90,6 +90,11 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	logger.Info("Reconciling")
 
+	if !kmc.ObjectMeta.DeletionTimestamp.IsZero() {
+		logger.Info("Cluster is being deleted, no action needed")
+		return ctrl.Result{}, nil
+	}
+
 	logger.Info("Reconciling services")
 	if err := r.reconcileServices(ctx, kmc); err != nil {
 		r.updateStatus(ctx, kmc, "Failed reconciling services")


### PR DESCRIPTION
This gets set not only with finalizers, but also when a user does a foreground delete operation (which is default for some UX like argo).

This keeps the controller from desparately attempting to recreate its resources during foreground deletes.