### PR TITLE
Remove some dependecies on k0s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/sirupsen/logrus v1.9.3
 	github.com/weaveworks/footloose v0.0.0-20210208164054-2862489574a3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
+++ b/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	k0stestutil "github.com/k0sproject/k0s/inttest/common"
 	autopilot "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	"github.com/k0sproject/k0smotron/inttest/util"
 
@@ -133,7 +132,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 	}
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
 	// nolint:staticcheck
 	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
@@ -172,7 +171,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 	})
 	s.Require().NoError(err)
 
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 }
 
 func (s *CAPIControlPlaneDockerDownScalingSuite) applyClusterObjects() {

--- a/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
+++ b/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
@@ -30,7 +30,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	k0stestutil "github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0smotron/inttest/util"
 
 	"github.com/stretchr/testify/suite"
@@ -129,13 +128,13 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.Require().NoError(err)
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
 	s.T().Log("waiting for frp server to be ready")
-	s.Require().NoError(k0stestutil.WaitForDeployment(s.ctx, s.client, "docker-test-frps", "default"))
+	s.Require().NoError(util.WaitForDeployment(s.ctx, s.client, "docker-test-frps", "default"))
 
 	s.T().Log("waiting for frp client to be ready")
-	s.Require().NoError(k0stestutil.WaitForDeployment(s.ctx, kmcKC, "frpc", "kube-system"))
+	s.Require().NoError(util.WaitForDeployment(s.ctx, kmcKC, "frpc", "kube-system"))
 
 	s.T().Log("checking connectivity to the child cluster via tunnel")
 
@@ -151,9 +150,9 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 		DoRaw(context.Background())
 	s.Require().NoError(err)
 
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, tunneledKmcKC, "docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, tunneledKmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
-	s.Require().NoError(k0stestutil.WaitForDeployment(s.ctx, tunneledKmcKC, "frpc", "kube-system"))
+	s.Require().NoError(util.WaitForDeployment(s.ctx, tunneledKmcKC, "frpc", "kube-system"))
 }
 
 func GetKMCClientSetWithProxy(ctx context.Context, kc *kubernetes.Clientset, name string, namespace string, port int) (*kubernetes.Clientset, error) {

--- a/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
+++ b/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	k0stestutil "github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0smotron/inttest/util"
 
 	"github.com/stretchr/testify/suite"
@@ -128,13 +127,13 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.Require().NoError(err)
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
 	s.T().Log("waiting for frp server to be ready")
-	s.Require().NoError(k0stestutil.WaitForDeployment(s.ctx, s.client, "docker-test-frps", "default"))
+	s.Require().NoError(util.WaitForDeployment(s.ctx, s.client, "docker-test-frps", "default"))
 
 	s.T().Log("waiting for frp client to be ready")
-	s.Require().NoError(k0stestutil.WaitForDeployment(s.ctx, kmcKC, "frpc", "kube-system"))
+	s.Require().NoError(util.WaitForDeployment(s.ctx, kmcKC, "frpc", "kube-system"))
 
 	s.T().Log("checking connectivity to the child cluster via tunnel")
 
@@ -166,9 +165,9 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.Require().NoError(err)
 
 	s.T().Log("check for node to be ready via tunnel")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, tunneledKmcKC, "docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, tunneledKmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
-	s.Require().NoError(k0stestutil.WaitForDeployment(s.ctx, tunneledKmcKC, "frpc", "kube-system"))
+	s.Require().NoError(util.WaitForDeployment(s.ctx, tunneledKmcKC, "frpc", "kube-system"))
 }
 
 func (s *CAPIControlPlaneDockerSuite) applyClusterObjects() {

--- a/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
+++ b/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	k0stestutil "github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0smotron/inttest/util"
 
 	"github.com/stretchr/testify/suite"
@@ -125,7 +124,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDockerWorker() {
 	s.Require().NoError(err)
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-0", corev1.ConditionTrue))
 }
 
 func (s *CAPIControlPlaneDockerSuite) applyClusterObjects() {

--- a/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	k0stestutil "github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0smotron/inttest/util"
 
 	"github.com/stretchr/testify/suite"
@@ -129,7 +128,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	}
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
 	s.T().Log("verifying cloud-init extras")
 	preStartFile, err := getDockerNodeFile("docker-test-cluster-docker-test-worker-0", "/tmp/pre-start")

--- a/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
+++ b/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
@@ -18,16 +18,15 @@ package capidockerclusterclassk0smotron
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"testing"
+
 	"github.com/k0sproject/k0smotron/inttest/util"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
-	"os/exec"
-	"testing"
-
-	"github.com/k0sproject/k0s/inttest/common"
 )
 
 type CAPIDockerClusterClassK0smotronSuite struct {
@@ -87,7 +86,7 @@ func (s *CAPIDockerClusterClassK0smotronSuite) TestCAPIDocker() {
 
 	// Wait for the cluster to be ready
 	// Wait to see the CP pods ready
-	s.Require().NoError(common.WaitForStatefulSet(s.ctx, s.client, "kmc-docker-test-cluster", "default"))
+	s.Require().NoError(util.WaitForStatefulSet(s.ctx, s.client, "kmc-docker-test-cluster", "default"))
 }
 
 func (s *CAPIDockerClusterClassK0smotronSuite) applyClusterObjects() {

--- a/inttest/capi-docker-machine-template-update/capi_docker_machine_template_update_test.go
+++ b/inttest/capi-docker-machine-template-update/capi_docker_machine_template_update_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	k0stestutil "github.com/k0sproject/k0s/inttest/common"
 	"github.com/k0sproject/k0smotron/inttest/util"
 
 	"github.com/stretchr/testify/suite"
@@ -131,7 +130,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 	}
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
 	s.updateClusterObjects()
 	// nolint:staticcheck
@@ -145,7 +144,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 	})
 	s.Require().NoError(err)
 
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 }
 
 func (s *CAPIControlPlaneDockerDownScalingSuite) applyClusterObjects() {

--- a/inttest/capi-docker-machinedeployment/capi_docker_test.go
+++ b/inttest/capi-docker-machinedeployment/capi_docker_test.go
@@ -33,9 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-
-	"github.com/k0sproject/k0s/inttest/common"
-	k0stestutil "github.com/k0sproject/k0s/inttest/common"
 )
 
 type CAPIDockerSuite struct {
@@ -87,7 +84,7 @@ func (s *CAPIDockerSuite) TestCAPIDocker() {
 
 	// Wait for the cluster to be ready
 	// Wait to see the CP pods ready
-	s.Require().NoError(common.WaitForStatefulSet(s.ctx, s.client, "kmc-docker-md-test", "default"))
+	s.Require().NoError(util.WaitForStatefulSet(s.ctx, s.client, "kmc-docker-md-test", "default"))
 
 	s.T().Log("Starting portforward")
 	fw, err := util.GetPortForwarder(s.restConfig, "kmc-docker-md-test-0", "default", 30443)
@@ -108,7 +105,7 @@ func (s *CAPIDockerSuite) TestCAPIDocker() {
 	s.T().Log("waiting for 2 nodes to be ready")
 	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Minute)
 	defer cancel()
-	err = k0stestutil.Poll(ctx, func(ctx context.Context) (done bool, err error) {
+	err = util.Poll(ctx, func(ctx context.Context) (done bool, err error) {
 		nodes, err := kmcKC.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err

--- a/inttest/capi-docker/capi_docker_test.go
+++ b/inttest/capi-docker/capi_docker_test.go
@@ -19,14 +19,15 @@ package capidocker
 import (
 	"context"
 	"fmt"
-	controlplanev1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/scheme"
 	"os"
 	"os/exec"
 	"testing"
 	"time"
+
+	controlplanev1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/k0sproject/k0smotron/inttest/util"
 	"github.com/stretchr/testify/suite"
@@ -39,9 +40,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/k0sproject/k0s/inttest/common"
-	k0stestutil "github.com/k0sproject/k0s/inttest/common"
 )
 
 type CAPIDockerSuite struct {
@@ -98,7 +96,7 @@ func (s *CAPIDockerSuite) TestCAPIDocker() {
 
 	// Wait for the cluster to be ready
 	// Wait to see the CP pods ready
-	s.Require().NoError(common.WaitForStatefulSet(s.ctx, s.client, "kmc-docker-test", "default"))
+	s.Require().NoError(util.WaitForStatefulSet(s.ctx, s.client, "kmc-docker-test", "default"))
 
 	s.checkControlPlaneStatus(s.ctx, s.restConfig)
 
@@ -120,7 +118,7 @@ func (s *CAPIDockerSuite) TestCAPIDocker() {
 	s.Require().NoError(err)
 
 	s.T().Log("waiting for node to be ready")
-	s.Require().NoError(k0stestutil.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-0", corev1.ConditionTrue))
+	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-0", corev1.ConditionTrue))
 	node, err := kmcKC.CoreV1().Nodes().Get(s.ctx, "docker-test-0", metav1.GetOptions{})
 	s.Require().NoError(err)
 	s.Require().Equal("v1.27.1+k0s", node.Status.NodeInfo.KubeletVersion)

--- a/inttest/util/k0scontext/context.go
+++ b/inttest/util/k0scontext/context.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package k0scontext
+
+import "context"
+
+// keyType is used to create unique keys based on the types of the values stored in a context.
+type keyType[T any] struct{}
+
+// bucket is used to wrap values before storing them in a context.
+type bucket[T any] struct{ inner T }
+
+// Value retrieves the value of type T from the context.
+// If there's no such value, it returns the zero value of type T.
+func Value[T any](ctx context.Context) T {
+	return ValueOrElse[T](ctx, func() (_ T) { return })
+}
+
+// ValueOrElse retrieves the value of type T from the context.
+// If there's no such value, it invokes the fallback function and returns its result.
+func ValueOrElse[T any](ctx context.Context, fallbackFn func() T) T {
+	if val, ok := value[T](ctx); ok {
+		return val.inner
+	}
+
+	return fallbackFn()
+}
+
+// value retrieves a value of type T from the context along with a boolean
+// indicating its presence.
+func value[T any](ctx context.Context) (bucket[T], bool) {
+	var key keyType[T]
+	val, ok := ctx.Value(key).(bucket[T])
+	return val, ok
+}

--- a/inttest/util/k0sutil.go
+++ b/inttest/util/k0sutil.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0smotron/inttest/util/k0scontext"
+	"github.com/k0sproject/k0smotron/inttest/util/watch"
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Poll tries a condition func until it returns true, an error or the specified
+// context is canceled or expired.
+func Poll(ctx context.Context, condition wait.ConditionWithContextFunc) error {
+	return wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, condition)
+}
+
+// LogfFn will be used whenever something needs to be logged.
+type LogfFn func(format string, args ...any)
+
+// Retrieves the LogfFn stored in context, falling back to use testing.T's Logf
+// if the context has a *testing.T or logrus's Infof as a last resort.
+func logfFrom(ctx context.Context) LogfFn {
+	if logf := k0scontext.Value[LogfFn](ctx); logf != nil {
+		return logf
+	}
+	if t := k0scontext.Value[*testing.T](ctx); t != nil {
+		return t.Logf
+	}
+	return logrus.Infof
+}
+
+type LineWriter struct {
+	WriteLine func([]byte)
+	buf       []byte
+}
+
+// Write implements [io.Writer].
+func (s *LineWriter) Write(in []byte) (int, error) {
+	s.buf = append(s.buf, in...)
+	s.logLines()
+	return len(in), nil
+}
+
+// Logs each complete line and discards the used data.
+func (s *LineWriter) logLines() {
+	var off int
+	for {
+		n := bytes.IndexByte(s.buf[off:], '\n')
+		if n < 0 {
+			break
+		}
+
+		s.WriteLine(s.buf[off : off+n])
+		off += n + 1
+	}
+
+	// Move the unprocessed data to the beginning of the buffer and reset the length.
+	if off > 0 {
+		l := copy(s.buf, s.buf[off:])
+		s.buf = s.buf[:l]
+	}
+}
+
+// Logs any remaining data in the buffer that doesn't end with a newline.
+func (s *LineWriter) Flush() {
+	if len(s.buf) > 0 {
+		s.WriteLine(s.buf)
+		// Reset the length and keep the underlying array.
+		s.buf = s.buf[:0]
+	}
+}
+
+func WaitForNodeReadyStatus(ctx context.Context, clients kubernetes.Interface, nodeName string, status corev1.ConditionStatus) error {
+	return watch.Nodes(clients.CoreV1().Nodes()).
+		WithObjectName(nodeName).
+		WithErrorCallback(RetryWatchErrors(logfFrom(ctx))).
+		Until(ctx, func(node *corev1.Node) (done bool, err error) {
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == corev1.NodeReady {
+					if cond.Status == status {
+						return true, nil
+					}
+
+					break
+				}
+			}
+
+			return false, nil
+		})
+}
+
+func RetryWatchErrors(logf LogfFn) watch.ErrorCallback {
+	return func(err error) (time.Duration, error) {
+		if retryDelay, e := watch.IsRetryable(err); e == nil {
+			logf("Encountered transient watch error, retrying in %s: %v", retryDelay, err)
+			return retryDelay, nil
+		}
+
+		retryDelay := 1 * time.Second
+
+		switch {
+		case errors.Is(err, syscall.ECONNRESET):
+			logf("Encountered connection reset while watching, retrying in %s: %v", retryDelay, err)
+			return retryDelay, nil
+
+		case errors.Is(err, syscall.ECONNREFUSED):
+			logf("Encountered connection refused while watching, retrying in %s: %v", retryDelay, err)
+			return retryDelay, nil
+
+		case errors.Is(err, io.EOF):
+			logf("Encountered EOF while watching, retrying in %s: %v", retryDelay, err)
+			return retryDelay, nil
+		}
+
+		return 0, err
+	}
+}
+
+// WaitForDeployment waits for the Deployment with the given name to become
+// available as long as the given context isn't canceled.
+func WaitForDeployment(ctx context.Context, kc *kubernetes.Clientset, name, namespace string) error {
+	return watch.Deployments(kc.AppsV1().Deployments(namespace)).
+		WithObjectName(name).
+		WithErrorCallback(RetryWatchErrors(logrus.Infof)).
+		Until(ctx, func(deployment *appsv1.Deployment) (bool, error) {
+			for _, c := range deployment.Status.Conditions {
+				if c.Type == appsv1.DeploymentAvailable {
+					if c.Status == corev1.ConditionTrue {
+						return true, nil
+					}
+
+					break
+				}
+			}
+
+			return false, nil
+		})
+}
+
+// WaitForStatefulSet waits for the StatefulSet with the given name to have
+// as many ready replicas as defined in the spec.
+func WaitForStatefulSet(ctx context.Context, kc *kubernetes.Clientset, name, namespace string) error {
+	return watch.StatefulSets(kc.AppsV1().StatefulSets(namespace)).
+		WithObjectName(name).
+		WithErrorCallback(RetryWatchErrors(logrus.Infof)).
+		Until(ctx, func(s *appsv1.StatefulSet) (bool, error) {
+			return s.Status.ReadyReplicas == *s.Spec.Replicas, nil
+		})
+}

--- a/inttest/util/k0sutil_test.go
+++ b/inttest/util/k0sutil_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRetryWatchErrors ensures that the ErrorCallback returned by RetryWatchErrors can
+// properly identify known syscall errors.
+func TestRetryWatchErrors_syscalls(t *testing.T) {
+	defaultRetryDelay := 1 * time.Second
+
+	tests := []struct {
+		name          string
+		err           error
+		expectedDelay time.Duration
+		expectedError error
+	}{
+		{name: "ECONNRESET", err: syscall.ECONNRESET, expectedDelay: defaultRetryDelay, expectedError: nil},
+		{name: "ECONNREFUSED", err: syscall.ECONNREFUSED, expectedDelay: defaultRetryDelay, expectedError: nil},
+
+		// The fallthrough case, don't expect retries with this.
+		{name: "ESPIPE", err: syscall.ESPIPE, expectedDelay: 0, expectedError: syscall.ESPIPE},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ecb := RetryWatchErrors(func(format string, args ...any) {})
+			retryDelay, err := ecb(test.err)
+
+			assert.Equal(t, test.expectedDelay, retryDelay)
+			assert.Equal(t, test.expectedError, err)
+		})
+	}
+}

--- a/inttest/util/watch/apps.go
+++ b/inttest/util/watch/apps.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func DaemonSets(client Provider[*appsv1.DaemonSetList]) *Watcher[appsv1.DaemonSet] {
+	return FromClient[*appsv1.DaemonSetList, appsv1.DaemonSet](client)
+}
+
+func Deployments(client Provider[*appsv1.DeploymentList]) *Watcher[appsv1.Deployment] {
+	return FromClient[*appsv1.DeploymentList, appsv1.Deployment](client)
+}
+
+func StatefulSets(client Provider[*appsv1.StatefulSetList]) *Watcher[appsv1.StatefulSet] {
+	return FromClient[*appsv1.StatefulSetList, appsv1.StatefulSet](client)
+}

--- a/inttest/util/watch/core.go
+++ b/inttest/util/watch/core.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Nodes(client Provider[*corev1.NodeList]) *Watcher[corev1.Node] {
+	return FromClient[*corev1.NodeList, corev1.Node](client)
+}

--- a/inttest/util/watch/watcher.go
+++ b/inttest/util/watch/watcher.go
@@ -1,0 +1,398 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// Watcher offers a convenient way of watching Kubernetes resources. An
+// ephemeral alternative to Reflectors and Indexers, useful for one-shot tasks
+// when no caching is required. It performs an initial list of all the resources
+// and then starts watching them. In case the watch needs to be restarted
+// (a.k.a. resource version too old), Watcher will re-list all the resources.
+// The Watcher will restart the watch API call from time to time at the last
+// seen resource version, so that stale HTTP connections won't make the watch go
+// stale, too.
+type Watcher[T any] struct {
+	List  func(ctx context.Context, opts metav1.ListOptions) (resourceVersion string, items []T, err error)
+	Watch func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+
+	includeDeletions bool
+	fieldSelector    string
+	labelSelector    string
+	errorCallback    ErrorCallback
+}
+
+// ErrorCallback is a func that, if specified, will be called by the [Watcher]
+// whenever it encounters some error. Whenever the returned error is nil, the
+// Watcher will wait for the specified duration and retry the last call.
+// Otherwise the Watcher will return the returned error.
+type ErrorCallback = func(error) (retryDelay time.Duration, err error)
+
+// Provider represents the backend for [Watcher].
+// It is compatible with client-go's typed interfaces.
+type Provider[L any] interface {
+	List(ctx context.Context, opts metav1.ListOptions) (L, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+}
+
+type VersionedResource interface {
+	GetResourceVersion() string
+}
+
+// Condition is a func that gets called by [Watcher] for each updated item. The
+// watch will terminate successfully if it returns true, continue if it returns
+// false or terminate with the returned error.
+type Condition[T any] func(item *T) (done bool, err error)
+
+// conditionError indicates that an error originated from a [Condition]. Those
+// errors will never be presented to the error callback, but terminate the watch
+// immediately.
+type conditionError struct{ error }
+
+type startWatch struct {
+	resourceVersion string
+}
+
+// FromClient creates a [Watcher] from the given client-go client. Note that the
+// types L and I need to be connected in a way that L is a pointer type to a
+// struct that has an `Items` field of type []I. This function will panic if
+// this is not the case. Refer to [FromProvider] in order to provide a custom
+// way of obtaining items from the list type.
+func FromClient[L metav1.ListInterface, I any](client Provider[L]) *Watcher[I] {
+	itemsFromList, err := itemsFromList[L, I]()
+	if err != nil {
+		panic(err)
+	}
+	return FromProvider(client, itemsFromList)
+}
+
+// FromProvider creates a [Watcher] from the given [Provider] and the
+// corresponding itemsFromList function.
+func FromProvider[L VersionedResource, I any](provider Provider[L], itemsFromList func(L) []I) *Watcher[I] {
+	return &Watcher[I]{
+		List: func(ctx context.Context, opts metav1.ListOptions) (string, []I, error) {
+			list, err := provider.List(ctx, opts)
+			if err != nil {
+				return "", nil, err
+			}
+			return list.GetResourceVersion(), itemsFromList(list), nil
+		},
+		Watch: provider.Watch,
+
+		fieldSelector: fields.Everything().String(),
+		labelSelector: labels.Everything().String(),
+	}
+}
+
+func itemsFromList[L metav1.ListInterface, I any]() (func(L) []I, error) {
+	// List types from client-go don't provide any methods to get their items.
+	// Hence provide a way to get the items via reflection.
+
+	index, err := func() ([]int, error) {
+		var list L
+		var items []I
+		listType := reflect.TypeOf(list)
+		if listType.Kind() != reflect.Pointer {
+			return nil, fmt.Errorf("not a pointer type: %s", listType)
+		}
+		itemsType := reflect.TypeOf(items)
+		itemsField, ok := listType.Elem().FieldByName("Items")
+		if !ok || itemsField.Type != itemsType {
+			return nil, fmt.Errorf(`expected an "Items" field of type %s in %s`, itemsType, listType)
+		}
+		return itemsField.Index, nil
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	return func(l L) []I {
+		// The compatibility of the types has been checked above.
+		// This will not panic at runtime.
+		return reflect.ValueOf(l).Elem().FieldByIndex(index).Interface().([]I)
+	}, nil
+}
+
+// WithObjectName sets this Watcher's field selector in a way to only match
+// objects with the given name.
+func (w *Watcher[T]) WithObjectName(name string) *Watcher[T] {
+	return w.WithFieldSelector(fields.OneTermEqualSelector(metav1.ObjectNameField, name))
+}
+
+// WithFieldSelector sets the given field selector for this Watcher. The default
+// is to match everything:
+//
+//	watcher.FromClient(...).WithFieldSelector(fields.Everything())
+//
+// Refer to the [concept] for a general introduction to field selectors. To gain
+// an overview of the supported values, have a look at the usages of
+// [k8s.io/apimachinery/pkg/runtime.Scheme.AddFieldLabelConversionFunc] in the
+// [Kubernetes codebase].
+//
+// [concept]: https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+// [Kubernetes codebase]: https://sourcegraph.com/search?q=lang:go+AddFieldLabelConversionFunc(...)+repo:^github\.com/kubernetes/kubernetes%24+-file:_test\.go%24+select:content&patternType=structural
+func (w *Watcher[T]) WithFieldSelector(selector fields.Selector) *Watcher[T] {
+	w.fieldSelector = selector.String()
+	return w
+}
+
+// WithErrorCallback sets this Watcher's error callback. It's invoked every time
+// an error occurs and determines if the watch should continue or terminate:
+//   - The returned error is nil: continue watching
+//   - The returned error is not nil: terminate watch with that error
+//
+// If the error callback is not set or nil, the default behavior is to terminate.
+func (w *Watcher[T]) WithErrorCallback(callback ErrorCallback) *Watcher[T] {
+	w.errorCallback = callback
+	return w
+}
+
+// Until runs a watch until condition returns true. It will error out in case
+// the context gets canceled or the condition returns an error.
+func (w *Watcher[T]) Until(ctx context.Context, condition Condition[T]) error {
+	return retry(ctx, w.errorCallback, func(ctx context.Context) error {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		return w.run(ctx, condition)
+	})
+}
+
+func (w *Watcher[T]) run(ctx context.Context, condition Condition[T]) error {
+	startWatch, err := w.list(ctx, condition)
+	if err != nil {
+		return err
+	}
+
+	for startWatch != nil {
+		startWatch, err = w.watch(ctx, startWatch.resourceVersion, condition)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w *Watcher[T]) list(ctx context.Context, condition Condition[T]) (*startWatch, error) {
+	const maxListDurationSecs = 30
+	ctx, cancel := context.WithTimeout(ctx, (maxListDurationSecs+10)*time.Second)
+	defer cancel()
+	resourceVersion, items, err := w.List(ctx, metav1.ListOptions{
+		FieldSelector:  w.fieldSelector,
+		LabelSelector:  w.labelSelector,
+		TimeoutSeconds: ptr.To(int64(maxListDurationSecs)),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range items {
+		done, err := condition(&items[i])
+		if err != nil {
+			return nil, conditionError{err}
+		}
+		if done {
+			return nil, nil // terminate successfully
+		}
+	}
+
+	if !isResourceVersionValid(resourceVersion) {
+		return nil, fmt.Errorf("list returned invalid resource version: %q", resourceVersion)
+	}
+
+	return &startWatch{resourceVersion}, nil
+}
+
+func (w *Watcher[T]) watch(ctx context.Context, resourceVersion string, condition Condition[T]) (*startWatch, error) {
+	const maxWatchDurationSecs = 120
+	watcher, err := w.Watch(ctx, metav1.ListOptions{
+		ResourceVersion:     resourceVersion,
+		AllowWatchBookmarks: true,
+		FieldSelector:       w.fieldSelector,
+		TimeoutSeconds:      ptr.To(int64(maxWatchDurationSecs)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer watcher.Stop()
+
+	watchTimeout := time.NewTimer((maxWatchDurationSecs + 10) * time.Second)
+	defer watchTimeout.Stop()
+
+	startWatch := &startWatch{resourceVersion}
+	for startWatch != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+
+		case <-watchTimeout.C:
+			return nil, apierrors.NewTimeoutError("server unexpectedly didn't close the watch", 1)
+
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				// The server closed the watch remotely.
+				// This usually happens after maxWatchDurationSecs have passed.
+				return startWatch, nil
+			}
+
+			startWatch, err = w.processWatchEvent(&event, condition)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return nil, nil // terminate successfully
+}
+
+func (w *Watcher[T]) processWatchEvent(event *watch.Event, condition Condition[T]) (*startWatch, error) {
+	switch event.Type {
+	case watch.Added, watch.Modified, watch.Deleted:
+		if w.includeDeletions || event.Type != watch.Deleted {
+			item, ok := any(event.Object).(*T)
+			if !ok {
+				var example T
+				var err error = &apierrors.UnexpectedObjectError{Object: event.Object}
+				return nil, fmt.Errorf("got an event of type %q, expecting an object of type %T: (%T) %w", event.Type, &example, event.Object, err)
+			}
+
+			if done, err := condition(item); err != nil {
+				return nil, conditionError{err}
+			} else if done {
+				return nil, nil // terminate successfully
+			}
+		}
+
+		fallthrough // update resource version
+
+	case watch.Bookmark:
+		nextResourceVersion, err := getResourceVersion(event.Object)
+		if err != nil {
+			return nil, err
+		}
+		return &startWatch{nextResourceVersion}, nil
+
+	case watch.Error:
+		return nil, fmt.Errorf("watch error: %w", apierrors.FromObject(event.Object))
+
+	default:
+		return nil, fmt.Errorf("unexpected watch event (%s): %w", event.Type, apierrors.FromObject(event.Object))
+	}
+}
+
+func retry(ctx context.Context, errorCallback ErrorCallback, runWatch func(context.Context) error) error {
+	for {
+		err := runWatch(ctx)
+		if err == nil {
+			// No error means the user-specified condition returned success.
+			// The watch is done.
+			return nil
+		}
+
+		if err, ok := err.(conditionError); ok {
+			// The user-specified condition returned an error.
+			return err.error
+		}
+
+		if ctx.Err() != nil {
+			// The context has been closed. Good bye.
+			return err
+		}
+
+		if apierrors.IsResourceExpired(err) {
+			// Start over without delay (resource version too old)
+			continue
+		}
+
+		// Ask the error callback about any other errors.
+		if errorCallback != nil {
+			retryDelay, err := errorCallback(err)
+			if err != nil {
+				return err
+			}
+
+			// Retry after some timeout.
+			timer := time.NewTimer(retryDelay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+				continue
+			}
+		}
+
+		return err
+	}
+}
+
+func getResourceVersion(resource runtime.Object) (string, error) {
+	if rv, ok := resource.(VersionedResource); ok {
+		resourceVersion := rv.GetResourceVersion()
+		if !isResourceVersionValid(resourceVersion) {
+			var err error = &apierrors.UnexpectedObjectError{Object: resource}
+			return "", fmt.Errorf("invalid resource version: %w", err)
+		}
+		return resourceVersion, nil
+	}
+
+	var err error = &apierrors.UnexpectedObjectError{Object: resource}
+	return "", fmt.Errorf("failed to get resource version: %w", err)
+}
+
+func isResourceVersionValid(resourceVersion string) bool {
+	// https://github.com/kubernetes/kubernetes/issues/74022
+	switch resourceVersion {
+	case "", "0":
+		return false
+	default:
+		return true
+	}
+}
+
+// IsRetryable checks if the given error might make sense to be retried in the
+// context of watching Kubernetes resources. Returns the retry delay and no
+// error if it's retryable, or the passed in error otherwise.
+func IsRetryable(err error) (time.Duration, error) {
+	// Only consider errors that suggest a client delay ...
+	if delaySecs, ok := apierrors.SuggestsClientDelay(err); ok {
+		// ... and whose reason indicates that retries might make sense.
+		switch apierrors.ReasonForError(err) {
+		case metav1.StatusReasonTooManyRequests,
+			metav1.StatusReasonServerTimeout,
+			metav1.StatusReasonTimeout,
+			metav1.StatusReasonServiceUnavailable:
+			return time.Duration(delaySecs) * time.Second, nil
+		}
+	}
+
+	return 0, err
+}

--- a/inttest/util/watch/watcher_test.go
+++ b/inttest/util/watch/watcher_test.go
@@ -1,0 +1,713 @@
+/*
+Copyright 2024 k0s authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/utils/ptr"
+)
+
+func TestWatcher(t *testing.T) {
+	ctx := func() context.Context {
+		ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+		t.Cleanup(cancel)
+		return ctx
+	}()
+
+	someConfigMap := corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "someConfigMap"}}
+
+	t.Run("Cancelation", func(t *testing.T) {
+		t.Run("ContextInitiallyCanceled", func(t *testing.T) {
+			t.Parallel()
+			provider, underTest := newTestWatcher()
+			provider.nextList.ListMeta.ResourceVersion = t.Name()
+			provider.watch = func(metav1.ListOptions) error {
+				provider.ch = openEventChanWith()
+				provider.watch = forbiddenWatch(t)
+				return nil
+			}
+
+			ctx, cancel := context.WithCancel(context.TODO())
+			cancel()
+
+			err := underTest.
+				WithErrorCallback(forbiddenErrorCallback(t)).
+				Until(ctx, forbiddenCondition(t))
+
+			assert.Same(t, err, context.Canceled)
+			assert.Equal(t, 1, provider.callsToList)
+			assert.Equal(t, 1, provider.callsToWatch)
+			assert.Equal(t, 1, provider.callsToStop)
+		})
+
+		t.Run("InRetryDelay", func(t *testing.T) {
+			t.Parallel()
+
+			provider, underTest := newTestWatcher()
+			provider.nextList.ResourceVersion = t.Name()
+			provider.watch = func(metav1.ListOptions) error { return assert.AnError }
+			var callsToErrorCallback int
+
+			ctx, cancel := context.WithCancel(context.TODO())
+
+			err := underTest.
+				WithErrorCallback(func(err error) (time.Duration, error) {
+					callsToErrorCallback++
+					require.Same(t, assert.AnError, err)
+					cancel()
+					return 24 * time.Hour, nil
+				}).
+				Until(ctx, forbiddenCondition(t))
+
+			assert.Same(t, err, context.Canceled)
+			assert.Equal(t, 1, provider.callsToList)
+			assert.Equal(t, 1, provider.callsToWatch)
+			assert.Equal(t, 1, callsToErrorCallback)
+			assert.Zero(t, provider.callsToStop)
+		})
+	})
+
+	t.Run("InitialListError", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextListErr = assert.AnError
+		var callsToErrorCallback int
+
+		err := underTest.
+			WithErrorCallback(func(err error) (time.Duration, error) {
+				callsToErrorCallback++
+				assert.Same(t, assert.AnError, err)
+				return 0, err
+			}).
+			Until(ctx, forbiddenCondition(t))
+
+		assert.Same(t, assert.AnError, err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, callsToErrorCallback)
+		assert.Zero(t, provider.callsToWatch)
+	})
+
+	t.Run("ListConditionError", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.Items = []corev1.ConfigMap{someConfigMap}
+		var callsToCondition int
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				assert.Zero(t, callsToCondition, "Condition called more than once")
+				callsToCondition++
+
+				return false, assert.AnError
+			})
+
+		assert.Same(t, assert.AnError, err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Zero(t, provider.callsToWatch)
+	})
+
+	t.Run("SuccessAfterInitialList", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.Items = []corev1.ConfigMap{someConfigMap}
+		var callsToCondition int
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				assert.Zero(t, callsToCondition, "Condition called more than once")
+				callsToCondition++
+
+				assert.Equal(t, &someConfigMap, watched)
+				return true, nil
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, callsToCondition)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Zero(t, provider.callsToWatch)
+	})
+
+	t.Run("WatchChannelClosed", func(t *testing.T) {
+		t.Skip("doesn't apply in its current form")
+
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(metav1.ListOptions) error {
+			provider.ch = closedEventChanWith()
+			provider.watch = forbiddenWatch(t)
+			return nil
+		}
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, forbiddenCondition(t))
+
+		assert.ErrorContains(t, err, "result channel closed unexpectedly")
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, provider.callsToWatch)
+		assert.Equal(t, 1, provider.callsToStop)
+	})
+
+	t.Run("BadWatchEventTypes", func(t *testing.T) {
+		t.Parallel()
+
+		injectedErr := apierrors.NewBadRequest("injected")
+
+		for _, test := range []struct {
+			eventType    apiwatch.EventType
+			errorMessage string
+		}{
+			{apiwatch.Error, "watch error"},
+			{apiwatch.EventType("Bogus"), "unexpected watch event (Bogus)"},
+		} {
+			test := test
+			t.Run(string(test.eventType), func(t *testing.T) {
+				t.Parallel()
+				provider, underTest := newTestWatcher()
+				provider.nextList.ListMeta.ResourceVersion = t.Name()
+				provider.watch = func(opts metav1.ListOptions) error {
+					provider.ch = openEventChanWith(apiwatch.Event{
+						Type:   test.eventType,
+						Object: &injectedErr.ErrStatus,
+					})
+					provider.watch = forbiddenWatch(t)
+					return nil
+				}
+				var callsToErrorCallback int
+
+				assertErr := func(err error) {
+					t.Helper()
+					assert.ErrorContains(t, err, test.errorMessage)
+					var statusErr *apierrors.StatusError
+					if assert.ErrorAs(t, err, &statusErr) {
+						assert.Equal(t, injectedErr, statusErr)
+					}
+				}
+
+				err := underTest.
+					WithErrorCallback(func(err error) (time.Duration, error) {
+						callsToErrorCallback++
+						assertErr(err)
+						return 0, err
+					}).
+					Until(ctx, forbiddenCondition(t))
+
+				assertErr(err)
+				assert.Equal(t, 1, provider.callsToList)
+				assert.Equal(t, 1, provider.callsToWatch)
+				assert.Equal(t, 1, provider.callsToStop)
+			})
+		}
+	})
+
+	t.Run("SuccessAfterWatch", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(opts metav1.ListOptions) error {
+			assert.Equal(t, t.Name(), opts.ResourceVersion)
+			assert.True(t, opts.AllowWatchBookmarks)
+			assert.Equal(t, opts.TimeoutSeconds, ptr.To(int64(120)))
+
+			provider.ch = openEventChanWith(
+				apiwatch.Event{
+					Type:   apiwatch.Added,
+					Object: &someConfigMap,
+				})
+			provider.watch = forbiddenWatch(t)
+
+			return nil
+		}
+		var callsToCondition int
+
+		err := underTest.Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+			assert.Equal(t, 1, provider.callsToWatch, "Expected a single call to watch prior to the condition call")
+			assert.Zero(t, callsToCondition, "Condition called more than once")
+			callsToCondition++
+
+			assert.Same(t, &someConfigMap, watched)
+			return true, nil
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, callsToCondition)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, provider.callsToWatch)
+		assert.Equal(t, 1, provider.callsToStop)
+	})
+
+	t.Run("ResourceVersionTooOld", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(metav1.ListOptions) error {
+			provider.ch = openEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Error,
+				Object: &apierrors.NewResourceExpired("injected resource version too old").ErrStatus,
+			})
+
+			provider.watch = func(opts metav1.ListOptions) error {
+				provider.ch = openEventChanWith(apiwatch.Event{
+					Type:   apiwatch.Added,
+					Object: &someConfigMap,
+				})
+				provider.watch = forbiddenWatch(t)
+
+				return nil
+			}
+
+			return nil
+		}
+		var callsToCondition int
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				assert.Equal(t, 2, provider.callsToWatch, "Expected two calls to watch prior to the condition call")
+				assert.Zero(t, callsToCondition, "Condition called more than once")
+				callsToCondition++
+
+				assert.Same(t, &someConfigMap, watched)
+				return true, nil
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, callsToCondition)
+		assert.Equal(t, 2, provider.callsToList)
+		assert.Equal(t, 2, provider.callsToWatch)
+		assert.Equal(t, 2, provider.callsToStop)
+	})
+
+	t.Run("WatchConditionError", func(t *testing.T) {
+		t.Parallel()
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(opts metav1.ListOptions) error {
+			provider.ch = openEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Added,
+				Object: &someConfigMap,
+			})
+			provider.watch = forbiddenWatch(t)
+
+			return nil
+		}
+		var conditionCalled int
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				assert.Equal(t, 1, provider.callsToWatch, "Expected a single call to watch prior to the condition call")
+				assert.Zero(t, conditionCalled, "Condition called more than once")
+				conditionCalled++
+
+				assert.Same(t, &someConfigMap, watched)
+				return false, assert.AnError
+			})
+
+		assert.Same(t, err, assert.AnError)
+		assert.Equal(t, 1, conditionCalled)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, provider.callsToWatch)
+		assert.Equal(t, 1, provider.callsToStop)
+	})
+
+	t.Run("BogusObjectInWatchEvent", func(t *testing.T) {
+		t.Parallel()
+
+		bogusSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "bogusSecret",
+			},
+		}
+
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(opts metav1.ListOptions) error {
+			provider.ch = openEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Added,
+				Object: &bogusSecret,
+			})
+			provider.watch = forbiddenWatch(t)
+
+			return nil
+		}
+		var callsToErrorCallback int
+
+		assertErr := func(err error) {
+			t.Helper()
+			assert.ErrorContains(t, err, `got an event of type "ADDED", expecting an object of type *v1.ConfigMap: `)
+			var wrappedErr *apierrors.UnexpectedObjectError
+			if assert.ErrorAs(t, err, &wrappedErr) {
+				assert.Equal(t, &bogusSecret, wrappedErr.Object)
+			}
+		}
+
+		err := underTest.
+			WithErrorCallback(func(err error) (time.Duration, error) {
+				callsToErrorCallback++
+				assertErr(err)
+				return 0, err
+			}).
+			Until(ctx, forbiddenCondition(t))
+
+		assertErr(err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, provider.callsToWatch)
+		assert.Equal(t, 1, callsToErrorCallback)
+		assert.Equal(t, 1, provider.callsToStop)
+	})
+
+	t.Run("InvalidResourceVersion", func(t *testing.T) {
+		t.Parallel()
+
+		invalidConfigMap := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "0",
+			},
+		}
+
+		t.Run("InList", func(t *testing.T) {
+			t.Parallel()
+			provider, underTest := newTestWatcher()
+			provider.nextList.ListMeta.ResourceVersion = "0"
+			provider.nextList.Items = []corev1.ConfigMap{invalidConfigMap}
+			var callsToErrorCallback int
+			var callsToCondition int
+
+			err := underTest.
+				WithErrorCallback(func(err error) (time.Duration, error) {
+					callsToErrorCallback++
+					assert.ErrorContains(t, err, `list returned invalid resource version: "0"`)
+					return 0, err
+				}).
+				Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+					assert.Zero(t, callsToCondition, "Condition called more than once")
+					callsToCondition++
+
+					assert.Equal(t, &invalidConfigMap, watched)
+					return false, nil
+				})
+
+			assert.ErrorContains(t, err, `list returned invalid resource version: "0"`)
+			assert.Equal(t, 1, callsToCondition)
+			assert.Equal(t, 1, provider.callsToList)
+			assert.Equal(t, 1, callsToErrorCallback)
+			assert.Zero(t, provider.callsToWatch)
+		})
+
+		t.Run("InWatch", func(t *testing.T) {
+			t.Parallel()
+
+			provider, underTest := newTestWatcher()
+			provider.nextList.ListMeta.ResourceVersion = t.Name()
+			provider.watch = func(opts metav1.ListOptions) error {
+				provider.ch = openEventChanWith(apiwatch.Event{
+					Type:   apiwatch.Added,
+					Object: &invalidConfigMap,
+				})
+				provider.watch = forbiddenWatch(t)
+
+				return nil
+			}
+			var callsToErrorCallback int
+			var callsToCondition int
+
+			assertErr := func(err error) {
+				t.Helper()
+				assert.ErrorContains(t, err, `invalid resource version: `)
+				var wrappedErr *apierrors.UnexpectedObjectError
+				if assert.ErrorAs(t, err, &wrappedErr) {
+					assert.Equal(t, &invalidConfigMap, wrappedErr.Object)
+				}
+			}
+
+			err := underTest.
+				WithErrorCallback(func(err error) (time.Duration, error) {
+					callsToErrorCallback++
+					assertErr(err)
+					return 0, err
+				}).
+				Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+					assert.Zero(t, callsToCondition, "Condition called more than once")
+					callsToCondition++
+
+					assert.Same(t, &invalidConfigMap, watched)
+					return false, nil
+				})
+
+			assertErr(err)
+			assert.Equal(t, 1, callsToCondition)
+			assert.Equal(t, 1, provider.callsToList)
+			assert.Equal(t, 1, provider.callsToWatch)
+			assert.Equal(t, 1, callsToErrorCallback)
+			assert.Equal(t, 1, provider.callsToStop)
+		})
+	})
+
+	t.Run("Bookmarking", func(t *testing.T) {
+		t.Parallel()
+
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		var second, third func(opts metav1.ListOptions) error
+		provider.watch = func(opts metav1.ListOptions) error {
+			bookmark := unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"resourceVersion": "the bookmark",
+					},
+				},
+			}
+
+			provider.ch = closedEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Bookmark,
+				Object: &bookmark,
+			})
+			provider.watch = second
+
+			return nil
+		}
+		second = func(opts metav1.ListOptions) error {
+			assert.Equal(t, "the bookmark", opts.ResourceVersion)
+			assert.True(t, opts.AllowWatchBookmarks)
+
+			provider.ch = closedEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Added,
+				Object: &someConfigMap,
+			})
+			provider.watch = third
+
+			return nil
+		}
+		third = func(opts metav1.ListOptions) error {
+			assert.Equal(t, "someConfigMap", opts.ResourceVersion)
+			assert.True(t, opts.AllowWatchBookmarks)
+
+			provider.ch = openEventChanWith(apiwatch.Event{
+				Type:   apiwatch.Modified,
+				Object: &someConfigMap,
+			})
+			provider.watch = forbiddenWatch(t)
+
+			return nil
+		}
+		var callsToCondition int
+
+		err := underTest.
+			WithErrorCallback(forbiddenErrorCallback(t)).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				defer func() { callsToCondition++ }()
+				assert.Same(t, &someConfigMap, watched)
+				switch callsToCondition {
+				case 0:
+					return false, nil
+				default:
+					require.Fail(t, "Unexpected call to condition")
+					fallthrough
+				case 1:
+					return true, nil
+				}
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 3, provider.callsToWatch)
+		assert.Equal(t, 3, provider.callsToStop)
+	})
+
+	t.Run("WatchError", func(t *testing.T) {
+		t.Parallel()
+
+		provider, underTest := newTestWatcher()
+		provider.nextList.ListMeta.ResourceVersion = t.Name()
+		provider.watch = func(metav1.ListOptions) error {
+			provider.watch = forbiddenWatch(t)
+			return assert.AnError
+		}
+		var callsToErrorCallback int
+
+		err := underTest.
+			WithErrorCallback(func(err error) (time.Duration, error) {
+				callsToErrorCallback++
+				assert.Same(t, assert.AnError, err)
+				return 0, err
+			}).
+			Until(ctx, forbiddenCondition(t))
+
+		assert.Same(t, assert.AnError, err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, provider.callsToWatch)
+		assert.Equal(t, 1, callsToErrorCallback)
+		assert.Zero(t, provider.callsToStop)
+	})
+
+	t.Run("ErrorCallbackAllowsRetry", func(t *testing.T) {
+		t.Parallel()
+
+		retryError := errors.New("retry me")
+		provider, underTest := newTestWatcher()
+		provider.nextListErr = retryError
+		var callsToErrorCallback int
+		var callsToCondition int
+
+		err := underTest.
+			WithErrorCallback(func(err error) (retryAfter time.Duration, _ error) {
+				underTest.WithErrorCallback(forbiddenErrorCallback(t))
+				callsToErrorCallback++
+
+				provider.nextList.Items = []corev1.ConfigMap{someConfigMap}
+				provider.nextListErr = nil
+
+				if assert.Equal(t, err, retryError) {
+					return time.Duration(0), nil
+				}
+				return retryAfter, err
+			}).
+			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+				assert.Equal(t, 1, callsToErrorCallback, "Expected a single call to error callback prior to the condition call")
+				assert.Zero(t, callsToCondition, "Condition called more than once")
+				callsToCondition++
+
+				assert.Equal(t, &someConfigMap, watched)
+				return true, nil
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, provider.callsToList)
+		assert.Equal(t, 1, callsToErrorCallback)
+		assert.Equal(t, 1, callsToCondition)
+		assert.Zero(t, provider.callsToWatch)
+	})
+
+	t.Run("ErrorCallbackTransformsErr", func(t *testing.T) {
+		t.Parallel()
+
+		listError := errors.New("list error")
+		transformedError := errors.New("transformed error")
+		provider, underTest := newTestWatcher()
+		provider.nextListErr = listError
+		var callsToErrorCallback int
+
+		err := underTest.
+			WithErrorCallback(func(err error) (retryAfter time.Duration, _ error) {
+				underTest.WithErrorCallback(forbiddenErrorCallback(t))
+				assert.Zero(t, callsToErrorCallback, "error callback called more than once")
+				callsToErrorCallback++
+
+				assert.Same(t, listError, err)
+				return time.Duration(0), transformedError
+			}).
+			Until(ctx, forbiddenCondition(t))
+
+		assert.Same(t, transformedError, err)
+		assert.Equal(t, 1, provider.callsToList)
+		assert.Equal(t, 1, callsToErrorCallback)
+		assert.Zero(t, provider.callsToWatch)
+	})
+}
+
+func forbiddenCondition(t *testing.T) Condition[corev1.ConfigMap] {
+	return func(*corev1.ConfigMap) (bool, error) {
+		require.Fail(t, "Condition shouldn't be called.")
+		return false, nil
+	}
+}
+
+func forbiddenWatch(t *testing.T) func(metav1.ListOptions) error {
+	return func(metav1.ListOptions) error {
+		require.Fail(t, "Watch shouldn't be called.")
+		return nil
+	}
+}
+
+func forbiddenErrorCallback(t *testing.T) ErrorCallback {
+	return func(err error) (time.Duration, error) {
+		require.Fail(t, "ErrorCallback shouldn't be called.", "Error was: %v", err)
+		return 0, nil
+	}
+}
+
+func openEventChanWith(events ...apiwatch.Event) chan apiwatch.Event {
+	ch := make(chan apiwatch.Event, len(events))
+	for _, event := range events {
+		ch <- event
+	}
+	return ch
+}
+
+func closedEventChanWith(events ...apiwatch.Event) chan apiwatch.Event {
+	ch := openEventChanWith(events...)
+	close(ch)
+	return ch
+}
+
+func newTestWatcher() (*mockProvider, *Watcher[corev1.ConfigMap]) {
+	provider := new(mockProvider)
+	return provider, FromClient[*corev1.ConfigMapList, corev1.ConfigMap](provider)
+}
+
+type mockProvider struct {
+	callsToList int
+	nextList    corev1.ConfigMapList
+	nextListErr error
+
+	callsToWatch int
+	watch        func(metav1.ListOptions) error
+	ch           chan apiwatch.Event
+
+	callsToStop int
+}
+
+func (m *mockProvider) List(_ context.Context, _ metav1.ListOptions) (*corev1.ConfigMapList, error) {
+	defer func() { m.callsToList++ }()
+	if m.nextListErr != nil {
+		return nil, m.nextListErr
+	}
+	return &m.nextList, nil
+}
+
+func (m *mockProvider) Watch(_ context.Context, opts metav1.ListOptions) (apiwatch.Interface, error) {
+	defer func() { m.callsToWatch++ }()
+	if err := m.watch(opts); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func (m *mockProvider) ResultChan() <-chan apiwatch.Event {
+	return m.ch
+}
+
+func (m *mockProvider) Stop() {
+	m.callsToStop++
+}


### PR DESCRIPTION
This PR is the first and easiest part of the efforts of #711.
It removes the dependency of github.com/k0sproject/k0s/inttest/common for every test that doesn't rely on it for `common.FootlooseSuite`