### PR TITLE
Use Machine's name as a k8s node name by default

### DIFF
--- a/api/bootstrap/v1beta1/k0s_types.go
+++ b/api/bootstrap/v1beta1/k0s_types.go
@@ -64,6 +64,12 @@ type K0sWorkerConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	Version string `json:"version,omitempty"`
 
+	// UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+	// By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	UseSystemHostname bool `json:"useSystemHostname,omitempty"`
+
 	// Files specifies extra files to be passed to user_data upon creation.
 	// +kubebuilder:validation:Optional
 	Files []cloudinit.File `json:"files,omitempty"`
@@ -161,6 +167,12 @@ type K0sConfigSpec struct {
 	// Files specifies extra files to be passed to user_data upon creation.
 	// +kubebuilder:validation:Optional
 	Files []cloudinit.File `json:"files,omitempty"`
+
+	// UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+	// By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	UseSystemHostname bool `json:"useSystemHostname,omitempty"`
 
 	// Args specifies extra arguments to be passed to k0s controller.
 	// See: https://docs.k0sproject.io/stable/cli/k0s_controller/

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -124,6 +124,12 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              useSystemHostname:
+                default: false
+                description: |-
+                  UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+                  By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+                type: boolean
               version:
                 description: |-
                   Version is the version of k0s to use. In case this is not set, k0smotron will use

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -98,6 +98,12 @@ spec:
                 items:
                   type: string
                 type: array
+              useSystemHostname:
+                default: false
+                description: |-
+                  UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+                  By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+                type: boolean
               version:
                 description: |-
                   Version is the version of k0s to use. In case this is not set, k0smotron will use

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -121,6 +121,12 @@ spec:
                         items:
                           type: string
                         type: array
+                      useSystemHostname:
+                        default: false
+                        description: |-
+                          UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+                          By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+                        type: boolean
                       version:
                         description: |-
                           Version is the version of k0s to use. In case this is not set, k0smotron will use

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -126,6 +126,12 @@ spec:
                         format: int32
                         type: integer
                     type: object
+                  useSystemHostname:
+                    default: false
+                    description: |-
+                      UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+                      By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+                    type: boolean
                 type: object
               machineTemplate:
                 properties:

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
@@ -149,6 +149,12 @@ spec:
                                 format: int32
                                 type: integer
                             type: object
+                          useSystemHostname:
+                            default: false
+                            description: |-
+                              UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+                              By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+                            type: boolean
                         type: object
                       machineTemplate:
                         properties:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -124,6 +124,12 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              useSystemHostname:
+                default: false
+                description: |-
+                  UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+                  By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+                type: boolean
               version:
                 description: |-
                   Version is the version of k0s to use. In case this is not set, k0smotron will use

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -98,6 +98,12 @@ spec:
                 items:
                   type: string
                 type: array
+              useSystemHostname:
+                default: false
+                description: |-
+                  UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+                  By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+                type: boolean
               version:
                 description: |-
                   Version is the version of k0s to use. In case this is not set, k0smotron will use

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -121,6 +121,12 @@ spec:
                         items:
                           type: string
                         type: array
+                      useSystemHostname:
+                        default: false
+                        description: |-
+                          UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+                          By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+                        type: boolean
                       version:
                         description: |-
                           Version is the version of k0s to use. In case this is not set, k0smotron will use

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -126,6 +126,12 @@ spec:
                         format: int32
                         type: integer
                     type: object
+                  useSystemHostname:
+                    default: false
+                    description: |-
+                      UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+                      By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+                    type: boolean
                 type: object
               machineTemplate:
                 properties:

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
@@ -149,6 +149,12 @@ spec:
                                 format: int32
                                 type: integer
                             type: object
+                          useSystemHostname:
+                            default: false
+                            description: |-
+                              UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+                              By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
+                            type: boolean
                         type: object
                       machineTemplate:
                         properties:

--- a/docs/resource-reference.md
+++ b/docs/resource-reference.md
@@ -150,6 +150,16 @@ If empty, will be used default configuration. @see https://docs.k0sproject.io/st
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>useSystemHostname</b></td>
+        <td>boolean</td>
+        <td>
+          UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>version</b></td>
         <td>string</td>
         <td>
@@ -428,6 +438,16 @@ This should be only set in the case you want to use a pre-generated join token.<
         <td>[]string</td>
         <td>
           PreStartCommands specifies commands to be run before starting k0s worker.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>useSystemHostname</b></td>
+        <td>boolean</td>
+        <td>
+          UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -783,6 +803,16 @@ This should be only set in the case you want to use a pre-generated join token.<
         <td>[]string</td>
         <td>
           PreStartCommands specifies commands to be run before starting k0s worker.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>useSystemHostname</b></td>
+        <td>boolean</td>
+        <td>
+          UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1276,6 +1306,16 @@ If empty, will be used default configuration. @see https://docs.k0sproject.io/st
         <td>object</td>
         <td>
           Tunneling defines the tunneling configuration for the cluster.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>useSystemHostname</b></td>
+        <td>boolean</td>
+        <td>
+          UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1892,6 +1932,16 @@ If empty, will be used default configuration. @see https://docs.k0sproject.io/st
         <td>object</td>
         <td>
           Tunneling defines the tunneling configuration for the cluster.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>useSystemHostname</b></td>
+        <td>boolean</td>
+        <td>
+          UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
+By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/controller/bootstrap/bootstrap_controller.go
+++ b/internal/controller/bootstrap/bootstrap_controller.go
@@ -310,11 +310,8 @@ func (r *Controller) getK0sToken(ctx context.Context, scope *Scope) (string, err
 func createInstallCmd(scope *Scope) string {
 	installCmd := []string{
 		"k0s install worker --token-file /etc/k0s.token",
-		"--labels=" + fmt.Sprintf("%s=%s", machineNameNodeLabel, scope.ConfigOwner.GetName()),
 	}
-	if scope.Config.Spec.Args != nil && len(scope.Config.Spec.Args) > 0 {
-		installCmd = append(installCmd, scope.Config.Spec.Args...)
-	}
+	installCmd = append(installCmd, mergeExtraArgs(scope.Config.Spec.Args, scope.ConfigOwner, true, scope.Config.Spec.UseSystemHostname)...)
 	return strings.Join(installCmd, " ")
 }
 

--- a/internal/controller/bootstrap/bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/bootstrap_controller_test.go
@@ -40,21 +40,36 @@ func Test_createInstallCmd(t *testing.T) {
 					"metadata": map[string]interface{}{"name": "test"},
 				}}},
 			},
