### PR TITLE
Update failure log collection after switching to clusterctl installation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -205,7 +205,9 @@ jobs:
       - name: Get k0smotron logs
         if: failure()
         run: |
-          kubectl logs -n k0smotron deploy/k0smotron-controller-manager > /tmp/${{ matrix.smoke-suite }}-k0smotron.log
+          kubectl logs -n k0smotron deploy/k0smotron-controller-manager-bootstrap > /tmp/${{ matrix.smoke-suite }}-k0smotron-bootstrap.log
+          kubectl logs -n k0smotron deploy/k0smotron-controller-manager-control-plane > /tmp/${{ matrix.smoke-suite }}-k0smotron-control-plane.log
+          kubectl logs -n k0smotron deploy/k0smotron-controller-manager-infrastructure > /tmp/${{ matrix.smoke-suite }}-k0smotron-infrastructure.log
 
       - name: Collect k0s logs and support bundle
         if: failure()


### PR DESCRIPTION
Deployments have changed since we switched to installation using clusterctl and log collection doesn't work now