### PR TITLE
Fix k0sConfigSpec required value for K0sControlPlane

### DIFF
--- a/docs/update/update-capi-cluster.md
+++ b/docs/update/update-capi-cluster.md
@@ -42,6 +42,13 @@ where deploying the new control plane is followed by decommissioning of the old 
         kind: DockerCluster
         name: docker-test
     ---
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerCluster
+    metadata:
+      name: docker-test
+      namespace: default
+    spec:
+    ---
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: K0sControlPlane
     metadata:
@@ -78,7 +85,8 @@ where deploying the new control plane is followed by decommissioning of the old 
       namespace: default
     spec:
       template:
-        spec: {}
+        spec:
+          customImage: kindest/node:v1.31.0
     ```
 
 2. Change the k0s version to [the target one](https://docs.k0sproject.io/stable/releases/#k0s-release-and-support-model). For example:
@@ -158,6 +166,13 @@ For the example below, k0smotron will create 3 new machines for the control plan
         kind: DockerCluster
         name: docker-test
     ---
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerCluster
+    metadata:
+      name: docker-test
+      namespace: default
+    spec:
+    ---
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: K0sControlPlane
     metadata:
@@ -194,7 +209,8 @@ For the example below, k0smotron will create 3 new machines for the control plan
       namespace: default
     spec:
       template:
-        spec: {}
+        spec:
+          customImage: kindest/node:v1.31.0
     ```
 
 2. Change the k0s version to [the target one](https://docs.k0sproject.io/stable/releases/#k0s-release-and-support-model). For example:
@@ -245,6 +261,7 @@ the worker nodes. For example, `--enable-worker` flag was used during
 the control plane deployment. The bug is fixed in the latest patch versions of k0s.
 
 To fix this issue:
+
 - Check the current node that is being updated from the `kubectl get plan autopilot -o yaml` output.
 - Manually drain the node.
 - In `Controlnode` object patch the corresponding `k0sproject.io/autopilot-signal-data` annotation:

--- a/docs/update/update-capi-cluster.md
+++ b/docs/update/update-capi-cluster.md
@@ -207,21 +207,21 @@ For the example below, k0smotron will create 3 new machines for the control plan
    spec:
      replicas: 3
      version: v1.31.2+k0s.0 # updated version
-     k0sConfigSpec:
-        args:
-          - --enable-worker
-        k0s:
-          apiVersion: k0s.k0sproject.io/v1beta1
-          kind: ClusterConfig
-          metadata:
-            name: k0s
-          spec:
-            api:
-              extraArgs:
-                anonymous-auth: "true" # anonymous-auth=true is needed for k0s to allow unauthorized health-checks on /healthz
-            telemetry:
-              enabled: true
      updateStrategy: Recreate
+     k0sConfigSpec:
+      args:
+        - --enable-worker
+      k0s:
+        apiVersion: k0s.k0sproject.io/v1beta1
+        kind: ClusterConfig
+        metadata:
+          name: k0s
+        spec:
+          api:
+            extraArgs:
+              anonymous-auth: "true" # anonymous-auth=true is needed for k0s to allow unauthorized health-checks on /healthz
+          telemetry:
+            enabled: true
      machineTemplate:
        infrastructureRef:
          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/docs/update/update-capi-cluster.md
+++ b/docs/update/update-capi-cluster.md
@@ -48,7 +48,7 @@ where deploying the new control plane is followed by decommissioning of the old 
       name: docker-test-cp
     spec:
       replicas: 3
-      version: v1.31.1+k0s.0
+      version: v1.31.2+k0s.0
       updateStrategy: InPlace
       k0sConfigSpec:
         args:
@@ -90,7 +90,7 @@ where deploying the new control plane is followed by decommissioning of the old 
      name: docker-test-cp
    spec:
      replicas: 3
-     version: v1.31.2+k0s.0 # updated version
+     version: v1.31.3+k0s.0 # updated version
      updateStrategy: InPlace
      k0sConfigSpec:
       args:
@@ -164,7 +164,7 @@ For the example below, k0smotron will create 3 new machines for the control plan
       name: docker-test-cp
     spec:
       replicas: 3
-      version: v1.31.1+k0s.0
+      version: v1.31.2+k0s.0
       updateStrategy: Recreate
       k0sConfigSpec:
         args:
@@ -206,7 +206,7 @@ For the example below, k0smotron will create 3 new machines for the control plan
      name: docker-test-cp
    spec:
      replicas: 3
-     version: v1.31.2+k0s.0 # updated version
+     version: v1.31.3+k0s.0 # updated version
      updateStrategy: Recreate
      k0sConfigSpec:
       args:

--- a/docs/update/update-capi-cluster.md
+++ b/docs/update/update-capi-cluster.md
@@ -18,7 +18,7 @@ where deploying the new control plane is followed by decommissioning of the old 
 
 1. Check the configuration of deployed k0smotron cluster in your repository. For example:
 
-    ```yaml 
+    ```yaml
     apiVersion: cluster.x-k8s.io/v1beta1
     kind: Cluster
     metadata:
@@ -48,8 +48,22 @@ where deploying the new control plane is followed by decommissioning of the old 
       name: docker-test-cp
     spec:
       replicas: 3
-      version: v1.28.7+k0s.0
+      version: v1.31.1+k0s.0
       updateStrategy: InPlace
+      k0sConfigSpec:
+        args:
+          - --enable-worker
+        k0s:
+          apiVersion: k0s.k0sproject.io/v1beta1
+          kind: ClusterConfig
+          metadata:
+            name: k0s
+          spec:
+            api:
+              extraArgs:
+                anonymous-auth: "true" # anonymous-auth=true is needed for k0s to allow unauthorized health-checks on /healthz
+            telemetry:
+              enabled: true
       machineTemplate:
         infrastructureRef:
           apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -76,8 +90,22 @@ where deploying the new control plane is followed by decommissioning of the old 
      name: docker-test-cp
    spec:
      replicas: 3
-     version: v1.29.2+k0s.0 # updated version
+     version: v1.31.2+k0s.0 # updated version
      updateStrategy: InPlace
+     k0sConfigSpec:
+      args:
+        - --enable-worker
+      k0s:
+        apiVersion: k0s.k0sproject.io/v1beta1
+        kind: ClusterConfig
+        metadata:
+          name: k0s
+        spec:
+          api:
+            extraArgs:
+              anonymous-auth: "true" # anonymous-auth=true is needed for k0s to allow unauthorized health-checks on /healthz
+          telemetry:
+            enabled: true
      machineTemplate:
        infrastructureRef:
          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -94,19 +122,19 @@ where deploying the new control plane is followed by decommissioning of the old 
 
 ## Updating the control plane using the Cluster API workflow
 
-In case `K0sControlPlane` is created with `spec.updateStrategy=Recreate`, k0smotron uses the Cluster API workflow to update the control plane, 
+In case `K0sControlPlane` is created with `spec.updateStrategy=Recreate`, k0smotron uses the Cluster API workflow to update the control plane,
 which involves creating a new machines for control plane and decommissioning the old ones.
 
 !!! warning
 
-    The `Recreate` update strategy is not supported for k0s clusters running in `--single` mode. 
+    The `Recreate` update strategy is not supported for k0s clusters running in `--single` mode.
 
 For the example below, k0smotron will create 3 new machines for the control plane, ensure that the new control plane nodes are online, and then remove the old machines.
 
 
 1. Check the configuration of deployed k0smotron cluster in your repository. For example:
 
-    ```yaml 
+    ```yaml
     apiVersion: cluster.x-k8s.io/v1beta1
     kind: Cluster
     metadata:
@@ -136,8 +164,22 @@ For the example below, k0smotron will create 3 new machines for the control plan
       name: docker-test-cp
     spec:
       replicas: 3
-      version: v1.28.7+k0s.0
+      version: v1.31.1+k0s.0
       updateStrategy: Recreate
+      k0sConfigSpec:
+        args:
+          - --enable-worker
+        k0s:
+          apiVersion: k0s.k0sproject.io/v1beta1
+          kind: ClusterConfig
+          metadata:
+            name: k0s
+          spec:
+            api:
+              extraArgs:
+                anonymous-auth: "true" # anonymous-auth=true is needed for k0s to allow unauthorized health-checks on /healthz
+            telemetry:
+              enabled: true
       machineTemplate:
         infrastructureRef:
           apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -164,7 +206,7 @@ For the example below, k0smotron will create 3 new machines for the control plan
      name: docker-test-cp
    spec:
      replicas: 3
-     version: v1.29.2+k0s.0 # updated version
+     version: v1.31.2+k0s.0 # updated version
      updateStrategy: Recreate
      machineTemplate:
        infrastructureRef:

--- a/docs/update/update-capi-cluster.md
+++ b/docs/update/update-capi-cluster.md
@@ -207,6 +207,20 @@ For the example below, k0smotron will create 3 new machines for the control plan
    spec:
      replicas: 3
      version: v1.31.2+k0s.0 # updated version
+     k0sConfigSpec:
+        args:
+          - --enable-worker
+        k0s:
+          apiVersion: k0s.k0sproject.io/v1beta1
+          kind: ClusterConfig
+          metadata:
+            name: k0s
+          spec:
+            api:
+              extraArgs:
+                anonymous-auth: "true" # anonymous-auth=true is needed for k0s to allow unauthorized health-checks on /healthz
+            telemetry:
+              enabled: true
      updateStrategy: Recreate
      machineTemplate:
        infrastructureRef:


### PR DESCRIPTION
The K0sControlPlane was missing the required k0sConfigSpec, causing validation issues. This commit adds necessary k0sConfigSpec fields to fix the invalid configuration.