-			want: base,
+			want: base + ` --kubelet-extra-args="--hostname-override=test"`,
 		},
 		{
 			name: "with args",
 			scope: &Scope{
 				Config: &bootstrapv1.K0sWorkerConfig{
 					Spec: bootstrapv1.K0sWorkerConfigSpec{
-						Args: []string{"--debug", "--labels=k0sproject.io/foo=bar"},
+						Args: []string{"--debug", "--labels=k0sproject.io/foo=bar", `--kubelet-extra-args="--hostname-override=test-from-arg"`},
 					},
 				},
 				ConfigOwner: &bsutil.ConfigOwner{Unstructured: &unstructured.Unstructured{Object: map[string]interface{}{
 					"metadata": map[string]interface{}{"name": "test"},
 				}}},
 			},
-			want: base + " --debug --labels=k0sproject.io/foo=bar",
+			want: base + ` --debug --labels=k0sproject.io/foo=bar --kubelet-extra-args="--hostname-override=test --hostname-override=test-from-arg"`,
+		},
+		{
+			name: "with useSystemHostname set",
+			scope: &Scope{
+				Config: &bootstrapv1.K0sWorkerConfig{
+					Spec: bootstrapv1.K0sWorkerConfigSpec{
+						UseSystemHostname: true,
+						Args:              []string{"--debug", "--labels=k0sproject.io/foo=bar", `--kubelet-extra-args="--hostname-override=test-from-arg"`},
+					},
+				},
+				ConfigOwner: &bsutil.ConfigOwner{Unstructured: &unstructured.Unstructured{Object: map[string]interface{}{
+					"metadata": map[string]interface{}{"name": "test"},
+				}}},
+			},
+			want: base + ` --debug --labels=k0sproject.io/foo=bar --kubelet-extra-args="--hostname-override=test-from-arg"`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/controller/bootstrap/common.go
+++ b/internal/controller/bootstrap/common.go
@@ -1,0 +1,39 @@
+package bootstrap
+
+import (
+	"fmt"
+	"strings"
+
+	bsutil "sigs.k8s.io/cluster-api/bootstrap/util"
+)
+
+func mergeExtraArgs(configArgs []string, configOwner *bsutil.ConfigOwner, isWorker bool, useSystemHostname bool) []string {
+	var args []string
+	if isWorker {
+		args = []string{
+			"--labels=" + fmt.Sprintf("%s=%s", machineNameNodeLabel, configOwner.GetName()),
+		}
+	}
+
+	kubeletExtraArgs := fmt.Sprintf(`--kubelet-extra-args="--hostname-override=%s"`, configOwner.GetName())
+	for _, arg := range configArgs {
+		if strings.HasPrefix(arg, "--kubelet-extra-args") && !useSystemHostname {
+			_, after, ok := strings.Cut(arg, "=")
+			if !ok {
+				_, after, ok = strings.Cut(arg, " ")
+			}
+			if !ok {
+				kubeletExtraArgs = arg
+			} else {
+				kubeletExtraArgs = fmt.Sprintf(`--kubelet-extra-args="--hostname-override=%s %s"`, configOwner.GetName(), strings.Trim(after, "\"'"))
+			}
+		} else {
+			args = append(args, arg)
+		}
+	}
+	if isWorker && !useSystemHostname {
+		args = append(args, kubeletExtraArgs)
+	}
+
+	return args
+}

--- a/internal/controller/bootstrap/controlplane_bootstrap_controller.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller.go
@@ -541,7 +541,7 @@ func createCPInstallCmd(scope *ControllerScope) string {
 		"--env AUTOPILOT_HOSTNAME=" + scope.Config.Name,
 	}
 
-	installCmd = append(installCmd, mergeExtraArgs(scope)...)
+	installCmd = append(installCmd, mergeControllerExtraArgs(scope)...)
 
 	return strings.Join(installCmd, " ")
 }
