### PR TITLE
Change the call order in the webhook initialization

### DIFF
--- a/internal/controller/controlplane/k0s_controlplane_webhook.go
+++ b/internal/controller/controlplane/k0s_controlplane_webhook.go
@@ -132,7 +132,7 @@ func denyRecreateOnSingleClusters(kcp *v1beta1.K0sControlPlane) error {
 // SetupK0sControlPlaneWebhookWithManager registers the webhook for K0sControlPlane in the manager.
 func (v *K0sControlPlaneValidator) SetupK0sControlPlaneWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&v1beta1.K0sControlPlane{}).
 		WithValidator(v).
+		For(&v1beta1.K0sControlPlane{}).
 		Complete()
 }

--- a/internal/controller/k0smotron.io/k0smotroncluster_webhook.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_webhook.go
@@ -47,7 +47,7 @@ var _ webhook.CustomDefaulter = &ClusterDefaulter{}
 
 func (c *ClusterDefaulter) SetupK0sControlPlaneWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&km.Cluster{}).
 		WithDefaulter(c).
+		For(&km.Cluster{}).
 		Complete()
 }


### PR DESCRIPTION
Not sure why it matters, but previous version didn't work locally