### PR TITLE
Add retry for all download operations for cloud-init

### DIFF
--- a/internal/controller/bootstrap/worker_bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller_test.go
@@ -96,59 +96,6 @@ func Test_createInstallCmd(t *testing.T) {
 	}
 }
 
-func Test_createDownloadCommands(t *testing.T) {
-	tests := []struct {
-		name   string
-		config *bootstrapv1.K0sWorkerConfig
-		want   []string
-	}{
-		{
-			name:   "with default config",
-			config: &bootstrapv1.K0sWorkerConfig{},
-			want: []string{
-				"curl -sSfL https://get.k0s.sh | sh",
-			},
-		},
-		{
-			name: "with pre-installed k0s",
-			config: &bootstrapv1.K0sWorkerConfig{
-				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					PreInstalledK0s: true,
-				},
-			},
-			want: nil,
-		},
-		{
-			name: "with custom version",
-			config: &bootstrapv1.K0sWorkerConfig{
-				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					Version: "v1.2.3",
-				},
-			},
-			want: []string{
-				"curl -sSfL https://get.k0s.sh | K0S_VERSION=v1.2.3 sh",
-			},
-		},
-		{
-			name: "with custom download URL",
-			config: &bootstrapv1.K0sWorkerConfig{
-				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					DownloadURL: "https://example.com/k0s",
-				},
-			},
-			want: []string{
-				"curl -sSfL https://example.com/k0s -o /usr/local/bin/k0s",
-				"chmod +x /usr/local/bin/k0s",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, createDownloadCommands(tt.config))
-		})
-	}
-}
-
 func TestReconcileNoK0sWorkerConfig(t *testing.T) {
 	ns, err := testEnv.CreateNamespace(ctx, "test-reconcile-no-workerconfig")
 	require.NoError(t, err)

--- a/internal/controller/util/download.go
+++ b/internal/controller/util/download.go
@@ -1,0 +1,45 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+)
+
+// DownloadCommands constructs the download commands for a given URL and version.
+func DownloadCommands(preInstalledK0s bool, url string, version string) []string {
+	if preInstalledK0s {
+		return nil
+	}
+	if url != "" {
+		return []string{
+			fmt.Sprintf("curl -sSfL --retry 5 %s -o /usr/local/bin/k0s", url),
+			"chmod +x /usr/local/bin/k0s",
+		}
+	}
+
+	if version != "" {
+		return []string{
+			fmt.Sprintf("curl -sSfL --retry 5 https://get.k0s.sh | K0S_VERSION=%s sh", version),
+		}
+	}
+
+	// Default to k0s get script to download the latest version
+	return []string{
+		"curl -sSfL --retry 5 https://get.k0s.sh | sh",
+	}
+}

--- a/internal/controller/util/download_test.go
+++ b/internal/controller/util/download_test.go
@@ -1,0 +1,71 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_createDownloadCommands(t *testing.T) {
+	tests := []struct {
+		name            string
+		preInstalledK0s bool
+		url             string
+		version         string
+		want            []string
+	}{
+		{
+			name:            "with pre-installed k0s",
+			preInstalledK0s: true,
+			url:             "",
+			version:         "",
+			want:            nil,
+		},
+		{
+			name:    "with default config",
+			version: "",
+			url:     "",
+			want: []string{
+				"curl -sSfL --retry 5 https://get.k0s.sh | sh",
+			},
+		},
+		{
+			name:    "with custom version",
+			version: "v1.2.3",
+			url:     "",
+			want: []string{
+				"curl -sSfL --retry 5 https://get.k0s.sh | K0S_VERSION=v1.2.3 sh",
+			},
+		},
+		{
+			name:    "with custom download URL",
+			version: "",
+			url:     "https://example.com/k0s",
+			want: []string{
+				"curl -sSfL --retry 5 https://example.com/k0s -o /usr/local/bin/k0s",
+				"chmod +x /usr/local/bin/k0s",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, DownloadCommands(tt.preInstalledK0s, tt.url, tt.version))
+		})
+	}
+}


### PR DESCRIPTION
By adding --retry 5 for curl commands we ensure we actually retry few times if for some reason the network takes a bit of time to come up properly.

Also refactored to handle all the download command generation for both controllers and workers into one single place.