### PR TITLE
Treat missing machines as unavailable

### DIFF
--- a/internal/controller/controlplane/status.go
+++ b/internal/controller/controlplane/status.go
@@ -106,6 +106,11 @@ func computeStatus(machines collections.Machines, kcp *cpv1beta1.K0sControlPlane
 		}
 	}
 
+	// If some machines are missing, count them as unavailable
+	if int(kcp.Spec.Replicas) > machines.Len() {
+		unavailableReplicas += int(kcp.Spec.Replicas) - machines.Len()
+	}
+
 	kcp.Status.ReadyReplicas = int32(readyReplicas)
 	kcp.Status.UpdatedReplicas = int32(updatedReplicas)
 	kcp.Status.UnavailableReplicas = int32(unavailableReplicas)

--- a/internal/controller/controlplane/status_test.go
+++ b/internal/controller/controlplane/status_test.go
@@ -112,6 +112,41 @@ func Test_computeStatus(t *testing.T) {
 		require.Equal(t, "v1.30.0+k0s.0", kcp.Status.Version)
 	})
 
+	t.Run("test non existent machines are unavailable", func(t *testing.T) {
+		kcp := &cpv1beta1.K0sControlPlane{
+			Spec: cpv1beta1.K0sControlPlaneSpec{
+				Version:  "v1.31.0",
+				Replicas: 3,
+			},
+		}
+		machines := collections.Machines{
+			"machine1": &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					Version: ptr.To[string]("v1.31.0"),
+				},
+				Status: clusterv1.MachineStatus{
+					Phase: string(clusterv1.MachinePhaseRunning),
+				},
+			},
+			"machine2": &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					Version: ptr.To[string]("v1.30.0"),
+				},
+				Status: clusterv1.MachineStatus{
+					Phase: string(clusterv1.MachinePhaseRunning),
+				},
+			},
+		}
+
+		computeStatus(machines, kcp)
+
+		require.Equal(t, int32(2), kcp.Status.Replicas)
+		require.Equal(t, int32(1), kcp.Status.UnavailableReplicas)
+		require.Equal(t, int32(1), kcp.Status.UpdatedReplicas)
+		require.Equal(t, int32(2), kcp.Status.ReadyReplicas)
+		require.Equal(t, "v1.30.0", kcp.Status.Version)
+	})
+
 	t.Run("test some machines are not ready", func(t *testing.T) {
 		kcp := &cpv1beta1.K0sControlPlane{
 			Spec: cpv1beta1.K0sControlPlaneSpec{


### PR DESCRIPTION
Currently, if there are only two machines in a cluster with 3 replicas, K0sControlPlane will report 2 nodes available and 0 unavailable 

With this change it will report the missing one as unavailable