### PR TITLE
Add k0smotron e2e upgrade test for CAPI integration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -185,6 +185,7 @@ jobs:
           - workload-cluster-recreate-upgrade
           - admission-webhook-recreate-strategy-in-single-mode
           - admission-webhook-k0s-not-compatible
+          - k0smotron-upgrade
 
     steps:
       - name: Check out code into the Go module directory

--- a/Makefile.variables
+++ b/Makefile.variables
@@ -3,10 +3,3 @@ CONTROLLER_TOOLS_VERSION ?= v0.14.0
 GO_VERSION ?= 1.22.6
 GOLANGCILINT_VERSION ?= 1.52.2
 CRDOC_VERSION ?= v0.6.2
-
-e2esuite := \
-    controlplane-remediation \
-    workload-cluster-inplace-upgrade \
-    workload-cluster-recreate-upgrade \
-    admission-webhook-recreate-strategy-in-single-mode \
-    admission-webhook-k0s-not-compatible \

--- a/e2e/admission_webhook_test.go
+++ b/e2e/admission_webhook_test.go
@@ -42,13 +42,13 @@ func admissionWebhookRecreateStrategyInSingleModeSpec(t *testing.T) {
 	testName := "admission-webhook-recreate-single-mode"
 
 	// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
-	namespace, _ := util.SetupSpecNamespace(ctx, testName, managementClusterProxy, artifactFolder)
+	namespace, _ := util.SetupSpecNamespace(ctx, testName, bootstrapClusterProxy, artifactFolder)
 
 	clusterName := fmt.Sprintf("%s-%s", testName, capiutil.RandomString(6))
 
 	workloadClusterTemplate := clusterctl.ConfigCluster(ctx, clusterctl.ConfigClusterInput{
 		ClusterctlConfigPath: clusterctlConfigPath,
-		KubeconfigPath:       managementClusterProxy.GetKubeconfigPath(),
+		KubeconfigPath:       bootstrapClusterProxy.GetKubeconfigPath(),
 		// select cluster templates
 		Flavor: "webhook-recreate-in-single-mode",
 
@@ -58,7 +58,7 @@ func admissionWebhookRecreateStrategyInSingleModeSpec(t *testing.T) {
 		ControlPlaneMachineCount: ptr.To[int64](3),
 		// TODO: make infra provider configurable
 		InfrastructureProvider: "docker",
-		LogFolder:              filepath.Join(artifactFolder, "clusters", managementClusterProxy.GetName()),
+		LogFolder:              filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
 		ClusterctlVariables: map[string]string{
 			"CLUSTER_NAME": clusterName,
 			"NAMESPACE":    namespace.Name,
@@ -66,7 +66,7 @@ func admissionWebhookRecreateStrategyInSingleModeSpec(t *testing.T) {
 	})
 	require.NotNil(t, workloadClusterTemplate)
 
-	err := managementClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate)
+	err := bootstrapClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "UpdateStrategy Recreate strategy is not allowed when the cluster is running in single mode")
 }
@@ -75,13 +75,13 @@ func admissionWebhookK0sVersionNotCompatibleSpec(t *testing.T) {
 	testName := "admission-webhook-k0s-not-compatible"
 
 	// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
-	namespace, _ := util.SetupSpecNamespace(ctx, testName, managementClusterProxy, artifactFolder)
+	namespace, _ := util.SetupSpecNamespace(ctx, testName, bootstrapClusterProxy, artifactFolder)
 
 	clusterName := fmt.Sprintf("%s-%s", testName, capiutil.RandomString(6))
 
 	workloadClusterTemplate := clusterctl.ConfigCluster(ctx, clusterctl.ConfigClusterInput{
 		ClusterctlConfigPath: clusterctlConfigPath,
-		KubeconfigPath:       managementClusterProxy.GetKubeconfigPath(),
+		KubeconfigPath:       bootstrapClusterProxy.GetKubeconfigPath(),
 		// select cluster templates
 		Flavor: "webhook-k0s-not-compatible",
 
@@ -91,7 +91,7 @@ func admissionWebhookK0sVersionNotCompatibleSpec(t *testing.T) {
 		ControlPlaneMachineCount: ptr.To[int64](3),
 		// TODO: make infra provider configurable
 		InfrastructureProvider: "docker",
-		LogFolder:              filepath.Join(artifactFolder, "clusters", managementClusterProxy.GetName()),
+		LogFolder:              filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
 		ClusterctlVariables: map[string]string{
 			"CLUSTER_NAME":    clusterName,
 			"NAMESPACE":       namespace.Name,
@@ -100,7 +100,7 @@ func admissionWebhookK0sVersionNotCompatibleSpec(t *testing.T) {
 	})
 	require.NotNil(t, workloadClusterTemplate)
 
-	err := managementClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate)
+	err := bootstrapClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "version v1.31.1+k0s.0 is not compatible with K0sControlPlane, use v1.31.2+")
 }

--- a/e2e/config/docker.yaml
+++ b/e2e/config/docker.yaml
@@ -12,8 +12,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.10.2
-        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.2/core-components.yaml
+      - name: "{go://sigs.k8s.io/cluster-api@v1.10}"
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.10}/core-components.yaml
         type: url
         contract: v1beta1
         files:
@@ -24,8 +24,8 @@ providers:
   - name: docker
     type: InfrastructureProvider
     versions:
-      - name: v1.10.2
-        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.2/infrastructure-components-development.yaml
+      - name: "{go://sigs.k8s.io/cluster-api@v1.10}"
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.10}/infrastructure-components-development.yaml
         type: url
         contract: v1beta1
         files:
