### PR TITLE
Avoid changing kcp on bootstrap config changes

### DIFF
--- a/internal/controller/controlplane/k0s_controlplane_controller.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller.go
@@ -589,7 +589,8 @@ func (c *K0sController) deleteK0sNodeResources(ctx context.Context, cluster *clu
 
 func (c *K0sController) createBootstrapConfig(ctx context.Context, name string, _ *clusterv1.Cluster, kcp *cpv1beta1.K0sControlPlane, machine *clusterv1.Machine, clusterName string) error {
 
-	kcp.Spec.K0sConfigSpec.Args = uniqueArgs(kcp.Spec.K0sConfigSpec.Args)
+	k0sConfigSpec := kcp.Spec.K0sConfigSpec.DeepCopy()
+	k0sConfigSpec.Args = uniqueArgs(k0sConfigSpec.Args)
 
 	controllerConfig := bootstrapv1.K0sControllerConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -612,7 +613,7 @@ func (c *K0sController) createBootstrapConfig(ctx context.Context, name string, 
 		},
 		Spec: bootstrapv1.K0sControllerConfigSpec{
 			Version:       kcp.Spec.Version,
-			K0sConfigSpec: &kcp.Spec.K0sConfigSpec,
+			K0sConfigSpec: k0sConfigSpec,
 		},
 	}
 


### PR DESCRIPTION
Currently, changing args cause K0sControlPlane update and machine recreation