### PR TITLE
feat: Enable PreferClose traffic distribution for etcd service

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_etcd.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_etcd.go
@@ -85,6 +85,7 @@ func (r *ClusterReconciler) reconcileEtcdSvc(ctx context.Context, kmc *km.Cluste
 			ClusterIP:                v1.ClusterIPNone,
 			Selector:                 labels,
 			PublishNotReadyAddresses: true,
+			TrafficDistribution:      ptr.To("PreferClose"),
 			Ports: []v1.ServicePort{
 				{
 					Name:       "client",


### PR DESCRIPTION
## Summary

Set the TrafficDistribution for etcd service to `PreferClose`.

## Changes

* Added `TrafficDistribution: PreferClose` to the etcd service definition.

## Motivation

Prioritizing nearby nodes improves network latency. Additionally, in AWS environments, this change reduces extra charges associated with cross-AZ traffic.

## Test

I did manually performing e2e testing, this change is working correctly.
![](https://github.com/user-attachments/assets/7d0b2ec3-ecd4-4fca-a513-7562f5bddbba)
