### PR TITLE
Add paused state as condition

### DIFF
--- a/api/controlplane/v1beta1/k0s_types.go
+++ b/api/controlplane/v1beta1/k0s_types.go
@@ -44,6 +44,9 @@ const (
 	// and more specifically it tracks that the system is in between having deleted an unhealthy machine
 	// and recreating its replacement.
 	RemediationInProgressAnnotation = "controlplane.cluster.x-k8s.io/remediation-in-progress"
+
+	// ControlPlanePausedCondition documents the reconciliation of the control plane is paused.
+	ControlPlanePausedCondition clusterv1.ConditionType = "Paused"
 )
 
 // +kubebuilder:object:root=true

--- a/internal/controller/controlplane/k0s_controlplane_controller.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller.go
@@ -47,6 +47,7 @@ import (
 	capiutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/failuredomains"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/secret"
@@ -169,8 +170,10 @@ func (c *K0sController) Reconcile(ctx context.Context, req ctrl.Request) (res ct
 
 	log = log.WithValues("cluster", cluster.Name)
 
+	// TODO: Use paused.EnsurePausedCondition from "sigs.k8s.io/cluster-api/util/paused" when upgrading to v1.9.0.
 	if annotations.IsPaused(cluster, kcp) {
 		log.Info("Reconciliation is paused for this object or owning cluster")
+		conditions.MarkTrue(kcp, cpv1beta1.ControlPlanePausedCondition)
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
from CAPI contract: https://main.cluster-api.sigs.k8s.io/developer/providers/contracts/control-plane#support-for-running-multiple-instances:~:text=If%20implementing%20the%20pause%20behavior%2C%20providers%20SHOULD%20surface%20the%20paused%20status%20of%20an%20object%20using%20the%20Paused%20condition%3A%20Status.Conditions%5BPaused%5D