### PR TITLE
Fix kubeconfig regeneration when rotating certificates

### DIFF
--- a/internal/controller/controlplane/k0s_controlplane_controller.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller.go
@@ -226,7 +226,7 @@ func (c *K0sController) reconcileKubeconfig(ctx context.Context, cluster *cluste
 
 			if needsRotation {
 				logger.Info("Rotating kubeconfig secret", "Secret", kc.GetName())
-				if err := c.regenerateKubeconfigSecret(ctx, kc); err != nil {
+				if err := c.regenerateKubeconfigSecret(ctx, kc, cluster.Name); err != nil {
 					logger.Error(err, "Failed to regenerate kubeconfig")
 					return
 				}

--- a/internal/controller/controlplane/util.go
+++ b/internal/controller/controlplane/util.go
@@ -93,14 +93,10 @@ func (c *K0sController) createKubeconfigSecret(ctx context.Context, cfg *api.Con
 	return c.Create(ctx, kcSecret)
 }
 
-func (c *K0sController) regenerateKubeconfigSecret(ctx context.Context, kubeconfigSecret *v1.Secret) error {
-	clusterName, _, err := secret.ParseSecretName(kubeconfigSecret.Name)
-	if err != nil {
-		return fmt.Errorf("failed to parse secret name: %w", err)
-	}
+func (c *K0sController) regenerateKubeconfigSecret(ctx context.Context, kubeconfigSecret *v1.Secret, clusterName string) error {
 	data, ok := kubeconfigSecret.Data[secret.KubeconfigDataName]
 	if !ok {
-		return fmt.Errorf("missing key %q in secret data: %w", secret.KubeconfigDataName, err)
+		return fmt.Errorf("missing key %q in secret data", secret.KubeconfigDataName)
 	}
 
 	oldConfig, err := clientcmd.Load(data)


### PR DESCRIPTION

## Changes
- fix: cluster name cannot be retrieved using `secret.ParseSecretName` for proxied/tunneled kubeconfig because method only takes into account secrets names with the format `<cluster-name>-<purpose-suffix>` and not others like `<cluster-name>-proxied-<purpose-suffix>` or `<cluster-name>-tunneled-<purpose-suffix>`
- added test covering certs rotation logic