### PR TITLE
Check for CAPI crds to be installed before setup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -183,8 +183,9 @@ func main() {
 			os.Exit(1)
 		}
 		if err = (&bootstrap.ProviderIDController{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
+			Client:    mgr.GetClient(),
+			Scheme:    mgr.GetScheme(),
+			ClientSet: clientSet,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Bootstrap")
 			os.Exit(1)

--- a/internal/controller/bootstrap/providerid_controller.go
+++ b/internal/controller/bootstrap/providerid_controller.go
@@ -8,6 +8,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capiutil "sigs.k8s.io/cluster-api/util"
@@ -20,7 +21,8 @@ import (
 
 type ProviderIDController struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme    *runtime.Scheme
+	ClientSet *kubernetes.Clientset
 }
 
 func (p *ProviderIDController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -88,6 +90,15 @@ func (p *ProviderIDController) Reconcile(ctx context.Context, req ctrl.Request) 
 }
 
 func (p *ProviderIDController) SetupWithManager(mgr ctrl.Manager) error {
+	apiResources, err := p.ClientSet.Discovery().ServerResourcesForGroupVersion(clusterv1.GroupVersion.String())
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if apiResources == nil {
+		log.Log.Info("CAPI crds are not installed yet, skipping initializing providerID controller")
+		return nil
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.Machine{}).
 		Complete(p)


### PR DESCRIPTION
Fixes #659

If the CAPI crds are missing, the controller watch fails and the pod fails into CrashLoopBackoff