### PR TITLE
Fix wrong links to the k0s docs

### DIFF
--- a/api/bootstrap/v1beta1/k0s_types.go
+++ b/api/bootstrap/v1beta1/k0s_types.go
@@ -69,7 +69,8 @@ type K0sWorkerConfigSpec struct {
 	Files []cloudinit.File `json:"files,omitempty"`
 
 	// Args specifies extra arguments to be passed to k0s worker.
-	// See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+	// See: https://docs.k0sproject.io/stable/worker-node-config/
+	// See: https://docs.k0sproject.io/stable/cli/k0s_worker/
 	Args []string `json:"args,omitempty"`
 
 	// PreStartCommands specifies commands to be run before starting k0s worker.
@@ -161,8 +162,8 @@ type K0sConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	Files []cloudinit.File `json:"files,omitempty"`
 
-	// Args specifies extra arguments to be passed to k0s worker.
-	// See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+	// Args specifies extra arguments to be passed to k0s controller.
+	// See: https://docs.k0sproject.io/stable/cli/k0s_controller/
 	Args []string `json:"args,omitempty"`
 
 	// PreStartCommands specifies commands to be run before starting k0s worker.

--- a/api/controlplane/v1beta1/k0s_types.go
+++ b/api/controlplane/v1beta1/k0s_types.go
@@ -70,7 +70,8 @@ type K0sBootstrapConfigSpec struct {
 	Files []cloudinit.File `json:"files,omitempty"`
 
 	// Args specifies extra arguments to be passed to k0s worker.
-	// See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+	// See: https://docs.k0sproject.io/stable/worker-node-config/
+	// See: https://docs.k0sproject.io/stable/cli/k0s_worker/
 	Args []string `json:"args,omitempty"`
 
 	// PreStartCommands specifies commands to be run before starting k0s worker.

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -42,8 +42,8 @@ spec:
             properties:
               args:
                 description: |-
-                  Args specifies extra arguments to be passed to k0s worker.
-                  See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+                  Args specifies extra arguments to be passed to k0s controller.
+                  See: https://docs.k0sproject.io/stable/cli/k0s_controller/
                 items:
                   type: string
                 type: array

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -43,7 +43,8 @@ spec:
               args:
                 description: |-
                   Args specifies extra arguments to be passed to k0s worker.
-                  See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+                  See: https://docs.k0sproject.io/stable/worker-node-config/
+                  See: https://docs.k0sproject.io/stable/cli/k0s_worker/
                 items:
                   type: string
                 type: array

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -66,7 +66,8 @@ spec:
                       args:
                         description: |-
                           Args specifies extra arguments to be passed to k0s worker.
-                          See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+                          See: https://docs.k0sproject.io/stable/worker-node-config/
+                          See: https://docs.k0sproject.io/stable/cli/k0s_worker/
                         items:
                           type: string
                         type: array

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -44,8 +44,8 @@ spec:
                 properties:
                   args:
                     description: |-
-                      Args specifies extra arguments to be passed to k0s worker.
-                      See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+                      Args specifies extra arguments to be passed to k0s controller.
+                      See: https://docs.k0sproject.io/stable/cli/k0s_controller/
                     items:
                       type: string
                     type: array

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
@@ -66,8 +66,8 @@ spec:
                         properties:
                           args:
                             description: |-
-                              Args specifies extra arguments to be passed to k0s worker.
-                              See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+                              Args specifies extra arguments to be passed to k0s controller.
+                              See: https://docs.k0sproject.io/stable/cli/k0s_controller/
                             items:
                               type: string
                             type: array

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -42,8 +42,8 @@ spec:
             properties:
               args:
                 description: |-
-                  Args specifies extra arguments to be passed to k0s worker.
-                  See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+                  Args specifies extra arguments to be passed to k0s controller.
+                  See: https://docs.k0sproject.io/stable/cli/k0s_controller/
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -43,7 +43,8 @@ spec:
               args:
                 description: |-
                   Args specifies extra arguments to be passed to k0s worker.
-                  See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+                  See: https://docs.k0sproject.io/stable/worker-node-config/
+                  See: https://docs.k0sproject.io/stable/cli/k0s_worker/
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -66,7 +66,8 @@ spec:
                       args:
                         description: |-
                           Args specifies extra arguments to be passed to k0s worker.
-                          See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+                          See: https://docs.k0sproject.io/stable/worker-node-config/
+                          See: https://docs.k0sproject.io/stable/cli/k0s_worker/
                         items:
                           type: string
                         type: array

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -44,8 +44,8 @@ spec:
                 properties:
                   args:
                     description: |-
-                      Args specifies extra arguments to be passed to k0s worker.
-                      See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+                      Args specifies extra arguments to be passed to k0s controller.
+                      See: https://docs.k0sproject.io/stable/cli/k0s_controller/
                     items:
                       type: string
                     type: array

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
@@ -66,8 +66,8 @@ spec:
                         properties:
                           args:
                             description: |-
-                              Args specifies extra arguments to be passed to k0s worker.
-                              See: https://docs.k0sproject.io/stable/advanced/worker-configuration/
+                              Args specifies extra arguments to be passed to k0s controller.
+                              See: https://docs.k0sproject.io/stable/cli/k0s_controller/
                             items:
                               type: string
                             type: array

--- a/docs/resource-reference.md
+++ b/docs/resource-reference.md
@@ -94,8 +94,8 @@ Resource Types:
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
-          Args specifies extra arguments to be passed to k0s worker.
-See: https://docs.k0sproject.io/stable/advanced/worker-configuration/<br/>
+          Args specifies extra arguments to be passed to k0s controller.
+See: https://docs.k0sproject.io/stable/cli/k0s_controller/<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -382,7 +382,8 @@ If empty, k0smotron will use the default one.<br/>
         <td>[]string</td>
         <td>
           Args specifies extra arguments to be passed to k0s worker.
-See: https://docs.k0sproject.io/stable/advanced/worker-configuration/<br/>
+See: https://docs.k0sproject.io/stable/worker-node-config/
+See: https://docs.k0sproject.io/stable/cli/k0s_worker/<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -736,7 +737,8 @@ This should be only set in the case you want to use a pre-generated join token.
         <td>[]string</td>
         <td>
           Args specifies extra arguments to be passed to k0s worker.
-See: https://docs.k0sproject.io/stable/advanced/worker-configuration/<br/>
+See: https://docs.k0sproject.io/stable/worker-node-config/
+See: https://docs.k0sproject.io/stable/cli/k0s_worker/<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1221,8 +1223,8 @@ just the Kubernetes version (e.g. v1.27.1). If left empty, k0smotron will select
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
-          Args specifies extra arguments to be passed to k0s worker.
-See: https://docs.k0sproject.io/stable/advanced/worker-configuration/<br/>
+          Args specifies extra arguments to be passed to k0s controller.
+See: https://docs.k0sproject.io/stable/cli/k0s_controller/<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1837,8 +1839,8 @@ More info: http://kubernetes.io/docs/user-guide/labels<br/>
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
-          Args specifies extra arguments to be passed to k0s worker.
-See: https://docs.k0sproject.io/stable/advanced/worker-configuration/<br/>
+          Args specifies extra arguments to be passed to k0s controller.
+See: https://docs.k0sproject.io/stable/cli/k0s_controller/<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
Looks like the existing link was a Copilot's hallucination, that was mistakenly copy-pasted over the docs