### PR TITLE
Group mkdocs version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
     open-pull-requests-limit: 3
     schedule:
       interval: daily
+    groups:
+      mkdocs:
+        patterns:
+          - "mkdocs*"


### PR DESCRIPTION
There might be cases in which some mkdocs extensions pin certain minor mkdocs versions. Then we're forced to update them in lockstep with the main mkdocs version.

This is already present in k0s: https://github.com/k0sproject/k0s/commit/9d981d27414d8479a7558bcd0b8b2f57de5e9d5c