### PR TITLE
Do not use default 6443 port for kube-apiserver in the container

### DIFF
--- a/internal/controller/infrastructure/remote_machine_controller.go
+++ b/internal/controller/infrastructure/remote_machine_controller.go
@@ -372,9 +372,6 @@ func (r *RemoteMachineController) getSSHKey(ctx context.Context, rm *infrastruct
 }
 
 func (r *RemoteMachineController) getBootstrapData(ctx context.Context, machine *clusterv1.Machine) ([]byte, error) {
-	if machine.Spec.Bootstrap.DataSecretName == nil {
-		return nil, fmt.Errorf("wait for bootstap secret for the machine: %s", machine.Name)
-	}
 	secret := &v1.Secret{}
 	key := client.ObjectKey{
 		Namespace: machine.Namespace,

--- a/internal/controller/infrastructure/remote_machine_controller.go
+++ b/internal/controller/infrastructure/remote_machine_controller.go
@@ -372,6 +372,9 @@ func (r *RemoteMachineController) getSSHKey(ctx context.Context, rm *infrastruct
 }
 
 func (r *RemoteMachineController) getBootstrapData(ctx context.Context, machine *clusterv1.Machine) ([]byte, error) {
+	if machine.Spec.Bootstrap.DataSecretName == nil {
+		return nil, fmt.Errorf("wait for bootstap secret for the machine: %s", machine.Name)
+	}
 	secret := &v1.Secret{}
 	key := client.ObjectKey{
 		Namespace: machine.Namespace,

--- a/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
@@ -214,7 +214,7 @@ func getV1Beta1Spec(kmc *km.Cluster, sans []string) map[string]interface{} {
 	v1beta1Spec := map[string]interface{}{
 		"api": map[string]interface{}{
 			"externalAddress": kmc.Spec.ExternalAddress,
-			"port":            defaultKubeAPIPort,
+			"port":            kmc.Spec.Service.APIPort,
 			"sans":            sans,
 		},
 		"konnectivity": map[string]interface{}{

--- a/internal/controller/k0smotron.io/k0smotroncluster_controller.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_controller.go
@@ -36,8 +36,6 @@ import (
 	km "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
 )
 
-const defaultKubeAPIPort = 6443
-
 var patchOpts []client.PatchOption = []client.PatchOption{
 	client.FieldOwner("k0smotron-operator"),
 	client.ForceOwnership,

--- a/internal/controller/k0smotron.io/k0smotroncluster_kubeconfig.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_kubeconfig.go
@@ -42,11 +42,6 @@ func (r *ClusterReconciler) reconcileKubeConfigSecret(ctx context.Context, kmc k
 		return err
 	}
 
-	output, _, err = replaceKubeconfigPort(output, kmc)
-	if err != nil {
-		return err
-	}
-
 	logger.Info("Kubeconfig generated, creating the secret")
 
 	secret := v1.Secret{

--- a/internal/controller/k0smotron.io/k0smotroncluster_service.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_service.go
@@ -40,8 +40,8 @@ func (r *ClusterReconciler) generateService(kmc *km.Cluster) v1.Service {
 		name = kmc.GetNodePortServiceName()
 		ports = append(ports,
 			v1.ServicePort{
-				Port:       int32(defaultKubeAPIPort),
-				TargetPort: intstr.FromInt(defaultKubeAPIPort),
+				Port:       int32(kmc.Spec.Service.APIPort),
+				TargetPort: intstr.FromInt(kmc.Spec.Service.APIPort),
 				Name:       "api",
 				NodePort:   int32(kmc.Spec.Service.APIPort),
 			},
@@ -57,7 +57,7 @@ func (r *ClusterReconciler) generateService(kmc *km.Cluster) v1.Service {
 		ports = append(ports,
 			v1.ServicePort{
 				Port:       int32(kmc.Spec.Service.APIPort),
-				TargetPort: intstr.FromInt(defaultKubeAPIPort),
+				TargetPort: intstr.FromInt(kmc.Spec.Service.APIPort),
 				Name:       "api",
 			},
 			v1.ServicePort{
@@ -76,7 +76,7 @@ func (r *ClusterReconciler) generateService(kmc *km.Cluster) v1.Service {
 		ports = append(ports,
 			v1.ServicePort{
 				Port:       int32(kmc.Spec.Service.APIPort),
-				TargetPort: intstr.FromInt(defaultKubeAPIPort),
+				TargetPort: intstr.FromInt(kmc.Spec.Service.APIPort),
 				Name:       "api",
 			},
 			v1.ServicePort{

--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -118,7 +118,7 @@ func (r *ClusterReconciler) generateStatefulSet(kmc *km.Cluster) (apps.StatefulS
 							{
 								Name:          "api",
 								Protocol:      v1.ProtocolTCP,
-								ContainerPort: int32(defaultKubeAPIPort),
+								ContainerPort: int32(kmc.Spec.Service.APIPort),
 							},
 							{
 								Name:          "konnectivity",

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -91,14 +91,14 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.checkClusterStatus(s.Context(), rc)
 
 	s.T().Log("Generating k0smotron join token")
-	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test", 30443)
+	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test")
 	s.Require().NoError(err)
 
 	s.T().Log("joining worker to k0smotron cluster")
 	s.Require().NoError(s.RunWithToken(s.K0smotronNode(0), token))
 
 	s.T().Log("Starting portforward")
-	fw, err := util.GetPortForwarder(rc, "kmc-kmc-test-0", "kmc-test", 6443)
+	fw, err := util.GetPortForwarder(rc, "kmc-kmc-test-0", "kmc-test", 30443)
 	s.Require().NoError(err)
 
 	go fw.Start(s.Require().NoError)

--- a/inttest/capi-docker-machinedeployment/capi_docker_test.go
+++ b/inttest/capi-docker-machinedeployment/capi_docker_test.go
@@ -90,7 +90,7 @@ func (s *CAPIDockerSuite) TestCAPIDocker() {
 	s.Require().NoError(common.WaitForStatefulSet(s.ctx, s.client, "kmc-docker-md-test", "default"))
 
 	s.T().Log("Starting portforward")
-	fw, err := util.GetPortForwarder(s.restConfig, "kmc-docker-md-test-0", "default", 6443)
+	fw, err := util.GetPortForwarder(s.restConfig, "kmc-docker-md-test-0", "default", 30443)
 	s.Require().NoError(err)
 
 	go fw.Start(s.Require().NoError)

--- a/inttest/capi-docker/capi_docker_test.go
+++ b/inttest/capi-docker/capi_docker_test.go
@@ -103,7 +103,7 @@ func (s *CAPIDockerSuite) TestCAPIDocker() {
 	s.checkControlPlaneStatus(s.ctx, s.restConfig)
 
 	s.T().Log("Starting portforward")
-	fw, err := util.GetPortForwarder(s.restConfig, "kmc-docker-test-0", "default", 6443)
+	fw, err := util.GetPortForwarder(s.restConfig, "kmc-docker-test-0", "default", 30443)
 	s.Require().NoError(err)
 
 	go fw.Start(s.Require().NoError)

--- a/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
+++ b/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
@@ -133,7 +133,7 @@ func (s *RemoteMachineSuite) TestCAPIRemoteMachine() {
 	s.Require().NoError(common.WaitForStatefulSet(ctx, s.client, "kmc-remote-test", "default"))
 
 	s.T().Log("Starting portforward")
-	fw, err := util.GetPortForwarder(s.restConfig, "kmc-remote-test-0", "default", 6443)
+	fw, err := util.GetPortForwarder(s.restConfig, "kmc-remote-test-0", "default", 30443)
 	s.Require().NoError(err)
 
 	go fw.Start(s.Require().NoError)

--- a/inttest/capi-remote-machine/capi_remote_machine_test.go
+++ b/inttest/capi-remote-machine/capi_remote_machine_test.go
@@ -134,7 +134,7 @@ func (s *RemoteMachineSuite) TestCAPIRemoteMachine() {
 	s.Require().NoError(common.WaitForStatefulSet(ctx, s.client, "kmc-remote-test", "default"))
 
 	s.T().Log("Starting portforward")
-	fw, err := util.GetPortForwarder(s.restConfig, "kmc-remote-test-0", "default", 6443)
+	fw, err := util.GetPortForwarder(s.restConfig, "kmc-remote-test-0", "default", 30443)
 	s.Require().NoError(err)
 
 	go fw.Start(s.Require().NoError)

--- a/inttest/config-update-hcp/config_update_test.go
+++ b/inttest/config-update-hcp/config_update_test.go
@@ -67,7 +67,7 @@ func (s *ConfigUpdateSuite) TestK0sGetsUp() {
 	s.checkClusterStatus(s.Context(), rc)
 
 	s.T().Log("Starting portforward")
-	fw, err := util.GetPortForwarder(rc, "kmc-kmc-test-0", "kmc-test", 6443)
+	fw, err := util.GetPortForwarder(rc, "kmc-kmc-test-0", "kmc-test", 30443)
 	s.Require().NoError(err)
 
 	go fw.Start(s.Require().NoError)

--- a/inttest/ha-controller-etcd/ha_controller_etcd_test.go
+++ b/inttest/ha-controller-etcd/ha_controller_etcd_test.go
@@ -56,7 +56,7 @@ func (s *HAControllerEtcdSuite) TestK0sGetsUp() {
 	s.Require().NoError(common.WaitForStatefulSet(s.Context(), kc, "kmc-kmc-test", "kmc-test"))
 
 	s.T().Log("Generating k0smotron join token")
-	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test", 30443)
+	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test")
 	s.Require().NoError(err)
 
 	s.T().Log("joining worker to k0smotron cluster")
@@ -65,18 +65,15 @@ func (s *HAControllerEtcdSuite) TestK0sGetsUp() {
 	s.T().Log("Starting portforward")
 	pod := s.getPod(s.Context(), kc)
 
-	fw, err := util.GetPortForwarder(rc, pod.Name, pod.Namespace, 6443)
+	fw, err := util.GetPortForwarder(rc, pod.Name, pod.Namespace, 30443)
 	s.Require().NoError(err)
 	go fw.Start(s.Require().NoError)
 	defer fw.Close()
 
 	<-fw.ReadyChan
 
-	localPort, err := fw.LocalPort()
-	s.Require().NoError(err)
-
 	s.T().Log("waiting for node to be ready")
-	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test", "kmc-test", localPort)
+	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test", "kmc-test", 30443)
 	s.Require().NoError(err)
 	s.Require().NoError(s.WaitForNodeReady(s.K0smotronNode(0), kmcKC))
 

--- a/inttest/ha-controller-secret/ha_controller_secret_test.go
+++ b/inttest/ha-controller-secret/ha_controller_secret_test.go
@@ -64,7 +64,7 @@ func (s *HAControllerSecretSuite) TestK0sGetsUp() {
 	s.Require().NoError(common.WaitForStatefulSet(s.Context(), kc, "kmc-kmc-test-secret", "kmc-test"))
 
 	s.T().Log("Generating k0smotron join token")
-	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-secret-0", "kmc-test", 30443)
+	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-secret-0", "kmc-test")
 	s.Require().NoError(err)
 
 	s.T().Log("joining worker to k0smotron cluster")
@@ -73,18 +73,15 @@ func (s *HAControllerSecretSuite) TestK0sGetsUp() {
 	s.T().Log("Starting portforward")
 	pod := s.getPod(s.Context(), kc)
 
-	fw, err := util.GetPortForwarder(rc, pod.Name, pod.Namespace, 6443)
+	fw, err := util.GetPortForwarder(rc, pod.Name, pod.Namespace, 30443)
 	s.Require().NoError(err)
 	go fw.Start(s.Require().NoError)
 	defer fw.Close()
 
 	<-fw.ReadyChan
 	s.T().Log("portforward ready")
-	localPort, err := fw.LocalPort()
-	s.Require().NoError(err)
-
 	s.T().Log("getting child clientset")
-	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test-secret", "kmc-test", localPort)
+	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test-secret", "kmc-test", 30443)
 	s.Require().NoError(err)
 	s.T().Log("waiting for node to be ready")
 	s.Require().NoError(s.WaitForNodeReady(s.K0smotronNode(0), kmcKC))

--- a/inttest/ha-controller/ha_controller_test.go
+++ b/inttest/ha-controller/ha_controller_test.go
@@ -60,7 +60,7 @@ func (s *HAControllerSuite) TestK0sGetsUp() {
 	s.Require().NoError(common.WaitForStatefulSet(s.Context(), kc, "kmc-kmc-test", "kmc-test"))
 
 	s.T().Log("Generating k0smotron join token")
-	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test", 30443)
+	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test")
 	s.Require().NoError(err)
 
 	s.T().Log("joining worker to k0smotron cluster")
@@ -69,18 +69,15 @@ func (s *HAControllerSuite) TestK0sGetsUp() {
 	s.T().Log("Starting portforward")
 	pod := s.getPod(s.Context(), kc)
 
-	fw, err := util.GetPortForwarder(rc, pod.Name, pod.Namespace, 6443)
+	fw, err := util.GetPortForwarder(rc, pod.Name, pod.Namespace, 30443)
 	s.Require().NoError(err)
 	go fw.Start(s.Require().NoError)
 	defer fw.Close()
 
 	<-fw.ReadyChan
 
-	localPort, err := fw.LocalPort()
-	s.Require().NoError(err)
-
 	s.T().Log("waiting for node to be ready")
-	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test", "kmc-test", localPort)
+	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test", "kmc-test", 30443)
 	s.Require().NoError(err)
 	s.Require().NoError(s.WaitForNodeReady(s.K0smotronNode(0), kmcKC))
 

--- a/inttest/hostpath/hostpath_test.go
+++ b/inttest/hostpath/hostpath_test.go
@@ -63,25 +63,22 @@ func (s *HostPathSuite) TestK0sGetsUp() {
 	s.Require().NoError(common.WaitForStatefulSet(s.Context(), kc, "kmc-kmc-test", "kmc-test"))
 
 	s.T().Log("Generating k0smotron join token")
-	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test", 30443)
+	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test")
 	s.Require().NoError(err)
 
 	s.T().Log("joining worker to k0smotron cluster")
 	s.Require().NoError(s.RunWithToken(s.K0smotronNode(0), token))
 
 	s.T().Log("Starting portforward")
-	fw, err := util.GetPortForwarder(rc, "kmc-kmc-test-0", "kmc-test", 6443)
+	fw, err := util.GetPortForwarder(rc, "kmc-kmc-test-0", "kmc-test", 30443)
 	s.Require().NoError(err)
 	go fw.Start(s.Require().NoError)
 	defer fw.Close()
 
 	<-fw.ReadyChan
 
-	localPort, err := fw.LocalPort()
-	s.Require().NoError(err)
-
 	s.T().Log("waiting for node to be ready")
-	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test", "kmc-test", localPort)
+	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test", "kmc-test", 30443)
 	s.Require().NoError(err)
 	s.Require().NoError(s.WaitForNodeReady(s.K0smotronNode(0), kmcKC))
 

--- a/inttest/monitoring/monitoring_test.go
+++ b/inttest/monitoring/monitoring_test.go
@@ -61,7 +61,7 @@ func (s *MonitoringSuite) TestK0sGetsUp() {
 	s.Require().NoError(common.WaitForStatefulSet(s.Context(), kc, "kmc-kmc-test", "kmc-test"))
 
 	s.T().Log("Generating k0smotron join token")
-	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test", 30443)
+	token, err := util.GetJoinToken(kc, rc, "kmc-kmc-test-0", "kmc-test")
 	s.Require().NoError(err)
 
 	s.T().Log("joining worker to k0smotron cluster")
@@ -70,7 +70,7 @@ func (s *MonitoringSuite) TestK0sGetsUp() {
 	s.Require().NoError(common.WaitForDeployment(s.Context(), kc, "prometheus-server", "default"))
 
 	s.T().Log("Starting portforward")
-	fw, err := util.GetPortForwarder(rc, "kmc-kmc-test-0", "kmc-test", 6443)
+	fw, err := util.GetPortForwarder(rc, "kmc-kmc-test-0", "kmc-test", 30443)
 	s.Require().NoError(err)
 
 	go fw.Start(s.Require().NoError)

--- a/inttest/util/portforward.go
+++ b/inttest/util/portforward.go
@@ -52,7 +52,7 @@ func GetPortForwarder(cfg *rest.Config, name string, namespace string, port int)
 
 	stopChan := make(chan struct{})
 	readyChan := make(chan struct{})
-	fw, err := portforward.New(dialer, []string{fmt.Sprintf("42042:%d", port)}, stopChan, readyChan, io.Discard, os.Stderr)
+	fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d", port)}, stopChan, readyChan, io.Discard, os.Stderr)
 	if err != nil {
 		return nil, err
 	}

--- a/inttest/util/util.go
+++ b/inttest/util/util.go
@@ -39,8 +39,6 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 
-	v1beta1 "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
-	k0smotronio "github.com/k0sproject/k0smotron/internal/controller/k0smotron.io"
 	"github.com/k0sproject/k0smotron/internal/exec"
 )
 
@@ -139,16 +137,13 @@ func CreateResources(ctx context.Context, resources []*unstructured.Unstructured
 	return nil
 }
 
-func GetJoinToken(kc *kubernetes.Clientset, rc *rest.Config, name string, namespace string, port int) (string, error) {
+func GetJoinToken(kc *kubernetes.Clientset, rc *rest.Config, name string, namespace string) (string, error) {
 	output, err := exec.PodExecCmdOutput(context.TODO(), kc, rc, name, namespace, "k0s token create --role=worker")
 	if err != nil {
 		return "", fmt.Errorf("failed to get join token: %s", err)
 	}
 
-	cluster := v1beta1.Cluster{Spec: v1beta1.ClusterSpec{Service: v1beta1.ServiceSpec{APIPort: port}}}
-	token, _, err := k0smotronio.ReplaceTokenPort(output, cluster)
-
-	return token, err
+	return output, nil
 }
 
 // GetKMCClientSet returns a kubernetes clientset for the cluster given


### PR DESCRIPTION
Revert #603 
Fixes #637 

Do not use the default 6443 port for kube-apiserver in the container.

Instead allow kube-apiserver binary to bind on privileged ports  