### PR TITLE
Fix autopilot plan version check

### DIFF
--- a/internal/controller/controlplane/helper.go
+++ b/internal/controller/controlplane/helper.go
@@ -379,7 +379,12 @@ func (c *K0sController) createAutopilotPlan(ctx context.Context, kcp *cpv1beta1.
 		if state == "Schedulable" || state == "SchedulableWait" {
 			// it is necessary to check if the current autopilot process corresponds to a previous update by comparing the current
 			// version of the resource with the desired one. If that is the case, the state is not yet ready to proceed with a new plan.
-			version, found, err := unstructured.NestedString(existingPlan.Object, "spec", "commands", "0", "k0supdate", "version")
+			commands, found, err := unstructured.NestedSlice(existingPlan.Object, "spec", "commands")
+			if err != nil || !found || len(commands) == 0 {
+				return fmt.Errorf("error getting current autopilot plan's commands: %w", err)
+			}
+
+			version, found, err := unstructured.NestedString(commands[0].(map[string]interface{}), "k0supdate", "version")
 			if err != nil || !found {
 				return fmt.Errorf("error getting current autopilot plan's version: %w", err)
 			}


### PR DESCRIPTION
Noticed the error in the logs:
```
2025-01-15T12:47:46Z    ERROR   Reconciler error        {"controller": "k0scontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "K0sControlPlane", "K0sControlPlane": {"name":"docker-test","namespace":"default"}, "namespace": "default", "name": "docker-test", "reconcileID": "714690fe-b0ce-4244-91a7-62a44217d99a", "error": "error creating autopilot plan: error getting current autopilot plan's version: .spec.commands.0 accessor error: [map[k0supdate:map[platforms:map[linux-amd64:map[url:https://get.k0sproject.io/v1.30.2+k0s.0/k0s-v1.30.2+k0s.0-amd64] linux-arm:map[url:https://get.k0sproject.io/v1.30.2+k0s.0/k0s-v1.30.2+k0s.0-arm] linux-arm64:map[url:https://get.k0sproject.io/v1.30.2+k0s.0/k0s-v1.30.2+k0s.0-arm64]] targets:map[controllers:map[discovery:map[static:map[nodes:[docker-test-2 docker-test-0 docker-test-1]]] limits:map[concurrent:1]]] version:v1.30.2+k0s.0]]] is of the type []interface {}, expected map[string]interface{}"}
```

`unstructured.NestedString` couldn't work with slices, so change the logic to get the commands first and then get the version field