@@ -41,7 +41,25 @@ providers:
   - name: k0sproject-k0smotron
     type: ControlPlaneProvider
     versions:
-      - name: v1.5.0
+      - name: "{go://github.com/k0sproject/k0smotron@v1.4}"
+        value: https://github.com/k0sproject/k0smotron/releases/download/{go://github.com/k0sproject/k0smotron@v1.4}/control-plane-components.yaml
+        type: url
+        contract: v1beta1
+        files:
+          - sourcePath: "../../metadata.yaml"
+        replacements:
+          - old: "imagePullPolicy: Always"
+            new: "imagePullPolicy: IfNotPresent"
+      - name: "{go://github.com/k0sproject/k0smotron@v1.5}"
+        value: https://github.com/k0sproject/k0smotron/releases/download/{go://github.com/k0sproject/k0smotron@v1.5}/control-plane-components.yaml
+        type: url
+        contract: v1beta1
+        files:
+          - sourcePath: "../../metadata.yaml"
+        replacements:
+          - old: "imagePullPolicy: Always"
+            new: "imagePullPolicy: IfNotPresent"
+      - name: v1.5.99 # potentially next release. Manifest from source files (development) are used.
         value: ../../config/default
         contract: v1beta1
         files:
@@ -50,11 +68,29 @@ providers:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
           - old: "image: k0s/k0smotron:latest"
-            new: "image: quay.io/k0sproject/k0smotron:latest"
+            new: "image: quay.io/k0sproject/k0smotron:latest" # For local testing, this image needs to be built before run e2e by using `make docker-build`
   - name: k0sproject-k0smotron
     type: BootstrapProvider
     versions:
-      - name: v1.5.0
+      - name: "{go://github.com/k0sproject/k0smotron@v1.4}"
+        value: https://github.com/k0sproject/k0smotron/releases/download/{go://github.com/k0sproject/k0smotron@v1.4}/bootstrap-components.yaml
+        type: url
+        contract: v1beta1
+        files:
+          - sourcePath: "../../metadata.yaml"
+        replacements:
+          - old: "imagePullPolicy: Always"
+            new: "imagePullPolicy: IfNotPresent"
+      - name: "{go://github.com/k0sproject/k0smotron@v1.5}"
+        value: https://github.com/k0sproject/k0smotron/releases/download/{go://github.com/k0sproject/k0smotron@v1.5}/bootstrap-components.yaml
+        type: url
+        contract: v1beta1
+        files:
+          - sourcePath: "../../metadata.yaml"
+        replacements:
+          - old: "imagePullPolicy: Always"
+            new: "imagePullPolicy: IfNotPresent"
+      - name: v1.5.99 # potentially next release. Manifest from source files (development) are used.
         value: ../../config/default
         contract: v1beta1
         files:

--- a/e2e/k0smotron_upgrade_test.go
+++ b/e2e/k0smotron_upgrade_test.go
@@ -1,0 +1,272 @@
+//go:build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/k0smotron/e2e/mothership"
+	e2eutil "github.com/k0sproject/k0smotron/e2e/util"
+	"github.com/k0sproject/k0smotron/internal/util"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
+	capiframework "sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestK0smotronUpgrade(t *testing.T) {
+	setupAndRun(t, k0smotronUpgradeSpec)
+}
+
+// k0smotronMinorVersionsToCheckUpgrades contains the list of k0smotron minor versions to check for upgrades.
+// The first version in the list is the one used to create the management cluster. Consequently, the next versions
+// in the list are the ones used to upgrade the management cluster, ending with the development version from source.
+//
+// Important: This version MUST match the ones set in the e2e config file because that guarantees that the clusterctl
+// local repository contains the required versions of the providers when running the upgrade tests. We should test
+// development version against the latests stable version of k0smotron.
+var k0smotronMinorVersionsToCheckUpgrades = []string{"1.4", "1.5"}
+
+func k0smotronUpgradeSpec(t *testing.T) {
+
+	testName := "k0smotron-upgrade"
+
+	initialK0smotronMinorVersion := k0smotronMinorVersionsToCheckUpgrades[0]
+
+	latestK0smotronStableMinor, _ := getStableReleaseOfMinor(context.Background(), initialK0smotronMinorVersion)
+	k0smotronVersion := []string{fmt.Sprintf("k0sproject-k0smotron:v%s", latestK0smotronStableMinor)}
+
+	managementClusterName := fmt.Sprintf("%s-management-%s", testName, util.RandomString(6))
+	managementClusterLogFolder := filepath.Join(artifactFolder, "clusters", managementClusterName)
+
+	managementClusterProvider := bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
+		Name:               managementClusterName,
+		KubernetesVersion:  e2eConfig.GetVariable(KubernetesVersionManagement),
+		RequiresDockerSock: e2eConfig.HasDockerProvider(),
+		Images:             e2eConfig.Images,
+		IPFamily:           e2eConfig.GetVariable(IPFamily),
+		LogFolder:          filepath.Join(managementClusterLogFolder, "logs-kind"),
+	})
+	require.NotNil(t, managementClusterProvider, "Failed to create cluster to upgrade")
+
+	kubeconfigPath := managementClusterProvider.GetKubeconfigPath()
+	require.FileExists(t, kubeconfigPath, "Failed to get the kubeconfig file for the cluster to upgrade")
+
+	scheme, err := initScheme()
+	require.NoError(t, err, "Failed to init scheme")
+	managementClusterProxy := framework.NewClusterProxy(managementClusterName, kubeconfigPath, scheme)
+	require.NotNil(t, managementClusterProxy, "Failed to create a cluster proxy for the cluster to upgrade")
+
+	fmt.Println("Turning the new cluster into a management cluster with older versions of providers")
+
+	err = mothership.InitAndWatchControllerLogs(watchesCtx, clusterctl.InitManagementClusterAndWatchControllerLogsInput{
+		ClusterProxy:             managementClusterProxy,
+		ClusterctlConfigPath:     clusterctlConfigPath,
+		InfrastructureProviders:  e2eConfig.InfrastructureProviders(),
+		DisableMetricsCollection: true,
+		BootstrapProviders:       k0smotronVersion,
+		ControlPlaneProviders:    k0smotronVersion,
+		LogFolder:                managementClusterLogFolder,
+	}, e2eutil.GetInterval(e2eConfig, "bootstrap", "wait-deployment-available"))
+	require.NoError(t, err, "Failed to init management cluster")
+
+	fmt.Println("THE MANAGEMENT CLUSTER WITH THE OLDER VERSION OF K0SMOTRON PROVIDERS IS UP&RUNNING!")
+
+	fmt.Println(fmt.Sprintf("Creating a namespace for hosting the %s test workload cluster", testName))
+
+	testNamespace, testCancelWatches := framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
+		Creator:   managementClusterProxy.GetClient(),
+		ClientSet: managementClusterProxy.GetClientSet(),
+		Name:      testName,
+		LogFolder: filepath.Join(artifactFolder, "clusters", "bootstrap"),
+	})
+
+	fmt.Println("Creating a test workload cluster")
+
+	workloadClusterName := fmt.Sprintf("%s-workload-%s", testName, util.RandomString(6))
+	workloadClusterNamespace := testNamespace.Name
+
+	fmt.Println("Getting the cluster template yaml")
+	workloadClusterTemplate := clusterctl.ConfigCluster(ctx, clusterctl.ConfigClusterInput{
+		ClusterctlConfigPath: clusterctlConfigPath,
+		KubeconfigPath:       managementClusterProxy.GetKubeconfigPath(),
+		// no flavor specified, so it will use the default one "cluster-template"
+		Flavor: "",
+
+		Namespace:                workloadClusterNamespace,
+		ClusterName:              workloadClusterName,
+		KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
+		ControlPlaneMachineCount: ptr.To[int64](1),
+		// TODO: make infra provider configurable
+		InfrastructureProvider: "docker",
+		LogFolder:              filepath.Join(artifactFolder, "clusters", managementClusterProxy.GetName()),
+		ClusterctlVariables: map[string]string{
+			"CLUSTER_NAME":    workloadClusterName,
+			"NAMESPACE":       workloadClusterNamespace,
+			"UPDATE_STRATEGY": "InPlace",
+		},
+	})
+	require.NotNil(t, workloadClusterTemplate)
+
+	require.Eventually(t, func() bool {
+		return managementClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate) == nil
+	}, 10*time.Second, 1*time.Second, "Failed to apply the cluster template")
+
+	cluster, err := e2eutil.DiscoveryAndWaitForCluster(ctx, capiframework.DiscoveryAndWaitForClusterInput{
+		Getter:    managementClusterProxy.GetClient(),
+		Namespace: workloadClusterNamespace,
+		Name:      workloadClusterName,
+	}, e2eutil.GetInterval(e2eConfig, testName, "wait-cluster"))
+	require.NoError(t, err)
+
+	defer func() {
+		e2eutil.DumpSpecResourcesAndCleanup(
+			ctx,
+			testName,
+			managementClusterProxy,
+			artifactFolder,
+			testNamespace,
+			cancelWatches,
+			cluster,
+			e2eutil.GetInterval(e2eConfig, testName, "wait-delete-cluster"),
+			skipCleanup,
+		)
+
+		testCancelWatches()
+
+		if !skipCleanup {
+			managementClusterProxy.Dispose(ctx)
+			managementClusterProvider.Dispose(ctx)
+		}
+	}()
+
+	controlPlane, err := e2eutil.DiscoveryAndWaitForControlPlaneInitialized(ctx, capiframework.DiscoveryAndWaitForControlPlaneInitializedInput{
+		Lister:  managementClusterProxy.GetClient(),
+		Cluster: cluster,
+	}, e2eutil.GetInterval(e2eConfig, testName, "wait-controllers"))
+	require.NoError(t, err)
+	err = e2eutil.WaitForControlPlaneToBeReady(ctx, managementClusterProxy.GetClient(), controlPlane, e2eutil.GetInterval(e2eConfig, testName, "wait-kube-proxy-upgrade"))
+	require.NoError(t, err)
+
+	for _, minor := range k0smotronMinorVersionsToCheckUpgrades[1:] {
+
+		latestK0smotronStableMinor, _ := getStableReleaseOfMinor(context.Background(), minor)
+		k0smotronVersion := []string{fmt.Sprintf("k0sproject-k0smotron:v%s", latestK0smotronStableMinor)}
+
+		fmt.Println(fmt.Sprintf("Upgrading the management cluster to k0smotron %s", latestK0smotronStableMinor))
+
+		mothership.UpgradeManagementClusterAndWait(ctx, clusterctl.UpgradeManagementClusterAndWaitInput{
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			ClusterProxy:          managementClusterProxy,
+			BootstrapProviders:    k0smotronVersion,
+			ControlPlaneProviders: k0smotronVersion,
+			LogFolder:             managementClusterLogFolder,
+		}, e2eutil.GetInterval(e2eConfig, "bootstrap", "wait-deployment-available"))
+
+		controlPlane, err := e2eutil.DiscoveryAndWaitForControlPlaneInitialized(ctx, capiframework.DiscoveryAndWaitForControlPlaneInitializedInput{
+			Lister:  managementClusterProxy.GetClient(),
+			Cluster: cluster,
+		}, e2eutil.GetInterval(e2eConfig, testName, "wait-controllers"))
+		require.NoError(t, err)
+		err = e2eutil.WaitForControlPlaneToBeReady(ctx, managementClusterProxy.GetClient(), controlPlane, e2eutil.GetInterval(e2eConfig, testName, "wait-kube-proxy-upgrade"))
+		require.NoError(t, err)
+
+		fmt.Println(fmt.Sprintf("THE MANAGEMENT CLUSTER WITH '%s' VERSION OF K0SMOTRON PROVIDERS WORKS!", latestK0smotronStableMinor))
+	}
+
+	// Get the workloadCluster before the management cluster is upgraded with development version to make sure that the upgrade did not trigger
+	// any unexpected rollouts.
+	preUpgradeMachineList := &clusterv1.MachineList{}
+	err = managementClusterProxy.GetClient().List(
+		ctx,
+		preUpgradeMachineList,
+		client.InNamespace(workloadClusterNamespace),
+		client.MatchingLabels{clusterv1.ClusterNameLabel: workloadClusterName},
+	)
+	require.NoError(t, err)
+
+	fmt.Println("Upgrading the management cluster to development version of k0smotron")
+	// We apply development version of the providers to the management cluster.
+	mothership.UpgradeManagementClusterAndWait(ctx, clusterctl.UpgradeManagementClusterAndWaitInput{
+		ClusterctlConfigPath: clusterctlConfigPath,
+		ClusterProxy:         managementClusterProxy,
+		// TODO: make contract configurable
+		Contract:  clusterv1.GroupVersion.Version,
+		LogFolder: managementClusterLogFolder,
+	}, e2eutil.GetInterval(e2eConfig, "bootstrap", "wait-deployment-available"))
+
+	// Wait a few minutes for any unexpected change in the development version to be applied in the workload cluster.
+	time.Sleep(3 * time.Minute)
+
+	controlPlane, err = e2eutil.DiscoveryAndWaitForControlPlaneInitialized(ctx, capiframework.DiscoveryAndWaitForControlPlaneInitializedInput{
+		Lister:  managementClusterProxy.GetClient(),
+		Cluster: cluster,
+	}, e2eutil.GetInterval(e2eConfig, testName, "wait-controllers"))
+	require.NoError(t, err)
+	err = e2eutil.WaitForControlPlaneToBeReady(ctx, managementClusterProxy.GetClient(), controlPlane, e2eutil.GetInterval(e2eConfig, testName, "wait-kube-proxy-upgrade"))
+	require.NoError(t, err)
+
+	postUpgradeMachineList := &clusterv1.MachineList{}
+	err = managementClusterProxy.GetClient().List(
+		ctx,
+		postUpgradeMachineList,
+		client.InNamespace(workloadClusterNamespace),
+		client.MatchingLabels{clusterv1.ClusterNameLabel: workloadClusterName},
+	)
+	require.NoError(t, err)
+
+	require.True(t, validateMachineRollout(preUpgradeMachineList, postUpgradeMachineList), "The machines in the workload cluster have been rolled out unexpectedly")
+
+	fmt.Println("UPGRADE TO DEVELOPMENT VERSION OF K0SMOTRON WORKED AS EXPECTED!")
+}
+
+// validateMachineRollout checks if the machines in the workload cluster have been rolled out correctly.
+// It compares the pre-upgrade and post-upgrade machine lists to ensure that the number of machines is the same
+// and that the machines have not been rolled out unexpectedly.
+//
+// TODO: Add more checks to ensure that the machines have not been rolled out unexpectedly like compare name. Actually, we
+// don't care about the machine names because there are pending issues to solve to change the machine naming strategy.
+// https://github.com/k0sproject/k0smotron/issues/1022.
+func validateMachineRollout(preMachineList, postMachineList *clusterv1.MachineList) bool {
+	if preMachineList == nil && postMachineList == nil {
+		return true
+	}
+	if preMachineList == nil || postMachineList == nil {
+		return false
+	}
+
+	if len(preMachineList.Items) != len(postMachineList.Items) {
+		return false
+	}
+
+	return true
+}
+
+func getStableReleaseOfMinor(ctx context.Context, minorRelease string) (string, error) {
+	releaseMarker := fmt.Sprintf("go://github.com/k0sproject/k0smotron@v%s", minorRelease)
+	return clusterctl.ResolveRelease(ctx, releaseMarker)
+}

