### PR TITLE
Fix PVC binding when Cluster PVC name is given

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -408,6 +408,11 @@ func (r *ClusterReconciler) mountSecrets(kmc *km.Cluster, sfs *apps.StatefulSet)
 		},
 	})
 
+	k0sDataVolumeName := kmc.GetVolumeName()
+	if kmc.Spec.Persistence.PersistentVolumeClaim != nil && kmc.Spec.Persistence.PersistentVolumeClaim.Name != "" {
+		k0sDataVolumeName = kmc.Spec.Persistence.PersistentVolumeClaim.Name
+	}
+
 	// We need to copy the certs from the projected volume to the /var/lib/k0s/pki directory
 	// Otherwise k0s will trip over the permissions and RO mounts
 	sfs.Spec.Template.Spec.InitContainers = append(sfs.Spec.Template.Spec.InitContainers, v1.Container{
@@ -424,7 +429,7 @@ func (r *ClusterReconciler) mountSecrets(kmc *km.Cluster, sfs *apps.StatefulSet)
 				MountPath: "/certs-init",
 			},
 			{
-				Name:      kmc.GetVolumeName(),
+				Name:      k0sDataVolumeName,
 				MountPath: "/var/lib/k0s",
 			},
 		},

--- a/inttest/pvc/pvc_test.go
+++ b/inttest/pvc/pvc_test.go
@@ -19,7 +19,6 @@ package pvc
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"strings"
 	"testing"
 	"time"
@@ -30,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -172,6 +172,9 @@ func (s *PVCSuite) createK0smotronCluster(ctx context.Context, kc *kubernetes.Cl
 			"persistence": {
 				"type": "pvc",
 				"persistentVolumeClaim": {
+					"metadata": {
+						"name": "kmc-volume-test"
+					},
 					"spec": {
 						"accessModes": ["ReadWriteOnce"],
 						"storageClassName": "seaweedfs-storage",


### PR DESCRIPTION
fix https://github.com/k0sproject/k0smotron/issues/650#issuecomment-2346707289

When the cluster persistence was of type`pvc` and the cluster name was given by the user, the statefulset related to the k0smotron Cluster could not create the pods because the init container was using the wrong mount name. It was using the name `kmc-<clustername>` instead of the one configured by the user.

### HOW TO REPRO ISSUE 
1. Create a cluster with a PVC name:
```yml
apiVersion: k0smotron.io/v1beta1
kind: Cluster
metadata:
  name: k0smotron-test
spec:
  replicas: 1
  image: k0sproject/k0s
  version: v1.27.1-k0s.0
  service:
    type: NodePort
    apiPort: 30443
    konnectivityPort: 30132
  persistence:
    type: pvc
    persistentVolumeClaim:
      metadata:
        name: my-pvc-test
      spec:
        accessModes:
        - ReadWriteOnce
        storageClassName: standard
        resources: 
          requests: 
            storage: 200Mi
```
2. Check StatefulSet pods are not created because the PVC used by the init container mount is not found.

_After this fix, mount name used in the init container is the one given by the user in the Cluster declaration._
