### PR TITLE
Adding open PRs limit to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,12 @@ updates:
       - dependency-name: github.com/k0sproject/k0s
   - package-ecosystem: github-actions
     directory: /
+    open-pull-requests-limit: 3
     schedule:
       interval: daily
 
   - package-ecosystem: pip
     directory: /docs
+    open-pull-requests-limit: 3
     schedule:
       interval: daily


### PR DESCRIPTION
Currently, we have limits only for go.mod file