### PR TITLE
fix(inttest): improve flaky TestCAPIDockerClusterClassSuite test

### DIFF
--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -54,4 +54,5 @@ check-capi-docker-machine-template-update-recreate-kine: TIMEOUT=15m
 check-capi-docker-machine-change-template: TIMEOUT=25m
 check-capi-docker-machine-change-args: TIMEOUT=15m
 check-capi-remote-machine-job-provision: TIMEOUT=10m
+check-capi-docker-clusterclass: TIMEOUT=12m
 check-upgrade: TIMEOUT=20m


### PR DESCRIPTION
## Overview

Fixed an issue where the `TestCAPIDockerClusterClassSuite` test was intermittently failing due to timing problems.

## Problem

The test was occasionally failing with the following errors:
- `context deadline exceeded`
- `timed out waiting for the condition`
- Timeout while waiting for worker nodes to reach 3

## Changes

### 1. Explicit Timeout Configuration
- Changed from `wait.PollImmediateUntilWithContext` to `wait.PollUntilContextTimeout`
- Set appropriate timeouts for each wait operation:
  - Load Balancer wait: 3 minutes
  - Control Plane wait: 3 minutes
  - Worker Nodes wait: 5 minutes

### 2. Detailed Logging for Debugging
- Added detailed logging of current state for each wait operation
- Display detailed node information (name, Ready state, Phase)
- Record detailed information when errors occur

### 3. Improved Error Handling
- Fixed areas where errors were being ignored
- Prevent nil reference in `getLBPort` function
- Proper handling of retryable errors

### 4. Extended Test Timeout
- Set a 12-minute timeout for `check-capi-docker-clusterclass` in Makefile