### PR TITLE
Remove unneeded status update since we now update the status via defe…

### DIFF
--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -172,7 +172,6 @@ func (c *K0smotronController) Reconcile(ctx context.Context, req ctrl.Request) (
 	kcp.Status.ExternalManagedControlPlane = true
 	kcp.Status.Inititalized = true
 	kcp.Status.ControlPlaneReady = true
-	err = c.Status().Update(ctx, kcp)
 
 	return res, err
 


### PR DESCRIPTION
…r func

This puts the controller into update failing "loop" since we now update the status twice from same reconciliation round.