### PR TITLE
Skipping etcd certs checks when Kine is used

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
@@ -89,7 +89,7 @@ func (r *ClusterReconciler) generateCM(kmc *km.Cluster) (v1.ConfigMap, error) {
 	return cm, nil
 }
 
-func (r *ClusterReconciler) reconcileCM(ctx context.Context, kmc km.Cluster) error {
+func (r *ClusterReconciler) reconcileCM(ctx context.Context, kmc *km.Cluster) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling configmap")
 
@@ -109,7 +109,7 @@ func (r *ClusterReconciler) reconcileCM(ctx context.Context, kmc km.Cluster) err
 		kmc.Spec.KineDataSourceURL = kineDataSourceURLPlaceholder
 	}
 
-	cm, err := r.generateCM(&kmc)
+	cm, err := r.generateCM(kmc)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/k0smotron.io/k0smotroncluster_controller.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_controller.go
@@ -95,7 +95,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}
 
-	if err := r.reconcileCM(ctx, kmc); err != nil {
+	if err := r.reconcileCM(ctx, &kmc); err != nil {
 		r.updateStatus(ctx, kmc, "Failed reconciling configmap")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}

--- a/inttest/ha-controller-secret/ha_controller_secret_test.go
+++ b/inttest/ha-controller-secret/ha_controller_secret_test.go
@@ -20,12 +20,16 @@ import (
 	"context"
 	"testing"
 
-	"github.com/k0sproject/k0s/inttest/common"
-	"github.com/k0sproject/k0smotron/inttest/util"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/secret"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	"github.com/k0sproject/k0smotron/inttest/util"
 )
 
 type HAControllerSecretSuite struct {
@@ -95,6 +99,20 @@ func TestHAControllerSecretSuite(t *testing.T) {
 	suite.Run(t, &s)
 }
 
+func (s *HAControllerSecretSuite) prepareCerts(kc *kubernetes.Clientset) {
+	certificates := secret.NewCertificatesForInitialControlPlane(&bootstrapv1.ClusterConfiguration{})
+	err := certificates.Generate()
+	s.Require().NoError(err, "failed to generate certificates")
+
+	for _, certificate := range certificates {
+		certificate.Generated = false
+		certSecret := certificate.AsSecret(client.ObjectKey{Namespace: "kmc-test", Name: "kmc-test"}, metav1.OwnerReference{})
+		if _, err := kc.CoreV1().Secrets("kmc-test").Create(s.Context(), certSecret, metav1.CreateOptions{}); err != nil {
+			s.Require().NoError(err)
+		}
+	}
+}
+
 func (s *HAControllerSecretSuite) createK0smotronClusterWithSecretRef(ctx context.Context, kc *kubernetes.Clientset) {
 	_, err := kc.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -102,6 +120,8 @@ func (s *HAControllerSecretSuite) createK0smotronClusterWithSecretRef(ctx contex
 		},
 	}, metav1.CreateOptions{})
 	s.Require().NoError(err)
+
+	s.prepareCerts(kc)
 
 	// create K0smotron namespace
 	_, err = kc.CoreV1().Secrets("kmc-test").Create(ctx, &corev1.Secret{
@@ -133,6 +153,7 @@ func (s *HAControllerSecretSuite) createK0smotronClusterWithSecretRef(ctx contex
 				"type": "NodePort"
 			},
 			"kineDataSourceSecretName": "postgres-dsn",
+			"certificateRefs": [{"name": "kmc-test-ca","type": "ca"}, {"name": "kmc-test-proxy", "type": "proxy"}, {"name": "kmc-test-sa", "type": "sa"}],
 			"k0sConfig": {
 				"apiVersion": "k0s.k0sproject.io/v1beta1",
 				"kind": "ClusterConfig",


### PR DESCRIPTION
The regression in the v0.9.5 is fixed.

We don't check for etcd certs if `KineDataSourceURL` is not an empty string. But currently it doesn't work with `KineDataSourceSecretName`. We do the following to make it work, but by mistake, we pass `kmc` not by reference and this doesn't change the KineDataSourceURL and the check works wrongly
```
if kmc.Spec.KineDataSourceSecretName != "" {
	kmc.Spec.KineDataSourceURL = kineDataSourceURLPlaceholder
}
```