### PR TITLE
Fix k0s.yaml config generation

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
@@ -170,7 +170,7 @@ func (r *ClusterReconciler) reconcileDynamicConfig(ctx context.Context, kmc *km.
 		}
 	}
 
-	return util.ReconcileDynamicConfig(ctx, kmc, r.Client, &u)
+	return util.ReconcileDynamicConfig(ctx, kmc, r.Client, u)
 }
 
 func (r *ClusterReconciler) detectExternalAddress(ctx context.Context) (string, error) {

--- a/internal/util/dynamic_config.go
+++ b/internal/util/dynamic_config.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ReconcileDynamicConfig(ctx context.Context, cluster metav1.Object, cli client.Client, u *unstructured.Unstructured) error {
+func ReconcileDynamicConfig(ctx context.Context, cluster metav1.Object, cli client.Client, u unstructured.Unstructured) error {
 	u.SetName("k0s")
 	u.SetNamespace("kube-system")
 
@@ -34,7 +34,7 @@ func ReconcileDynamicConfig(ctx context.Context, cluster metav1.Object, cli clie
 	err = retry.OnError(retry.DefaultBackoff, func(err error) bool {
 		return true
 	}, func() error {
-		return chCS.Patch(ctx, u, client.RawPatch(client.Merge.Type(), b), []client.PatchOption{}...)
+		return chCS.Patch(ctx, &u, client.RawPatch(client.Merge.Type(), b), []client.PatchOption{}...)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to patch k0s config: %w", err)

--- a/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
@@ -130,6 +130,11 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.T().Log("waiting for node to be ready")
 	s.Require().NoError(util.WaitForNodeReadyStatus(s.ctx, kmcKC, "docker-test-worker-0", corev1.ConditionTrue))
 
+	s.T().Log("verifying k0s.yaml")
+	k0sConfig, err := getDockerNodeFile("docker-test-cluster-docker-test-0", "/etc/k0s.yaml")
+	s.Require().NoError(err)
+	s.Require().True(strings.Contains(k0sConfig, "controlPlaneLoadBalancing"))
+
 	s.T().Log("verifying cloud-init extras")
 	preStartFile, err := getDockerNodeFile("docker-test-cluster-docker-test-worker-0", "/tmp/pre-start")
 	s.Require().NoError(err)
@@ -255,7 +260,9 @@ spec:
             anonymous-auth: "true"
         telemetry:
           enabled: false
-    
+        network:
+          controlPlaneLoadBalancing:
+            enabled: false 
     files:
     - path: /tmp/test-file-secret
       contentFrom: 


### PR DESCRIPTION
Currently, dynamic config reconciliation mutates given k0s config, which causes some fields are missing in the static config