### PR TITLE
Fix file content extraction for configmap references and add test covering affected logic

### DIFF
--- a/internal/controller/bootstrap/common.go
+++ b/internal/controller/bootstrap/common.go
@@ -1,11 +1,65 @@
 package bootstrap
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strings"
 
+	bootstrapv1 "github.com/k0sproject/k0smotron/api/bootstrap/v1beta1"
+	"github.com/k0sproject/k0smotron/internal/cloudinit"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bsutil "sigs.k8s.io/cluster-api/bootstrap/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var (
+	// errExtractingFileContent represents an error when extracting the file content from a source.
+	errExtractingFileContent = errors.New("failed to get file content from source")
+)
+
+// resolveFiles extracts the content from the given source (ConfigMap or Secret) and returns a list of cloudinit.File containing the extracted data.
+func resolveFiles(ctx context.Context, cli client.Client, cluster *clusterv1.Cluster, filesToResolve []bootstrapv1.File) ([]cloudinit.File, error) {
+	var files []cloudinit.File
+	for _, file := range filesToResolve {
+		if file.ContentFrom != nil {
+			switch {
+			case file.ContentFrom.SecretRef != nil:
+				s := &corev1.Secret{}
+				err := cli.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: file.ContentFrom.SecretRef.Name}, s)
+				if err != nil {
+					return nil, fmt.Errorf("%w: %v", errExtractingFileContent, err)
+				}
+
+				content, ok := s.Data[file.ContentFrom.SecretRef.Key]
+				if !ok {
+					return nil, fmt.Errorf("%w: key not found in secret", errExtractingFileContent)
+				}
+				file.Content = string(content)
+			case file.ContentFrom.ConfigMapRef != nil:
+				cfg := &corev1.ConfigMap{}
+				err := cli.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: file.ContentFrom.ConfigMapRef.Name}, cfg)
+				if err != nil {
+					return nil, fmt.Errorf("%w: %v", errExtractingFileContent, err)
+				}
+
+				content, ok := cfg.Data[file.ContentFrom.ConfigMapRef.Key]
+				if !ok {
+					return nil, fmt.Errorf("%w: key not found in configmap", errExtractingFileContent)
+				}
+				file.Content = content
+			default:
+				return nil, fmt.Errorf("%w: no source specified", errExtractingFileContent)
+			}
+
+			file.ContentFrom = nil
+		}
+
+		files = append(files, file.File)
+	}
+	return files, nil
+}
 
 func mergeExtraArgs(configArgs []string, configOwner *bsutil.ConfigOwner, isWorker bool, useSystemHostname bool) []string {
 	var args []string

--- a/internal/controller/bootstrap/common_test.go
+++ b/internal/controller/bootstrap/common_test.go
@@ -1,0 +1,200 @@
+package bootstrap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/k0sproject/k0smotron/api/bootstrap/v1beta1"
+	"github.com/k0sproject/k0smotron/internal/cloudinit"
+	"github.com/k0sproject/k0smotron/internal/util"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestResolveFiles(t *testing.T) {
+	ns, err := testEnv.CreateNamespace(ctx, "test-resolve-files")
+	require.NoError(t, err)
+
+	cluster := newCluster(ns.Name)
+	require.NoError(t, testEnv.Create(ctx, cluster))
+
+	secretRef := "my-secret-file-content"
+	secretKeyRef := "key"
+	secretContent := "secretcontent"
+	secretFileContent := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretRef,
+			Namespace: ns.Name,
+		},
+		Data: map[string][]byte{
+			secretKeyRef: []byte(secretContent),
+		},
+	}
+	require.NoError(t, testEnv.Create(ctx, secretFileContent))
+
+	configmapRef := "my-configmap-file-content"
+	configmapKeyRef := "key"
+	configmapContent := "configmapcontent"
+	configmapFileContent := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmapRef,
+			Namespace: ns.Name,
+		},
+		Data: map[string]string{
+			configmapKeyRef: configmapContent,
+		},
+	}
+	require.NoError(t, testEnv.Create(ctx, configmapFileContent))
+
+	defer func(do ...client.Object) {
+		require.NoError(t, testEnv.Cleanup(ctx, do...))
+	}(cluster, ns, secretFileContent, configmapFileContent)
+
+	filesToResolve := []v1beta1.File{
+		{
+			ContentFrom: &v1beta1.ContentSource{
+				SecretRef: &v1beta1.ContentSourceRef{
+					Name: secretRef,
+					Key:  secretKeyRef,
+				},
+			},
+		},
+		{
+			ContentFrom: &v1beta1.ContentSource{
+				ConfigMapRef: &v1beta1.ContentSourceRef{
+					Name: configmapRef,
+					Key:  configmapKeyRef,
+				},
+			},
+		},
+	}
+	expectedOutput := []cloudinit.File{
+		{
+			Content: secretContent,
+		},
+		{
+			Content: configmapContent,
+		},
+	}
+	output, err := resolveFiles(ctx, testEnv, cluster, filesToResolve)
+	require.NoError(t, err, errExtractingFileContent)
+	require.Equal(t, expectedOutput, output)
+}
+
+func TestResolveFilesErrorExtractingFileContent(t *testing.T) {
+	ns, err := testEnv.CreateNamespace(ctx, "test-resolve-files-invalid-content-location")
+	require.NoError(t, err)
+
+	cluster := newCluster(ns.Name)
+	require.NoError(t, testEnv.Create(ctx, cluster))
+
+	defer func(do ...client.Object) {
+		require.NoError(t, testEnv.Cleanup(ctx, do...))
+	}(cluster, ns)
+
+	// source references to non existing resources
+
+	filesToResolve := []v1beta1.File{
+		{
+			ContentFrom: &v1beta1.ContentSource{
+				SecretRef: &v1beta1.ContentSourceRef{
+					Name: "test",
+					Key:  "test",
+				},
+			},
+		},
+	}
+	_, err = resolveFiles(ctx, testEnv, cluster, filesToResolve)
+	require.ErrorIs(t, err, errExtractingFileContent)
+
+	filesToResolve = []v1beta1.File{
+		{
+			ContentFrom: &v1beta1.ContentSource{
+				ConfigMapRef: &v1beta1.ContentSourceRef{
+					Name: "test",
+					Key:  "test",
+				},
+			},
+		},
+	}
+	_, err = resolveFiles(ctx, testEnv, cluster, filesToResolve)
+	require.ErrorIs(t, err, errExtractingFileContent)
+
+	// source references to non existing resource key
+
+	secretRef := "my-secret-file-content"
+	secretFileContent := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretRef,
+			Namespace: ns.Name,
+		},
+		Data: map[string][]byte{
+			"realkey": []byte("somecontent"),
+		},
+	}
+	err = testEnv.Create(ctx, secretFileContent)
+	require.NoError(t, err)
+	filesToResolve = []v1beta1.File{
+		{
+			ContentFrom: &v1beta1.ContentSource{
+				SecretRef: &v1beta1.ContentSourceRef{
+					Name: secretRef,
+					Key:  "nonexistingkey",
+				},
+			},
+		},
+	}
+	_, err = resolveFiles(ctx, testEnv, cluster, filesToResolve)
+	require.ErrorIs(t, err, errExtractingFileContent)
+
+	configmapRef := "my-configmap-file-content"
+	configmapFileContent := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmapRef,
+			Namespace: ns.Name,
+		},
+		Data: map[string]string{
+			"realkey": "somecontent",
+		},
+	}
+	err = testEnv.Create(ctx, configmapFileContent)
+	require.NoError(t, err)
+	filesToResolve = []v1beta1.File{
+		{
+			ContentFrom: &v1beta1.ContentSource{
+				ConfigMapRef: &v1beta1.ContentSourceRef{
+					Name: configmapRef,
+					Key:  "nonexistingkey",
+				},
+			},
+		},
+	}
+	_, err = resolveFiles(ctx, testEnv, cluster, filesToResolve)
+	require.ErrorIs(t, err, errExtractingFileContent)
+
+	filesToResolve = []v1beta1.File{
+		{
+			ContentFrom: &v1beta1.ContentSource{},
+		},
+	}
+	_, err = resolveFiles(ctx, testEnv, cluster, filesToResolve)
+	require.ErrorIs(t, err, errExtractingFileContent)
+}
+
+func newCluster(namespace string) *clusterv1.Cluster {
+	clusterName := fmt.Sprintf("kcp-foo-%s", util.RandomString(6))
+
+	return &clusterv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: clusterv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      clusterName,
+		},
+	}
+}

