### PR TITLE
Update vSphere docs & navigation

### DIFF
--- a/docs/capi-vsphere-tmpl-cp-in-vms.yaml
+++ b/docs/capi-vsphere-tmpl-cp-in-vms.yaml
@@ -113,78 +113,6 @@ spec:
     # WA for NLLB (temporary, until k0s team fix it)
     preStartCommands:
       - sed -i 's/"externalAddress":"${CONTROL_PLANE_ENDPOINT_IP}",//' /etc/k0s.yaml
-    files:
-      - content: |
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            creationTimestamp: null
-            name: kube-vip
-            namespace: kube-system
-          spec:
-            containers:
-            - args:
-              - manager
-              env:
-              - name: vip_arp
-                value: "true"
-              - name: port
-                value: "6443"
-              - name: vip_interface
-                value: ${VIP_NETWORK_INTERFACE:=""}
-              - name: vip_cidr
-                value: "32"
-              - name: cp_enable
-                value: "true"
-              - name: cp_namespace
-                value: kube-system
-              - name: vip_ddns
-                value: "false"
-              - name: svc_enable
-                value: "true"
-              - name: svc_leasename
-                value: plndr-svcs-lock
-              - name: svc_election
-                value: "true"
-              - name: vip_leaderelection
-                value: "true"
-              - name: vip_leasename
-                value: plndr-cp-lock
-              - name: vip_leaseduration
-                value: "15"
-              - name: vip_renewdeadline
-                value: "10"
-              - name: vip_retryperiod
-                value: "2"
-              - name: address
-                value: ${CONTROL_PLANE_ENDPOINT_IP}
-              - name: prometheus_server
-                value: :2112
-              image: ghcr.io/kube-vip/kube-vip:v0.6.4
-              imagePullPolicy: IfNotPresent
-              name: kube-vip
-              resources: {}
-              securityContext:
-                capabilities:
-                  add:
-                  - NET_ADMIN
-                  - NET_RAW
-              volumeMounts:
-              - mountPath: /etc/kubernetes/admin.conf
-                name: kubeconfig
-            hostNetwork: true
-            volumes:
-            - hostPath:
-                path: /var/lib/k0s/pki/admin.conf
-              name: kubeconfig
-            hostAliases:
-            - hostnames:
-              - kubernetes
-              ip: 127.0.0.1
-            nodeSelector:
-              node.k0sproject.io/role: control-plane
-        path: /var/lib/k0s/manifests/kubevip/kube-vip.yaml
-        permissions: "0644"
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: ClusterConfig
@@ -197,6 +125,49 @@ spec:
             - ${CONTROL_PLANE_ENDPOINT_IP}
           extraArgs:
             anonymous-auth: "true" 
+        extensions:
+          helm:
+            repositories:
+            - name: kube-vip
+              url: https://kube-vip.github.io/helm-charts
+            charts:
+            - name: kube-vip
+              chart: kube-vip/kube-vip
+              version: 0.6.1
+              namespace: kube-system
+              values: |
+                image:
+                  repository: ghcr.io/kube-vip/kube-vip
+                  pullPolicy: IfNotPresent
+                  tag: "v0.6.4"
+                config:
+                  address: ${CONTROL_PLANE_ENDPOINT_IP}
+                env:
+                  vip_interface: ${VIP_NETWORK_INTERFACE}       # Network interface for VIP
+                  vip_arp: "true"                               # Enable ARP to announce VIP
+                  lb_enable: "true"                             # Enable load balancing
+                  lb_port: "6443"                               # Port for the Kubernetes API
+                  vip_cidr: "32"                                # CIDR for VIP
+                  cp_enable: "true"                             # Enable control-plane mode
+                  svc_enable: "true"                            # Enable service mode
+                  svc_election: "true"                          # Enable service election
+                  vip_leaderelection: "true" 
+                extraArgs:
+                  prometheusHTTPServer: "0.0.0.0:2112"
+                serviceAccount:
+                  create: true
+                  annotations: {}
+                securityContext:
+                  capabilities:
+                    add:
+                      - NET_ADMIN
+                      - NET_RAW
+                nodeSelector:
+                  node.k0sproject.io/role: control-plane
+                tolerations:
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/control-plane
+                    operator: Exists
         network:
           nodeLocalLoadBalancing:
             enabled: true

--- a/docs/capi-vsphere.md
+++ b/docs/capi-vsphere.md
@@ -154,7 +154,7 @@ There are two options for child cluster control plane with k0smotron:
 
 #### Control plane in Pods:
 
-If you want to have child cluster [control plane in a Pods](https://docs.k0smotron.io/stable/capi-controlplane/), use [this template](capi-vsphere-tmpl-cp-in-pods.yaml): 
+If you want to have child cluster [control plane in a Pods](https://docs.k0smotron.io/stable/capi-controlplane/), use the following [template](capi-vsphere-tmpl-cp-in-pods.yaml): 
 
 ```sh
 clusterctl generate cluster my-cluster --control-plane-machine-count 1 --worker-machine-count 1 --from k0scluster-tmpl-cp-in-pods.yaml > my-cluster.yaml
@@ -162,7 +162,7 @@ clusterctl generate cluster my-cluster --control-plane-machine-count 1 --worker-
 
 #### Control plane in VMs:
 
-If you want to have child cluster [control plane in separate VMs](https://docs.k0smotron.io/stable/capi-controlplane-bootstrap/), use [that template](capi-vsphere-tmpl-cp-in-pods.yaml) (CP will consist of 3 controllers):
+If you want to have child cluster [control plane in separate VMs](https://docs.k0smotron.io/stable/capi-controlplane-bootstrap/), use the following [template](capi-vsphere-tmpl-cp-in-vms.yaml) (Control Plane will consist of 3 nodes):
 
 ```sh
 clusterctl generate cluster my-cluster --worker-machine-count 1 --from k0scluster-tmpl-cp-in-vms.yaml > my-cluster.yaml 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,10 +31,10 @@ nav:
       - Examples:
         - Software prerequisites: capi-examples.md
         - AWS (HCP): capi-aws.md
-        - Hetzner Cloud: capi-hetzner.md
-        - OpenStack: capi-openstack.md
-        - Docker: capi-docker.md
-        - KubeVirt: capi-kubevirt.md
+        - Hetzner Cloud (HCP): capi-hetzner.md
+        - OpenStack (HCP): capi-openstack.md
+        - Docker (HCP): capi-docker.md
+        - KubeVirt (HCP): capi-kubevirt.md
         - vSphere: capi-vsphere.md
         - Remote Machine with Teleport: capi-remotemachine-teleport.md
         - Remote Machine with Okta ASA: capi-remotemachine-okta-asa.md


### PR DESCRIPTION
Update of vSphere docs: 
- Link to example with vms was broken
- Update example with helm chart installation of kube-vip
Update to mkdocs navigation: 
- Add type of example (HCP) 