### PR TITLE
Add CNCF required footer to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,8 @@ docs_dir: docs/
 repo_name: GitHub
 repo_url: https://github.com/k0sproject/k0smotron
 copyright:
-  Copyright &copy; 2024 <a href="https://mirantis.com/">Mirantis Inc.</a>
+  Copyright &copy; 2021 k0sproject a Series of LF Projects, LLC.
+  For website terms of use, trademark policy and other project policies please see lfprojects.org/policies/.
   - All rights reserved.
 edit_uri: ""
 nav:


### PR DESCRIPTION
Add the CNCF required footer according to https://github.com/cncf/foundation/blob/main/policies-guidance/website-guidelines.md