### PR TITLE
Fix release pipeline after Go version update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            BUILD_IMG=golang:1.21.3
+            BUILD_IMG=golang:1.22.6
           context: .
           platforms: linux/amd64,linux/arm64
           tags: |


### PR DESCRIPTION
Updates build image tag to the needed Go version