### PR TITLE
Update HA k0smotron cluster fix & test

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_etcd_test.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_etcd_test.go
@@ -82,7 +82,7 @@ func TestEtcd_generateEtcdStatefulSet(t *testing.T) {
 	for _, tc := range tests {
 		t.Run("", func(t *testing.T) {
 			r := new(ClusterReconciler)
-			sts := r.generateEtcdStatefulSet(tc.cluster, 1)
+			sts := r.generateEtcdStatefulSet(tc.cluster, nil, 1)
 			for _, w := range tc.want {
 				assert.True(t, strings.Contains(sts.Spec.Template.Spec.Containers[0].Args[1], w))
 			}


### PR DESCRIPTION
Fixes #857

We used a wrong etcd data path in the init container's entrypoint script. 
Another issue was that the etcd statefulset update was triggered with the k0s update. 