### PR TITLE
fix: set AutomountServiceAccountToken to false

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_etcd.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_etcd.go
@@ -180,6 +180,7 @@ func (r *ClusterReconciler) generateEtcdStatefulSet(kmc *km.Cluster, replicas in
 					Labels: labels,
 				},
 				Spec: v1.PodSpec{
+					AutomountServiceAccountToken: ptr.To(false),
 					Affinity: &v1.Affinity{PodAntiAffinity: &v1.PodAntiAffinity{
 						PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
 							{


### PR DESCRIPTION
this is not needed and it's best-practice to disable it
otherwise fails in clusters with policies forbidding this.