### PR TITLE
fix: Resolve K0smotronControlPlane reconciliation loop caused by Etcd resources initialization

### DIFF
--- a/inttest/capi-docker/capi_docker_test.go
+++ b/inttest/capi-docker/capi_docker_test.go
@@ -268,6 +268,8 @@ spec:
       type: sa
     - name: docker-test-etcd
       type: etcd
+  etcd:
+    autoDeletePVCs: true
   persistence:
     type: pvc
     persistentVolumeClaim:


### PR DESCRIPTION
## Summary

Fixes #1047

This PR resolves a critical regression introduced in v1.5.3 where K0smotronControlPlane enters an infinite reconciliation loop when the `etcd` field is partially configured without the `resources` field.

## Problem

When users configure K0smotronControlPlane with partial etcd settings (e.g., only `autoDeletePVCs` or `image`), the controller gets stuck in a reconciliation loop:

- `.status.ready` never becomes `true`
- The k0smotron Cluster spec is repeatedly updated

**Live reproduction**: https://github.com/k0sproject/k0smotron/actions/runs/15410066553/job/43360285044?pr=1046

## Root Cause

The issue stems from inconsistent initialization of `Etcd.Resources`:

1. The kubebuilder default for `Etcd` was missing the `resources` field:
   ```go
   //+kubebuilder:default={"image":"...","persistence":{}}  // No resources!
   ```

2. This caused `Etcd.Resources` to be initialized differently:
   - Sometimes as `nil`
   - Sometimes as empty struct `{}`

3. The `isClusterSpecEqual` function using `reflect.DeepEqual` treats these as different, causing endless updates

## Solution

### 1. Fix the root cause (commit 1)
Added `"resources":{}` to the kubebuilder default:
```diff
-//+kubebuilder:default={"image":"quay.io/k0sproject/etcd:v3.5.13","persistence":{}}
+//+kubebuilder:default={"image":"quay.io/k0sproject/etcd:v3.5.13","persistence":{},"resources":{}}
```

### 2. Prevent regression (commit 2)
Enhanced the test to cover partial etcd configuration:
```yaml
etcd:
  autoDeletePVCs: true  # Partial config without resources
```

## Verification

- ✅ K0smotronControlPlane reconciles successfully
- ✅ `.status.ready` becomes `true` when cluster is ready
- ✅ No more spec comparison loops in controller logs
- ✅ Test now covers the problematic scenario

## Impact

- **Fixes regression**: Restores functionality broken since v1.5.3
- **Backward compatible**: Empty resources struct equals no resource constraints
- **Common use case**: Partial etcd configuration is a typical pattern