@@ -554,38 +554,14 @@ func createCPInstallCmdWithJoinToken(scope *ControllerScope, tokenPath string) s
 		"--env AUTOPILOT_HOSTNAME=" + scope.Config.Name,
 	}
 
-	installCmd = append(installCmd, mergeExtraArgs(scope)...)
+	installCmd = append(installCmd, mergeControllerExtraArgs(scope)...)
 	installCmd = append(installCmd, "--token-file", tokenPath)
 
 	return strings.Join(installCmd, " ")
 }
 
-func mergeExtraArgs(scope *ControllerScope) []string {
-	args := []string{
-		"--labels=" + fmt.Sprintf("%s=%s", machineNameNodeLabel, scope.ConfigOwner.GetName()),
-	}
-
-	kubeletExtraArgs := fmt.Sprintf(`--kubelet-extra-args="--hostname-override=%s"`, scope.Config.Name)
-	for _, arg := range scope.Config.Spec.Args {
-		if strings.HasPrefix(arg, "--kubelet-extra-args") {
-			_, after, ok := strings.Cut(arg, "=")
-			if !ok {
-				_, after, ok = strings.Cut(arg, " ")
-			}
-			if !ok {
-				kubeletExtraArgs = arg
-			} else {
-				kubeletExtraArgs = fmt.Sprintf(`--kubelet-extra-args="--hostname-override=%s %s"`, scope.Config.Name, strings.Trim(after, "\"'"))
-			}
-		} else {
-			args = append(args, arg)
-		}
-	}
-	if scope.WorkerEnabled {
-		args = append(args, kubeletExtraArgs)
-	}
-
-	return args
+func mergeControllerExtraArgs(scope *ControllerScope) []string {
+	return mergeExtraArgs(scope.Config.Spec.Args, scope.ConfigOwner, scope.WorkerEnabled, scope.Config.Spec.UseSystemHostname)
 }
 
 func (c *ControlPlaneController) findFirstControllerIP(ctx context.Context, config *bootstrapv1.K0sControllerConfig) (string, error) {

--- a/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
@@ -47,7 +47,7 @@ func Test_createCPInstallCmd(t *testing.T) {
 					"metadata": map[string]interface{}{"name": "test-machine"},
 				}}},
 			},
-			want: base + "--env AUTOPILOT_HOSTNAME=test --labels=k0smotron.io/machine-name=test-machine",
+			want: base + "--env AUTOPILOT_HOSTNAME=test",
 		},
 		{
 			name: "with args",
@@ -58,15 +58,16 @@ func Test_createCPInstallCmd(t *testing.T) {
 					},
 					Spec: bootstrapv1.K0sControllerConfigSpec{
 						K0sConfigSpec: &bootstrapv1.K0sConfigSpec{
-							Args: []string{"--debug", "--labels=k0sproject.io/foo=bar"},
+							Args: []string{"--enable-worker", "--labels=k0sproject.io/foo=bar"},
 						},
 					},
 				},
 				ConfigOwner: &bsutil.ConfigOwner{Unstructured: &unstructured.Unstructured{Object: map[string]interface{}{
 					"metadata": map[string]interface{}{"name": "test-machine"},
 				}}},
