### PR TITLE
Fix '--enable-controller' arg for clusterctl installation

### DIFF
--- a/config/clusterapi/bootstrap/manager_config_patch.yaml
+++ b/config/clusterapi/bootstrap/manager_config_patch.yaml
@@ -16,3 +16,8 @@ spec:
     spec:
       containers:
       - name: manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
+        - "--enable-controller=bootstrap"

--- a/config/clusterapi/infrastructure/manager_config_patch.yaml
+++ b/config/clusterapi/infrastructure/manager_config_patch.yaml
@@ -16,3 +16,8 @@ spec:
     spec:
       containers:
       - name: manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
+        - "--enable-controller=infrastructure"


### PR DESCRIPTION
I fixed the latest release where we introduced this bug but we need `enable-controller` arg for each CAPI provider (at least for the ones that don't use webhook capabilities. If not, the controller will panic due to missing certificates only needed for control plane controller