### PR TITLE
Adding forgotten test to go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -159,6 +159,7 @@ jobs:
           - check-capi-controlplane-docker-tunneling
           - check-capi-controlplane-docker-tunneling-proxy
           - check-capi-controlplane-docker-worker
+          - check-capi-docker-machine-change-template
           - check-capi-remote-machine-template-update
           - check-capi-docker-machine-template-update
           - check-capi-docker-machine-template-update-recreate

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -46,6 +46,7 @@ check-capi-controlplane-docker-tunneling: TIMEOUT=10m
 check-capi-remote-machine: TIMEOUT=12m
 check-capi-remote-machine-template: TIMEOUT=12m
 check-capi-remote-machine-template-update: TIMEOUT=10m
+check-capi-docker-machine-change-template: TIMEOUT=15m
 check-capi-docker-machine-template-update: TIMEOUT=12m
 check-capi-docker-machine-template-update-recreate: TIMEOUT=15m
 check-capi-remote-machine-job-provision: TIMEOUT=10m

--- a/inttest/capi-docker-machine-change-template/capi_docker_machine_change_template_test.go
+++ b/inttest/capi-docker-machine-change-template/capi_docker_machine_change_template_test.go
@@ -294,6 +294,9 @@ spec:
   version: v1.31.2+k0s.0
   updateStrategy: Recreate
   k0sConfigSpec:
+    postStartCommands:
+    - sed -i 's/RestartSec=120/RestartSec=1/' /etc/systemd/system/k0scontroller.service
+    - systemctl daemon-reload
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: ClusterConfig


### PR DESCRIPTION
Adding check-capi-docker-machine-change-template to the tests running on CI