### PR TITLE
Clean up controlnode if machine related to K0sControlPlane is deleted

### DIFF
--- a/internal/controller/controlplane/helper.go
+++ b/internal/controller/controlplane/helper.go
@@ -195,6 +195,23 @@ func (c *K0sController) markChildControlNodeToLeave(ctx context.Context, name st
 	return nil
 }
 
+func (c *K0sController) deleteControlNode(ctx context.Context, name string, clientset *kubernetes.Clientset) error {
+	if clientset == nil {
+		return nil
+	}
+
+	err := clientset.RESTClient().
+		Delete().
+		AbsPath("/apis/autopilot.k0sproject.io/v1beta2/controlnodes/" + name).
+		Do(ctx).
+		Error()
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
 func (c *K0sController) createAutopilotPlan(ctx context.Context, kcp *cpv1beta1.K0sControlPlane, cluster *clusterv1.Cluster, clientset *kubernetes.Clientset) error {
 	if clientset == nil {
 		return nil

--- a/internal/controller/controlplane/k0s_controlplane_controller.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller.go
@@ -418,6 +418,10 @@ func (c *K0sController) reconcileMachines(ctx context.Context, cluster *clusterv
 			return replicasToReport, fmt.Errorf("error deleting machine from template: %w", err)
 		}
 
+		if err := c.deleteControlNode(ctx, name, kubeClient); err != nil {
+			return replicasToReport, fmt.Errorf("error deleting controlnode: %w", err)
+		}
+
 		logger.Info("Deleted machine", "machine", name, "replicasToReport", replicasToReport)
 		return replicasToReport, nil
 	}


### PR DESCRIPTION
Fix #768 

Follow up PR to https://github.com/k0sproject/k0s/pull/5128. We need to use machine name as `ControlNode` name in order to be able to delete it when applies