### PR TITLE
Use server-side apply for installation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | kubectl create -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -161,7 +161,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image k0s/k0smotron=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | kubectl create -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -276,7 +276,7 @@ kind-cluster:
 .PHONY: kind-deploy-k0smotron
 kind-deploy-k0smotron: release k0smotron-image-bundle.tar
 	kind load image-archive k0smotron-image-bundle.tar
-	kubectl create -f install.yaml
+	kubectl apply --server-side=true -f install.yaml
 	kubectl rollout restart -n k0smotron deployment/k0smotron-controller-manager
 
 sbom/spdx.json: go.mod

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ With k0smotron, you can run the control plane management cluster in a public or 
 Getting started with k0smotron is easy. Simply install the controller into an existing cluster:
 
 ```bash
-kubectl create -f https://docs.k0smotron.io/stable/install.yaml
+kubectl apply --server-side=true -f https://docs.k0smotron.io/stable/install.yaml
 ```
 
 You can also install k0smotron ClusterAPI providers via `clusterctl`:

--- a/docs/contributing/dev-environment.md
+++ b/docs/contributing/dev-environment.md
@@ -28,7 +28,7 @@ provided configuration file:
 4. Release the necessary components and install them into the Kubernetes cluster:
 
     ```bash
-    make release && kubectl create -f install.yaml
+    make release && kubectl apply --server-side=true -f install.yaml
     ```
 
 5. Initialize the cluster, patch configurations, and enable features:

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ control plane.
 !!! note "TL;DR"
 
     ```bash
-    kubectl apply -f https://docs.k0smotron.io/{{{ extra.k0smotron_version }}}/install.yaml
+    kubectl apply --server-side=true -f https://docs.k0smotron.io/{{{ extra.k0smotron_version }}}/install.yaml
     ```
 
 ## Known limitations
@@ -70,7 +70,7 @@ A full k0smotron installation implies the following components:
 To install the full version of k0smotron:
 
 ```bash
-kubectl create -f https://docs.k0smotron.io/{{{ extra.k0smotron_version }}}/install.yaml
+kubectl apply --server-side=true -f https://docs.k0smotron.io/{{{ extra.k0smotron_version }}}/install.yaml
 ```
 
 Now, you can create your first control planes using k0smotron either as a


### PR DESCRIPTION
Due to the size of CRDs, client-side apply doesn't work with "metadata.annotations: Too long" error. It tries to add it to the `last-applied-configuration` annotation, but it's too long