### PR TITLE
Fix entrypoint script

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -118,7 +118,7 @@ func (r *ClusterReconciler) generateStatefulSet(kmc *km.Cluster) (apps.StatefulS
 						Name:            "controller",
 						Image:           kmc.Spec.GetImage(),
 						ImagePullPolicy: v1.PullIfNotPresent,
-						Args:            []string{"/k0smotron-entrypoint.sh"},
+						Args:            []string{"/bin/sh", "-c", "/k0smotron-entrypoint.sh"},
 						Ports: []v1.ContainerPort{
 							{
 								Name:          "api",


### PR DESCRIPTION
Noticed weird error running k0smotron cluster on newer k0s version. Haven't found the root cause yet, but this change fixes it
```
/entrypoint.sh: executing /k0smotron-entrypoint.sh
env: can't execute '/k0smotron-entrypoint.sh': Exec format error
```