### PR TITLE
Add GITHUB_TOKEN to avoid rate limits

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -196,6 +196,8 @@ jobs:
           go-version-file: go.mod
 
       - name: Run e2e test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export TEST_NAME=Test$(echo "${{ matrix.e2e-suite }}" | awk -F'-' '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1' OFS='')
           echo "Running E2E tests with TEST_NAME=$TEST_NAME"


### PR DESCRIPTION
I got the rate limit in here. 😢 

https://github.com/k0sproject/k0smotron/actions/runs/15992815886/job/45109681671?pr=1053

```
failed to list the machines: client rate limiter Wait returned an error: context deadline exceeded    workload_cluster_inplace_upgrade_test.go:108: 
        	Error Trace:	/home/runner/work/k0smotron/k0smotron/e2e/workload_cluster_inplace_upgrade_test.go:108
        	            				/home/runner/work/k0smotron/k0smotron/e2e/setup.go:121
        	            				/home/runner/work/k0smotron/k0smotron/e2e/workload_cluster_inplace_upgrade_test.go:36
        	Error:      	Received unexpected error:
        	            	error waiting for the first control machine to be provisioned: no Control Plane machines came into existence: client rate limiter Wait returned an error: context deadline exceeded
        	Test:       	TestWorkloadClusterInplaceUpgrade
Failed to get logs for Machine workload-inplace-upgrade-olpgqb-docker-test-worker-0, Cluster workload-inplace-upgrade-9icc41/workload-inplace-upgrade-olpgqb: : exited with status: 2, &{%!s(*os.file=&{{{0 0 0} 14 {<nil>} {0} 0 1 true true true} /tmp/workload-inplace-upgrade-olpgqb-docker-test-worker-03061215136 <nil> false false false})}
```