--- a/e2e/mothership/upgrade.go
+++ b/e2e/mothership/upgrade.go
@@ -1,0 +1,85 @@
+//go:build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mothership
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/k0sproject/k0smotron/e2e/util"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+)
+
+// UpgradeManagementClusterAndWait upgrades providers in a management cluster using clusterctl, and waits for the cluster to be ready.
+func UpgradeManagementClusterAndWait(ctx context.Context, input clusterctl.UpgradeManagementClusterAndWaitInput, interval util.Interval) error {
+	upgradeInput := clusterctl.UpgradeInput{
+		ClusterctlConfigPath:      input.ClusterctlConfigPath,
+		ClusterctlVariables:       input.ClusterctlVariables,
+		ClusterName:               input.ClusterProxy.GetName(),
+		KubeconfigPath:            input.ClusterProxy.GetKubeconfigPath(),
+		Contract:                  input.Contract,
+		CoreProvider:              input.CoreProvider,
+		BootstrapProviders:        input.BootstrapProviders,
+		ControlPlaneProviders:     input.ControlPlaneProviders,
+		InfrastructureProviders:   input.InfrastructureProviders,
+		IPAMProviders:             input.IPAMProviders,
+		RuntimeExtensionProviders: input.RuntimeExtensionProviders,
+		AddonProviders:            input.AddonProviders,
+		LogFolder:                 input.LogFolder,
+	}
+
+	client := input.ClusterProxy.GetClient()
+
+	clusterctl.Upgrade(ctx, upgradeInput)
+
+	fmt.Println("Waiting for provider controllers to be running")
+	controllersDeployments := framework.GetControllerDeployments(ctx, framework.GetControllerDeploymentsInput{
+		Lister: client,
+		// This namespace has been dropped in v0.4.x.
+		// We have to exclude this namespace here as after an upgrade from v0.3x there won't
+		// be a controller in this namespace anymore and if we wait for it to come up the test would fail.
+		// Note: We can drop this as soon as we don't have a test upgrading from v0.3.x anymore.
+		ExcludeNamespaces: []string{"capi-webhook-system"},
+	})
+	if len(controllersDeployments) == 0 {
+		return errors.New("the list of controller deployments should not be empty")
+	}
+
+	for _, deployment := range controllersDeployments {
+		err := util.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+			Getter:     client,
+			Deployment: deployment,
+		}, interval)
+		if err != nil {
+			return err
+		}
+
+		framework.WatchPodMetrics(ctx, framework.WatchPodMetricsInput{
+			GetLister:   client,
+			ClientSet:   input.ClusterProxy.GetClientSet(),
+			Deployment:  deployment,
+			MetricsPath: filepath.Join(input.LogFolder, "metrics", deployment.GetNamespace()),
+		})
+	}
+
+	return nil
+}

