### PR TITLE
Fix deprecated patchesStrategicMerge usage in kustomization files

### DIFF
--- a/config/clusterapi/infrastructure/kustomization.yaml
+++ b/config/clusterapi/infrastructure/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Adds namespace to all resources.
 namespace: k0smotron
 
@@ -31,11 +33,11 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_config_patch.yaml
+- path: manager_config_patch.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/clusterapi/k0smotron.io/kustomization.yaml
+++ b/config/clusterapi/k0smotron.io/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
@@ -6,7 +8,7 @@ resources:
 - bases/k0smotron.io_jointokenrequests.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_k0smotronclusters.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Adds namespace to all resources.
 namespace: k0smotron
 
@@ -25,9 +27,9 @@ resources:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-patchesStrategicMerge:
-- manager_webhook_patch.yaml
-- webhookcainjection_patch.yaml
+patches:
+- path: manager_webhook_patch.yaml
+- path: webhookcainjection_patch.yaml
 
 replacements:
 - source:
@@ -122,5 +124,3 @@ replacements:
       group: cert-manager.io
       kind: Certificate
       version: v1
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization


### PR DESCRIPTION
Replace deprecated 'patchesStrategicMerge' with 'patches' in:
- config/default/kustomization.yaml
- config/clusterapi/infrastructure/kustomization.yaml
- config/clusterapi/k0smotron.io/kustomization.yaml

This resolves the kustomize warning:
"'patchesStrategicMerge' is deprecated. Please use 'patches' instead."