### PR TITLE
docs(capi-aws-vm): use NLB for control-plane load balancer

### DIFF
--- a/docs/capi-aws-vm.md
+++ b/docs/capi-aws-vm.md
@@ -106,6 +106,7 @@ spec:
   region: eu-west-1
   sshKeyName: <your-ssh-key-name>
   controlPlaneLoadBalancer:
+    loadBalancerType: nlb
     healthCheckProtocol: TCP
   network:
     additionalControlPlaneIngressRules:


### PR DESCRIPTION
Setting `loadBalancerType: nlb` replaces the default Classic ELB, eliminating the deprecation warning:

  “primary control plane load balancer is using a classic elb which is
   deprecated & support will be removed in a future release …”

This ensures new clusters are created with an NLB and remain future-proof.