### PR TITLE
Fix k0smotronControlplane status report for updatedReplicas field

### DIFF
--- a/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
+++ b/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
@@ -113,7 +113,7 @@ func (s *CAPIDockerClusterClassK0smotronSuite) TestCAPIDocker() {
 			kcp.Status.UnavailableReplicas == 0 &&
 			kcp.Status.Ready &&
 			kcp.Status.UpdatedReplicas == 2 &&
-			kcp.Status.Version == "v1.27.2+k0s.0"
+			kcp.Status.Version == "v1.27.2-k0s.0"
 
 		return ready, nil
 	})


### PR DESCRIPTION
a conversion is necessary to compare the versions since the format reported by the `k0s version` command and the one stored in the registry differ