### PR TITLE
fix: add GITHUB_TOKEN to clusterctl init to avoid rate limits

### DIFF
--- a/.github/workflows/capi-smoke-tests.yml
+++ b/.github/workflows/capi-smoke-tests.yml
@@ -78,6 +78,8 @@ jobs:
           sed -e 's#%pwd%#'`pwd`'#g' ./hack/capi-ci/config.yaml > config.yaml
 
       - name: Install cluster api components
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CLUSTER_TOPOLOGY=true clusterctl init --control-plane k0sproject-k0smotron --bootstrap k0sproject-k0smotron --infrastructure k0sproject-k0smotron,docker --config config.yaml
           kubectl wait --for=condition=available -n cert-manager deployment/cert-manager-webhook --timeout=300s
@@ -122,4 +124,4 @@ jobs:
             /tmp/${{ inputs.smoke-suite }}-k0smotron-*.log
             /tmp/${{ inputs.smoke-suite }}-support-bundle.tar.gz
             /tmp/${{ inputs.smoke-suite }}-docker-*.log
-    
+


### PR DESCRIPTION
## Overview
Added GITHUB_TOKEN environment variable to prevent GitHub API rate limit errors that sometimes occur when executing the `clusterctl init` command in the CAPI smoke tests workflow.

## Changes
- Added `GITHUB_TOKEN` environment variable to the "Install cluster api components" step in `.github/workflows/capi-smoke-tests.yml`

## Background
`clusterctl init` uses the GitHub API when downloading provider manifests from GitHub. Without authentication, the following limits apply:
- Without authentication: 60 requests/hour
- With authentication: 5,000 requests/hour

In CI environments, multiple jobs may run concurrently, making it more likely to hit the rate limit without authentication.
