### PR TITLE
Fix typos and improve import aliases in k0smotron controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,7 +44,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	bootstrapv1beta1 "github.com/k0sproject/k0smotron/api/bootstrap/v1beta1"
-	controlplanev1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
+	cpv1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
 	infrastructurev1beta1 "github.com/k0sproject/k0smotron/api/infrastructure/v1beta1"
 	k0smotronv1beta1 "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
 	"github.com/k0sproject/k0smotron/internal/controller/bootstrap"
@@ -80,7 +80,7 @@ func init() {
 	// Register cluster-api types
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
-	utilruntime.Must(controlplanev1beta1.AddToScheme(scheme))
+	utilruntime.Must(cpv1beta1.AddToScheme(scheme))
 	utilruntime.Must(infrastructurev1beta1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
-	controlplanev1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
+	cpv1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
 	"github.com/k0sproject/k0smotron/e2e/mothership"
 	"github.com/k0sproject/k0smotron/e2e/util"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -194,7 +194,7 @@ func tearDown(bootstrapClusterProvider bootstrap.ClusterProvider, bootstrapClust
 func initScheme() (*runtime.Scheme, error) {
 	s := runtime.NewScheme()
 	capiframework.TryAddDefaultSchemes(s)
-	err := controlplanev1beta1.AddToScheme(s)
+	err := cpv1beta1.AddToScheme(s)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/lint/Dockerfile
+++ b/hack/lint/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_IMG
 
-FROM ${BUILD_IMG} as builder
+FROM ${BUILD_IMG} AS builder
 ARG GOLANGCILINT_VERSION
 
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v${GOLANGCILINT_VERSION}

--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -135,7 +135,7 @@ func (c *K0smotronController) Reconcile(ctx context.Context, req ctrl.Request) (
 			if errors.Is(derr, ErrNotReady) {
 				res = ctrl.Result{RequeueAfter: 10 * time.Second, Requeue: true}
 			} else {
-				log.Error(derr, "Failed to update K0smotronContorlPlane status")
+				log.Error(derr, "Failed to update K0smotronControlPlane status")
 				err = derr
 				return
 			}
@@ -143,7 +143,7 @@ func (c *K0smotronController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		derr = kcpPatchHelper.Patch(ctx, kcp)
 		if derr != nil {
-			log.Error(derr, "Failed to patch K0smotronContorlPlane")
+			log.Error(derr, "Failed to patch K0smotronControlPlane")
 			err = kerrors.NewAggregate([]error{err, derr})
 		}
 
@@ -155,7 +155,7 @@ func (c *K0smotronController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		if err != nil {
 			// We shouldn't proceed with Infrastructure patching
-			// if we couldn't update the Cluster, K0smotronContorlPlane object(s)
+			// if we couldn't update the Cluster, K0smotronControlPlane object(s)
 			return
 		}
 

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -40,7 +40,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 
 	bootstrapv1beta1 "github.com/k0sproject/k0smotron/api/bootstrap/v1beta1"
-	controlplanev1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
+	cpv1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
 	infrastructurev1beta1 "github.com/k0sproject/k0smotron/api/infrastructure/v1beta1"
 	k0smotronv1beta1 "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -87,7 +87,7 @@ func init() {
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(k0smotronv1beta1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(bootstrapv1beta1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(controlplanev1beta1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(cpv1beta1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(infrastructurev1beta1.AddToScheme(scheme.Scheme))
 }
 

--- a/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	controlplanev1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
+	cpv1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/k0sproject/k0smotron/inttest/util"
@@ -123,7 +123,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 			Do(ctx).
 			Into(&cluster)
 
-		clusterIDAnnotation, found := cluster.GetAnnotations()[controlplanev1beta1.K0sClusterIDAnnotation]
+		clusterIDAnnotation, found := cluster.GetAnnotations()[cpv1beta1.K0sClusterIDAnnotation]
 		return found && strings.Contains(clusterIDAnnotation, "kube-system"), nil
 	})
 	s.Require().NoError(err)
@@ -280,14 +280,14 @@ spec:
           enabled: false
         network:
           controlPlaneLoadBalancing:
-            enabled: false 
+            enabled: false
     files:
     - path: /tmp/test-file-secret
-      contentFrom: 
-        secretRef: 
+      contentFrom:
+        secretRef:
           name: test-file-secret
           key: value
-    customUserDataRef: 
+    customUserDataRef:
       configMapRef:
         name: custom-user-data
         key: customUserData
@@ -351,11 +351,11 @@ spec:
     - path: /tmp/test-file
       content: test-file
     - path: /tmp/test-file-secret
-      contentFrom: 
-        secretRef: 
+      contentFrom:
+        secretRef:
           name: test-file-secret
           key: value
-  customUserDataRef: 
+  customUserDataRef:
     configMapRef:
       name: custom-user-data
       key: customUserData

--- a/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
+++ b/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	controlplanev1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
+	cpv1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
 	"github.com/k0sproject/k0smotron/inttest/util"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -94,14 +94,14 @@ func (s *CAPIDockerClusterClassK0smotronSuite) TestCAPIDocker() {
 	s.Require().NoError(util.WaitForStatefulSet(s.ctx, s.client, "kmc-docker-test-cluster", "default"))
 
 	crdConfig := *s.restConfig
-	crdConfig.ContentConfig.GroupVersion = &controlplanev1beta1.GroupVersion
+	crdConfig.ContentConfig.GroupVersion = &cpv1beta1.GroupVersion
 	crdConfig.APIPath = "/apis"
 	crdConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme.Scheme)
 	crdConfig.UserAgent = rest.DefaultKubernetesUserAgent()
 	crdRestClient, err := rest.UnversionedRESTClientFor(&crdConfig)
 	s.Require().NoError(err)
 	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
-		var kcps controlplanev1beta1.K0smotronControlPlaneList
+		var kcps cpv1beta1.K0smotronControlPlaneList
 		err = crdRestClient.Get().Resource("k0smotroncontrolplanes").Namespace("default").Do(ctx).Into(&kcps)
 		if err != nil || len(kcps.Items) == 0 {
 			return false, nil

--- a/inttest/capi-docker/capi_docker_test.go
+++ b/inttest/capi-docker/capi_docker_test.go
@@ -27,7 +27,7 @@ import (
 
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 
-	controlplanev1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
+	cpv1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -180,7 +180,7 @@ func (s *CAPIDockerSuite) deleteCluster() {
 func (s *CAPIDockerSuite) checkControlPlaneStatus(ctx context.Context, rc *rest.Config) {
 
 	crdConfig := *rc
-	crdConfig.ContentConfig.GroupVersion = &controlplanev1beta1.GroupVersion
+	crdConfig.ContentConfig.GroupVersion = &cpv1beta1.GroupVersion
 	crdConfig.APIPath = "/apis"
 	crdConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme.Scheme)
 	crdConfig.UserAgent = rest.DefaultKubernetesUserAgent()
@@ -188,7 +188,7 @@ func (s *CAPIDockerSuite) checkControlPlaneStatus(ctx context.Context, rc *rest.
 	s.Require().NoError(err)
 
 	err = wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
-		var kcp controlplanev1beta1.K0smotronControlPlane
+		var kcp cpv1beta1.K0smotronControlPlane
 		err = crdRestClient.
 			Get().
 			Resource("k0smotroncontrolplanes").
@@ -213,7 +213,7 @@ func (s *CAPIDockerSuite) checkClusterIDAnnotation(ctx context.Context) {
 			Into(&cluster)
 
 		s.T().Log(cluster)
-		clusterIDAnnotation, found := cluster.GetAnnotations()[controlplanev1beta1.K0sClusterIDAnnotation]
+		clusterIDAnnotation, found := cluster.GetAnnotations()[cpv1beta1.K0sClusterIDAnnotation]
 		return found && strings.Contains(clusterIDAnnotation, "kube-system"), nil
 	})
 


### PR DESCRIPTION
## Summary
This PR fixes typos and improves code consistency by standardizing import aliases.

## Changes
- **Fix typos**: Corrected "K0smotronContorlPlane" to "K0smotronControlPlane" in error messages and comments
- **Improve import aliases**: Changed `controlplanev1beta1` to `cpv1beta1` for better consistency with existing codebase patterns
- **Minor Docker improvement**: Updated Dockerfile to use uppercase `AS` keyword following best practices

## Files Changed
- `internal/controller/controlplane/k0smotron_controlplane_controller.go`: Fixed typos in log messages and comments
- `inttest/capi-docker/capi_docker_test.go`: Standardized import alias from `controlplanev1beta1` to `cpv1beta1`
- `hack/lint/Dockerfile`: Changed `as` to `AS` for consistency

## Testing
- [x] No functional changes, only cosmetic improvements