### PR TITLE
fix controlplane service also matching etcd pods

### DIFF
--- a/internal/controller/k0smotron.io/util.go
+++ b/internal/controller/k0smotron.io/util.go
@@ -30,6 +30,7 @@ func labelsForCluster(kmc *km.Cluster) map[string]string {
 	for k, v := range kmc.Labels {
 		labels[k] = v
 	}
+	labels["component"] = "cluster"
 	return labels
 }
 


### PR DESCRIPTION
fixes #592 

this ensures the controlplane pods have an `component: cluster` while the etcd pods have an `component: etcd` label, this way the service for the controlplanes don't also match the etcd pods.