--- a/e2e/util/deployments.go
+++ b/e2e/util/deployments.go
@@ -34,7 +34,7 @@ import (
 // WaitForDeploymentsAvailable waits until the Deployment has status.Available = True, that signals that
 // all the desired replicas are in place.
 func WaitForDeploymentsAvailable(ctx context.Context, input framework.WaitForDeploymentsAvailableInput, interval Interval) error {
-	fmt.Printf("Waiting for deployment %s to be available", klog.KObj(input.Deployment))
+	fmt.Printf("Waiting for deployment %s to be available\n", klog.KObj(input.Deployment))
 	deployment := &appsv1.Deployment{}
 	err := wait.PollUntilContextTimeout(ctx, interval.tick, interval.timeout, true, func(ctx context.Context) (done bool, err error) {
 		key := client.ObjectKey{

--- a/e2e/workload_cluster_inplace_upgrade_test.go
+++ b/e2e/workload_cluster_inplace_upgrade_test.go
@@ -51,13 +51,13 @@ func workloadClusterInplaceUpgradeSpec(t *testing.T) {
 	testName := "workload-inplace-upgrade"
 
 	// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
-	namespace, _ := util.SetupSpecNamespace(ctx, testName, managementClusterProxy, artifactFolder)
+	namespace, _ := util.SetupSpecNamespace(ctx, testName, bootstrapClusterProxy, artifactFolder)
 
 	clusterName := fmt.Sprintf("%s-%s", testName, capiutil.RandomString(6))
 
 	workloadClusterTemplate := clusterctl.ConfigCluster(ctx, clusterctl.ConfigClusterInput{
 		ClusterctlConfigPath: clusterctlConfigPath,
-		KubeconfigPath:       managementClusterProxy.GetKubeconfigPath(),
+		KubeconfigPath:       bootstrapClusterProxy.GetKubeconfigPath(),
 		// no flavor specified, so it will use the default one "cluster-template"
 		Flavor: "",
 
@@ -67,7 +67,7 @@ func workloadClusterInplaceUpgradeSpec(t *testing.T) {
 		ControlPlaneMachineCount: ptr.To[int64](3),
 		// TODO: make infra provider configurable
 		InfrastructureProvider: "docker",
-		LogFolder:              filepath.Join(artifactFolder, "clusters", managementClusterProxy.GetName()),
+		LogFolder:              filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
 		ClusterctlVariables: map[string]string{
 			"CLUSTER_NAME":    clusterName,
 			"NAMESPACE":       namespace.Name,
@@ -77,11 +77,11 @@ func workloadClusterInplaceUpgradeSpec(t *testing.T) {
 	require.NotNil(t, workloadClusterTemplate)
 
 	require.Eventually(t, func() bool {
-		return managementClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate) == nil
+		return bootstrapClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate) == nil
 	}, 10*time.Second, 1*time.Second, "Failed to apply the cluster template")
 
 	cluster, err := util.DiscoveryAndWaitForCluster(ctx, capiframework.DiscoveryAndWaitForClusterInput{
-		Getter:    managementClusterProxy.GetClient(),
+		Getter:    bootstrapClusterProxy.GetClient(),
 		Namespace: namespace.Name,
 		Name:      clusterName,
 	}, util.GetInterval(e2eConfig, testName, "wait-cluster"))
@@ -91,7 +91,7 @@ func workloadClusterInplaceUpgradeSpec(t *testing.T) {
 		util.DumpSpecResourcesAndCleanup(
 			ctx,
 			testName,
-			managementClusterProxy,
+			bootstrapClusterProxy,
 			artifactFolder,
 			namespace,
 			cancelWatches,
@@ -102,17 +102,17 @@ func workloadClusterInplaceUpgradeSpec(t *testing.T) {
 	}()
 
 	controlPlane, err := util.DiscoveryAndWaitForControlPlaneInitialized(ctx, capiframework.DiscoveryAndWaitForControlPlaneInitializedInput{
-		Lister:  managementClusterProxy.GetClient(),
+		Lister:  bootstrapClusterProxy.GetClient(),
 		Cluster: cluster,
 	}, util.GetInterval(e2eConfig, testName, "wait-controllers"))
 	require.NoError(t, err)
 	// For Inplace upgrades we need to wait for the controlplane to have all the replicas ready before upgrading it again.
-	err = util.WaitForControlPlaneToBeReady(ctx, managementClusterProxy.GetClient(), controlPlane, util.GetInterval(e2eConfig, testName, "wait-kube-proxy-upgrade"))
+	err = util.WaitForControlPlaneToBeReady(ctx, bootstrapClusterProxy.GetClient(), controlPlane, util.GetInterval(e2eConfig, testName, "wait-kube-proxy-upgrade"))
 	require.NoError(t, err)
 
 	fmt.Println("Upgrading the Kubernetes control-plane version")
 	err = util.UpgradeControlPlaneAndWaitForReadyUpgrade(ctx, util.UpgradeControlPlaneAndWaitForUpgradeInput{
-		ClusterProxy:                     managementClusterProxy,
+		ClusterProxy:                     bootstrapClusterProxy,
 		Cluster:                          cluster,
 		ControlPlane:                     controlPlane,
 		KubernetesUpgradeVersion:         e2eConfig.GetVariable(KubernetesVersionFirstUpgradeTo),
@@ -123,7 +123,7 @@ func workloadClusterInplaceUpgradeSpec(t *testing.T) {
 
 	fmt.Println("Upgrading the Kubernetes control-plane version again")
 	err = util.UpgradeControlPlaneAndWaitForReadyUpgrade(ctx, util.UpgradeControlPlaneAndWaitForUpgradeInput{
-		ClusterProxy:                     managementClusterProxy,
+		ClusterProxy:                     bootstrapClusterProxy,
 		Cluster:                          cluster,
 		ControlPlane:                     controlPlane,
 		KubernetesUpgradeVersion:         e2eConfig.GetVariable(KubernetesVersionSecondUpgradeTo),


### PR DESCRIPTION
e2e test for k0smotron upgrades. It is based on the case of updating the k0smotron provider using clusterctl (`clusterctl upgrade apply ...`). The test adds the latest k0smotron minors and upgrades to the development version, verifying that the deployed cluster is stable.

fix #1012 