### PR TITLE
Create autopilot Plan object with an emptry selector

### DIFF
--- a/internal/controller/controlplane/helper.go
+++ b/internal/controller/controlplane/helper.go
@@ -246,11 +246,11 @@ func (c *K0sController) createAutopilotPlan(ctx context.Context, kcp *cpv1beta1.
 					},
 					"targets": {
 						"controllers": {
-							"discovery": {
-							    "static": {
-									"nodes": ["` + strings.Join(machines.Names(), `","`) + `"]
-								}
-							}
+							"discovery": { }
+							    // "static": {
+								// 	"nodes": ["` + strings.Join(machines.Names(), `","`) + `"]
+								// }
+							// }
 						}
 					}
 				}


### PR DESCRIPTION
Using an empty selector selects all controllers. This way we do not need to try to figure out machine names nor node names for the selector.

Fixes #670 