### PR TITLE
Fix markdown for CAPI update docs

### DIFF
--- a/docs/update/update-capi-cluster.md
+++ b/docs/update/update-capi-cluster.md
@@ -103,7 +103,6 @@ which involves creating a new machines for control plane and decommissioning the
 
 For the example below, k0smotron will create 3 new machines for the control plane, ensure that the new control plane nodes are online, and then remove the old machines.
 
-```yaml
 
 1. Check the configuration of deployed k0smotron cluster in your repository. For example:
 


### PR DESCRIPTION
Removes excess yaml tag. Currently it looks like this:

<img width="793" alt="Screenshot 2024-11-13 at 10 26 27" src="https://github.com/user-attachments/assets/b3da8bc3-9027-4477-95cc-a219f5a73ab0">
