### PR TITLE
fix: correct error variable check in k0smotron controlplane controller

### DIFF
--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -140,8 +140,8 @@ func (c *K0smotronController) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		derr = clusterPatchHelper.Patch(ctx, cluster)
-		if err != nil {
-			log.Error(err, "Failed to update Cluster endpoint")
+		if derr != nil {
+			log.Error(derr, "Failed to update Cluster endpoint")
 			err = kerrors.NewAggregate([]error{err, derr})
 		}
 	}()


### PR DESCRIPTION
Fix incorrect error variable check where 'err' was being checked instead of 'derr' after clusterPatchHelper.Patch() call. This could have caused patch errors to be silently ignored.

- Check 'derr' instead of 'err' in the if condition
- Log 'derr' instead of 'err' in the error message