### PR TITLE
Use CNCF hosted runners

### DIFF
--- a/.github/workflows/capi-smoke-tests.yml
+++ b/.github/workflows/capi-smoke-tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   capi-smokes:
     name: "${{ inputs.smoke-suite }} :: ${{ inputs.k0s-version }}"
-    runs-on: ubuntu-22.04-8core
+    runs-on: oracle-vm-16cpu-64gb-x86-64
 
     steps:
       - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -89,7 +89,7 @@ jobs:
   smoketest:
     name: Smoke test
     needs: build
-    runs-on: ubuntu-22.04-8core
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     strategy:
       fail-fast: false
       matrix:
@@ -175,7 +175,7 @@ jobs:
   e2e:
     name: E2E test
     needs: build
-    runs-on: ubuntu-22.04-8core
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Now that the k0rproject org has been moved to CNCF custody, we cannot anymore use the GH provided large runners. Instead we can use CNCF [hosted](https://github.com/cncf/automation/tree/main/ci/) runners.

These CNCF runners have pretty much the same resources as we used before and thus the total workflow run time is also comparable: ~35min vs. ~38mins