+				WorkerEnabled: true,
 			},
-			want: base + "--env AUTOPILOT_HOSTNAME=test --labels=k0smotron.io/machine-name=test-machine --debug --labels=k0sproject.io/foo=bar",
+			want: base + "--env AUTOPILOT_HOSTNAME=test --labels=k0smotron.io/machine-name=test-machine --enable-worker --labels=k0sproject.io/foo=bar --kubelet-extra-args=\"--hostname-override=test-machine\"",
 		},
 	}
 	for _, tt := range tests {

--- a/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
+++ b/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
@@ -129,7 +129,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.Require().NoError(err)
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-cluster-docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
 	s.T().Log("waiting for frp server to be ready")
 	s.Require().NoError(k0stestutil.WaitForDeployment(s.ctx, s.client, "docker-test-frps", "default"))
@@ -151,7 +151,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 		DoRaw(context.Background())
 	s.Require().NoError(err)
 
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, tunneledKmcKC, "docker-test-cluster-docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, tunneledKmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
 	s.Require().NoError(k0stestutil.WaitForDeployment(s.ctx, tunneledKmcKC, "frpc", "kube-system"))
 }

--- a/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
+++ b/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
@@ -128,7 +128,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.Require().NoError(err)
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-cluster-docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
 	s.T().Log("waiting for frp server to be ready")
 	s.Require().NoError(k0stestutil.WaitForDeployment(s.ctx, s.client, "docker-test-frps", "default"))
@@ -166,7 +166,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.Require().NoError(err)
 
 	s.T().Log("check for node to be ready via tunnel")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, tunneledKmcKC, "docker-test-cluster-docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, tunneledKmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
 	s.Require().NoError(k0stestutil.WaitForDeployment(s.ctx, tunneledKmcKC, "frpc", "kube-system"))
 }

--- a/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
@@ -129,7 +129,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	}
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-cluster-docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
 	s.T().Log("verifying cloud-init extras")
 	preStartFile, err := getDockerNodeFile("docker-test-cluster-docker-test-worker-0", "/tmp/pre-start")

--- a/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
+++ b/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
@@ -149,7 +149,7 @@ func (s *RemoteMachineSuite) TestCAPIRemoteMachine() {
 	s.Require().NoError(err)
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(common.WaitForNodeReadyStatus(ctx, kmcKC, "k0smotron0", corev1.ConditionTrue))
+	s.Require().NoError(common.WaitForNodeReadyStatus(ctx, kmcKC, "remote-test-0", corev1.ConditionTrue))
 	// Verify the RemoteMachine is at expected state
 	rm, err := s.getRemoteMachine("remote-test-0", "default")
 	s.Require().NoError(err)

--- a/inttest/capi-remote-machine/capi_remote_machine_test.go
+++ b/inttest/capi-remote-machine/capi_remote_machine_test.go
@@ -153,7 +153,7 @@ func (s *RemoteMachineSuite) TestCAPIRemoteMachine() {
 	s.Require().NoError(err)
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(common.WaitForNodeReadyStatus(ctx, kmcKC, "k0smotron0", corev1.ConditionTrue))
+	s.Require().NoError(common.WaitForNodeReadyStatus(ctx, kmcKC, "remote-test-0", corev1.ConditionTrue))
 	// Verify the RemoteMachine is at expected state
 	rm, err := s.getRemoteMachine("remote-test-0", "default")
 	s.Require().NoError(err)
@@ -162,7 +162,7 @@ func (s *RemoteMachineSuite) TestCAPIRemoteMachine() {
 	s.Require().Equal(expectedProviderID, rm.Spec.ProviderID)
 
 	err = wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (done bool, err error) {
-		node, err := kmcKC.CoreV1().Nodes().Get(ctx, "k0smotron0", metav1.GetOptions{})
+		node, err := kmcKC.CoreV1().Nodes().Get(ctx, "remote-test-0", metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Adds `--hostname-override` to the worker nodes to match the kubernetes node name and machine name. Can be disabled by setting the `UseSystemHostname` to true.

Also `mergeExtraArgs` func improved to work both with controller and worker args.