--- a/internal/controller/bootstrap/suite_test.go
+++ b/internal/controller/bootstrap/suite_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"os"
+	"testing"
+
+	"github.com/k0sproject/k0smotron/internal/test/envtest"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	testEnv *envtest.Environment
+	ctx     = ctrl.SetupSignalHandler()
+)
+
+func TestMain(m *testing.M) {
+	testEnv = envtest.Build(ctx)
+	code := m.Run()
+	testEnv.Teardown()
+	os.Exit(code)
+}

--- a/internal/controller/bootstrap/worker_bootstrap_controller.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller.go
@@ -342,47 +342,6 @@ func createDownloadCommands(config *bootstrapv1.K0sWorkerConfig) []string {
 	return []string{"curl -sSfL https://get.k0s.sh | sh"}
 }
 
-func resolveFiles(ctx context.Context, cli client.Client, cluster *clusterv1.Cluster, filesToResolve []bootstrapv1.File) ([]cloudinit.File, error) {
-	var files []cloudinit.File
-	for _, file := range filesToResolve {
-		if file.ContentFrom != nil {
-			switch {
-			case file.ContentFrom.SecretRef != nil:
-				s := &corev1.Secret{}
-				err := cli.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: file.ContentFrom.SecretRef.Name}, s)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get file content from source: %w", err)
-				}
-
-				content, ok := s.Data[file.ContentFrom.SecretRef.Key]
-				if !ok {
-					return nil, fmt.Errorf("failed to get file content from source: key not found in secret")
-				}
-				file.Content = string(content)
-			case file.ContentFrom.ConfigMapRef != nil:
-				cfg := &corev1.ConfigMap{}
-				err := cli.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: file.ContentFrom.ConfigMapRef.Name}, cfg)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get file content from source: %w", err)
-				}
-
-				content, ok := cfg.Data[file.ContentFrom.SecretRef.Key]
-				if !ok {
-					return nil, fmt.Errorf("failed to get file content from source: key not found in configmap")
-				}
-				file.Content = content
-			default:
-				return nil, fmt.Errorf("failed to get file content from source: no source specified")
-			}
-
-			file.ContentFrom = nil
-		}
-
-		files = append(files, file.File)
-	}
-	return files, nil
-}
-
 func (r *Controller) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bootstrapv1.K0sWorkerConfig{}).


### PR DESCRIPTION
## Changes
- fix wrong reference to configmap in `resolveFiles` func
- add integration test 
- moved func to common.go