### PR TITLE
Removing kube-rbac-proxy

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -25,29 +25,6 @@ spec:
                   values:
                     - linux
       containers:
-      - name: kube-rbac-proxy
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=0"
-        ports:
-        - containerPort: 8443
-          protocol: TCP
-          name: https
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"


### PR DESCRIPTION
Fixes #838 

The image gcr.io/kubebuilder/kube-rbac-proxy is deprecated and will become unavailable.
> You must move as soon as possible, sometime from early 2025, the GCR will go away.