### PR TITLE
feat: allow setting annotations all the way down to pods

### DIFF
--- a/api/k0smotron.io/v1beta1/k0smotroncluster_types.go
+++ b/api/k0smotron.io/v1beta1/k0smotroncluster_types.go
@@ -354,6 +354,10 @@ func (kmc *Cluster) GetConfigMapName() string {
 	return kmc.getObjectName("kmc-%s-config")
 }
 
+func (kmc *Cluster) GetConfigMapChecksumAnnotationName() string {
+	return "checksum/configmap"
+}
+
 func (kmc *Cluster) GetServiceName() string {
 	switch kmc.Spec.Service.Type {
 	case v1.ServiceTypeNodePort:

--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -293,6 +293,7 @@ func (c *K0smotronController) reconcile(ctx context.Context, cluster *clusterv1.
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel: cluster.Name,
 			},
+			Annotations: kcp.Annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: cpv1beta1.GroupVersion.String(),

--- a/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/cloudflare/cfssl/scan/crypto/sha256"
 	"github.com/imdario/mergo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,6 +93,17 @@ func (r *ClusterReconciler) generateConfig(kmc *km.Cluster, sans []string) (v1.C
 		return v1.ConfigMap{}, nil, err
 	}
 
+	annotations := kcontrollerutil.AnnotationsForK0smotronCluster(kmc)
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	hash := sha256.New()
+	_, err = hash.Write(b)
+	if err != nil {
+		return v1.ConfigMap{}, nil, fmt.Errorf("failed to hash configmap: %w", err)
+	}
+	annotations[kmc.GetConfigMapChecksumAnnotationName()] = fmt.Sprintf("%x", hash.Sum(nil))
 	cm := v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
@@ -101,7 +113,7 @@ func (r *ClusterReconciler) generateConfig(kmc *km.Cluster, sans []string) (v1.C
 			Name:        kmc.GetConfigMapName(),
 			Namespace:   kmc.Namespace,
 			Labels:      kcontrollerutil.LabelsForK0smotronCluster(kmc),
-			Annotations: kcontrollerutil.AnnotationsForK0smotronCluster(kmc),
+			Annotations: annotations,
 		},
 		Data: map[string]string{
 			"K0SMOTRON_K0S_YAML": string(b),

--- a/internal/controller/k0smotron.io/k0smotroncluster_etcd.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_etcd.go
@@ -267,7 +267,8 @@ func (r *ClusterReconciler) generateEtcdStatefulSet(kmc *km.Cluster, existingSts
 			PodManagementPolicy: apps.ParallelPodManagement,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: kcontrollerutil.AnnotationsForK0smotronCluster(kmc),
 				},
 				Spec: v1.PodSpec{
 					AutomountServiceAccountToken: ptr.To(false),


### PR DESCRIPTION
pull annotations from K0smotronControlPlane all the way through the
k0sCluster to the StatefulSet template

this allows the user to add e.g. `checksum/configmap` on the K0smotronControlPlane to auto-roll the StatefulSet pods

Signed-off-by: Chris Werner Rau <cwrau@cwrau.info>

---

I'm not 100% sure if this is the preferred way, as this uses the "global" `annotationsForCluster` function. But this way there is at least no API change 😅
