### PR TITLE
Remove trailing whitespace from all files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -11,7 +11,7 @@ body:
         Describe the bug in as much detail as possible.
     validations:
       required: true
-  
+
   - type: dropdown
     id: area
     attributes:
@@ -37,7 +37,7 @@ body:
         How can we reproduce it (as minimally and precisely as possible)?
     validations:
       required: true
-  
+
   - type: input
     id: k0smotron-version
     attributes:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -96,7 +96,7 @@ jobs:
           make release IMG=quay.io/k0sproject/k0smotron:${STABLE}
           cp install.yaml /tmp/install.yaml
           git checkout gh-pages
-          cp /tmp/install.yaml ${STABLE}/install.yaml 
+          cp /tmp/install.yaml ${STABLE}/install.yaml
           git add ${STABLE}/install.yaml && git update-index --refresh
           git diff-index --quiet HEAD -- || git commit -m "Update install.yaml to ${STABLE}"
           git push origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           asset_path: ./templates/cluster-template.yaml
           asset_name: cluster-template.yaml
           asset_content_type: application/octet-stream
-      
+
       - name: Upload Release Assets - cluster-template-hcp.yaml
         id: upload-release-asset-cluster-template-hcp
         uses: shogo82148/actions-upload-release-asset@v1.8.1

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Using k0smotron the clusters controlplane and workerplane are truly separated. T
 
 ### Bring your own workers
 
-With k0smotron you can connect worker nodes from ANY infrastructure to your cluster control plane. 
+With k0smotron you can connect worker nodes from ANY infrastructure to your cluster control plane.
 
 ## How does it work
 
@@ -34,7 +34,7 @@ Often when running integration and end-to-end testing for your software running 
 
 ### Edge
 
-Running Kubernetes on the network edge usually means running in low resource infrastructure. What this often means is that setting up the controlplane is either a challenge or a mission impossible. Running the controlplane on a existing cluster, on a separate dedicated infrastructure, removes that challenge and let's you focus on the real edge. 
+Running Kubernetes on the network edge usually means running in low resource infrastructure. What this often means is that setting up the controlplane is either a challenge or a mission impossible. Running the controlplane on a existing cluster, on a separate dedicated infrastructure, removes that challenge and let's you focus on the real edge.
 
 Running on the edge often also means large number of clusters to manage. Do you really want to dedicate nodes for each cluster controlplane and manage all the infrastructure for those?
 

--- a/docs/capi-aws.md
+++ b/docs/capi-aws.md
@@ -1,6 +1,6 @@
 # Cluster API - AWS (Hosted Control Plane)
 
-This example demonstrates how k0smotron can be used with CAPA (Cluster API Provider Amazon Web Services) to deploy 
+This example demonstrates how k0smotron can be used with CAPA (Cluster API Provider Amazon Web Services) to deploy
 a cluster with hosted control plane and workers in AWS.
 
 ## Prerequisites
@@ -115,7 +115,7 @@ spec:
     spec:
       ami:
         # Replace with your AMI ID
-        id: ami-0989fb15ce71ba39e # Ubuntu 22.04 in eu-central-1 
+        id: ami-0989fb15ce71ba39e # Ubuntu 22.04 in eu-central-1
       instanceType: t3.large
       iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io # Instance Profile created by `clusterawsadm bootstrap iam create-cloudformation-stack`
       cloudInit:
@@ -146,20 +146,20 @@ Once complete, your command line should display output similar to this:
 ```shell
 % kubectl get cluster,machine
 NAME                                    PHASE         AGE   VERSION
-cluster.cluster.x-k8s.io/k0s-aws-test   Provisioned   16m   
+cluster.cluster.x-k8s.io/k0s-aws-test   Provisioned   16m
 
 NAME                                         CLUSTER        NODENAME   PROVIDERID                                 PHASE         AGE   VERSION
-machine.cluster.x-k8s.io/k0s-aws-test-md-0   k0s-aws-test              aws:///eu-central-1a/i-05f2de7da41dc542a   Provisioned   16m   
+machine.cluster.x-k8s.io/k0s-aws-test-md-0   k0s-aws-test              aws:///eu-central-1a/i-05f2de7da41dc542a   Provisioned   16m
 ```
 
 You can also check the status of the cluster deployment with `clusterctl`:
 ```shell
-% clusterctl describe cluster  
-NAME                                                   READY  SEVERITY  REASON                    SINCE  MESSAGE          
-Cluster/k0s-aws-test                                   True                                       25m                      
-├─ClusterInfrastructure - AWSCluster/k0s-aws-test                                                                             
-├─ControlPlane - K0smotronControlPlane/k0s-aws-test-cp                                                                           
-└─Workers                                                                                                                  
+% clusterctl describe cluster
+NAME                                                   READY  SEVERITY  REASON                    SINCE  MESSAGE
+Cluster/k0s-aws-test                                   True                                       25m
+├─ClusterInfrastructure - AWSCluster/k0s-aws-test
+├─ControlPlane - K0smotronControlPlane/k0s-aws-test-cp
+└─Workers
   └─Other
 ```
 
@@ -169,7 +169,7 @@ k0smotron, running in a management cluster in AWS, supports flexible networking 
 If you prefer using an NLB instead of ELB, you must specify annotations for the Service in the `k0smotronControlPlane`. These annotations guide the AWS Cloud Controller Manager (CCM) or the AWS Load Balancer Controller to create the respective services.
 
 ```yaml
- [...] 
+ [...]
   service:
     type: LoadBalancer
     apiPort: 6443
@@ -184,7 +184,7 @@ For scenarios involving Classic ELBs or NLBs without special options, the AWS CC
 If you aim to use the NLB and set the schema to `internal`, the target group attribute `preserve_client_ip.enabled=false` is required due to "hairpinning" or "NAT loopback". In such cases, the AWS CCM cannot be used because it doesn't support setting Target Group Attributes. Therefore, the AWS Load Balancer Controller, which has the ability to set Target Group Attributes, becomes necessary. Follow [this guide](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html) to install the AWS Load Balancer Controller.
 
 ```yaml
- [...] 
+ [...]
   service:
     type: LoadBalancer
     apiPort: 6443

--- a/docs/capi-bootstrap.md
+++ b/docs/capi-bootstrap.md
@@ -112,6 +112,6 @@ spec:
     # More details about the aws machine template can be set here
 ```
 
-This example creates a `MachineDeployment` with 2 replicas, using k0smotron as the bootstrap provider. The `infrastructureRef` is used to specify the infrastructure requirements for the machines, in this case, AWS. 
+This example creates a `MachineDeployment` with 2 replicas, using k0smotron as the bootstrap provider. The `infrastructureRef` is used to specify the infrastructure requirements for the machines, in this case, AWS.
 
 Check the [examples](capi-examples.md) pages for more detailed examples how k0smotron can be used with various Cluster API infrastructure providers.

--- a/docs/capi-clusterclass.md
+++ b/docs/capi-clusterclass.md
@@ -1,6 +1,6 @@
 # ClusterClass
 
-K0smotron supports ClusterClass, a simple way to create many clusters of a similar shape. 
+K0smotron supports ClusterClass, a simple way to create many clusters of a similar shape.
 
 For instance, we will create a ClusterClass that will create a cluster running control plane and worker nodes on DockerMachines:
 
@@ -136,7 +136,7 @@ spec:
           spec:
             api:
               extraArgs:
-                anonymous-auth: "true" # anonymous-auth=true is needed for k0s to allow unauthorized health-checks on /healthz 
+                anonymous-auth: "true" # anonymous-auth=true is needed for k0s to allow unauthorized health-checks on /healthz
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/docs/capi-controlplane-bootstrap.md
+++ b/docs/capi-controlplane-bootstrap.md
@@ -42,7 +42,7 @@ spec:
       spec:
         api:
           extraArgs:
-            anonymous-auth: "true" # anonymous-auth=true is needed for k0s to allow unauthorized health-checks on /healthz 
+            anonymous-auth: "true" # anonymous-auth=true is needed for k0s to allow unauthorized health-checks on /healthz
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -69,7 +69,7 @@ For a full reference on `K0sControlPlane` configurability see the [reference doc
 **WARNING: Downscaling is a potentially dangerous operation.**
 
 Kubernetes using etcd as its backing store. It's crucial to have a quorum of etcd nodes available at all times. Always run etcd as a cluster of **odd** members.
-    
+
 When downscaling the control plane, you need firstly to deregister the node from the etcd cluster. k0smotron will do it automatically for you.
 
 **NOTE:** k0smotron gives node names sequentially and on downscaling it will remove the "latest" nodes. For instance, if you have `k0smotron-test` cluster of 5 nodes and you downscale to 3 nodes, the nodes `k0smotron-test-3` and `k0smotron-test-4` will be removed.

--- a/docs/capi-hetzner.md
+++ b/docs/capi-hetzner.md
@@ -59,7 +59,7 @@ spec:
     apiPort: 6443
     konnectivityPort: 8132
     annotations:
-      load-balancer.hetzner.cloud/location: fsn1 
+      load-balancer.hetzner.cloud/location: fsn1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerCluster
@@ -134,7 +134,7 @@ spec:
 apiVersion: v1
 kind: Secret
 data:
-  hcloud: <base64 encoded token> 
+  hcloud: <base64 encoded token>
 metadata:
   name: hetzner
 ```
@@ -146,7 +146,7 @@ After applying the manifests to the management cluster and confirming the infras
 ```
 % kubectl get cluster,machine
 NAME                                   PHASE         AGE     VERSION
-cluster.cluster.x-k8s.io/hetzer-test   Provisioned   3m51s   
+cluster.cluster.x-k8s.io/hetzer-test   Provisioned   3m51s
 
 NAME                                         CLUSTER        NODENAME   PROVIDERID          PHASE         AGE     VERSION
 machine.cluster.x-k8s.io/hetzner-test-md-0   hetzner-test              hcloud://12345678   Provisioned   3m50s

--- a/docs/capi-kubevirt.md
+++ b/docs/capi-kubevirt.md
@@ -4,7 +4,7 @@ This example demonstrates how k0smotron can be used with CAPK (Cluster API Provi
 
 ## Preparations
 
-Before starting this example, ensure that you have met the [general prerequisites](capi-examples.md#prerequisites). 
+Before starting this example, ensure that you have met the [general prerequisites](capi-examples.md#prerequisites).
 
 To install the latest stable version of Kubevirt you can run:
 
@@ -155,7 +155,7 @@ After applying the manifests to the management cluster and confirming the infras
 ```bash
 % kubectl get cluster,machine
 NAME                                   PHASE         AGE     VERSION
-cluster.cluster.x-k8s.io/kubevirt-test Provisioned   22h   
+cluster.cluster.x-k8s.io/kubevirt-test Provisioned   22h
 
 NAME                                               CLUSTER         NODENAME                  PROVIDERID                           PHASE     AGE     VERSION
 machine.cluster.x-k8s.io/kubevirt-md-mdvns-l2rxb   kubevirt-test   kubevirt-md-mdvns-l2rxb   kubevirt://kubevirt-md-mdvns-l2rxb   Running   22h     v1.27.4

--- a/docs/capi-openstack.md
+++ b/docs/capi-openstack.md
@@ -22,7 +22,7 @@ To be able to provision the OpenStack provider infrastructre, you will need to s
 
 Download your “OpenStack clouds.yaml file” (Login -> API Access -> Download OpenStack clouds.yaml file)
 
-Add "verify: false" to your clouds.yaml to avoir having the "x509: certificate signed by unknown authority" error. 
+Add "verify: false" to your clouds.yaml to avoir having the "x509: certificate signed by unknown authority" error.
 
 More information here : [cluster-api-troubleshooting](https://cluster-api-openstack.sigs.k8s.io/topics/troubleshooting)
 
@@ -179,7 +179,7 @@ spec:
 Once complete, your command line should display output similar to this:
 
 ```shell
-kubectl get cluster,machine,kmc                                                                                                                   
+kubectl get cluster,machine,kmc
 
 NAME                                   CLUSTERCLASS   PHASE         AGE     VERSION
 cluster.cluster.x-k8s.io/cluster-openstack                     Provisioned   135m
@@ -192,13 +192,13 @@ machine.cluster.x-k8s.io/cluster-openstack-worker-vms-drjzw-7699d      cluster2 
 You can also check the status of the cluster deployment with `clusterctl`:
 ```shell
 ❯ clusterctl describe cluster cluster3
-NAME                                                                     READY  SEVERITY  REASON                       SINCE  MESSAGE                                                       
-Cluster/cluster3                                                         True                                          5d4h                                                                  
-├─ClusterInfrastructure - OpenStackCluster/cluster3                                                                                                                                          
-├─ControlPlane - K0smotronControlPlane/cluster3                                                                                                                                              
-└─Workers                                                                                                                                                           
-    └─Machine/cluster3-worker-vms-929sw-nkhht                            True                                          5d4h                                                                  
-      └─BootstrapConfig - K0sWorkerConfig/cluster3-machine-config-tlg78                                                        
+NAME                                                                     READY  SEVERITY  REASON                       SINCE  MESSAGE
+Cluster/cluster3                                                         True                                          5d4h
+├─ClusterInfrastructure - OpenStackCluster/cluster3
+├─ControlPlane - K0smotronControlPlane/cluster3
+└─Workers
+    └─Machine/cluster3-worker-vms-929sw-nkhht                            True                                          5d4h
+      └─BootstrapConfig - K0sWorkerConfig/cluster3-machine-config-tlg78
 ```
 
 

--- a/docs/capi-remote.md
+++ b/docs/capi-remote.md
@@ -103,7 +103,7 @@ spec:
 
 ## Using `RemoteMachine`s in `machineTemplate`s of higher-level objects
 
-Objects like `K0sControlPlane` or `MachineDeployment` use `machineTemplate` to define the template for the `Machine` objects they create. 
+Objects like `K0sControlPlane` or `MachineDeployment` use `machineTemplate` to define the template for the `Machine` objects they create.
 Since k0smotron remote machine provider can't create machines on its own, it works with a pool of pre-created machines.
 
 ```yaml

--- a/docs/capi-remotemachine-okta-asa.md
+++ b/docs/capi-remotemachine-okta-asa.md
@@ -23,14 +23,14 @@ RUN apt-get update && apt-get install -y \
 # Obtain the Okta ASA agent key and add the repository
 RUN curl -fsSL https://dist.scaleft.com/GPG-KEY-OktaPAM-2023 | gpg --dearmor | tee /usr/share/keyrings/oktapam-2023-archive-keyring.gpg > /dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/oktapam-2023-archive-keyring.gpg] https://dist.scaleft.com/repos/deb jammy okta" | tee /etc/apt/sources.list.d/oktapam-stable.list \
- 
-# Install the Okta ASA agents    
+
+# Install the Okta ASA agents
 RUN apt-get update && apt-get install -y \
       scaleft-client-tools \
       # Mute the error about missing systemd from the post-install script
       scaleft-server-tools | true \
 
-# Configure the ssh client to use the proxy 
+# Configure the ssh client to use the proxy
 RUN mkdir -p ~/.ssh/ && sft ssh-config >> ~/.ssh/config
 
 # Add the entrypoint script.
@@ -45,7 +45,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 ## Server enrollment
 
-Okta ASA agent needs to be enrolled to the Okta ASA service. To do that, first we need to run `sftd` once with the enrollment token. 
+Okta ASA agent needs to be enrolled to the Okta ASA service. To do that, first we need to run `sftd` once with the enrollment token.
 The token can be [obtained](https://help.okta.com/asa/en-us/content/topics/adv_server_access/docs/server-enroll-token.htm) from the Okta ASA console.
 In this example we put the token to the Kubernetes secret:
 

--- a/docs/capi-remotemachine-teleport.md
+++ b/docs/capi-remotemachine-teleport.md
@@ -44,7 +44,7 @@ roleRef:
 
 ## Creating Teleport Bot User
 
-Next, you need to create a Teleport Bot user for the service account. Since we use a `kubernetes` auth method for Teleport, first we need to figure out the cluster's JWKS. 
+Next, you need to create a Teleport Bot user for the service account. Since we use a `kubernetes` auth method for Teleport, first we need to figure out the cluster's JWKS.
 It will be used by the Teleport Cluster to verify the JWT tokens.
 
 ```bash

--- a/docs/capi-vsphere-tmpl-cp-in-pods.yaml
+++ b/docs/capi-vsphere-tmpl-cp-in-pods.yaml
@@ -12,7 +12,7 @@ spec:
       - 192.168.0.0/16
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-    kind: K0smotronControlPlane 
+    kind: K0smotronControlPlane
     name: '${CLUSTER_NAME}'
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -144,7 +144,7 @@ spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-          kind: K0sWorkerConfigTemplate 
+          kind: K0sWorkerConfigTemplate
           name: '${CLUSTER_NAME}'
       clusterName: '${CLUSTER_NAME}'
       infrastructureRef:

--- a/docs/capi-vsphere-tmpl-cp-in-vms.yaml
+++ b/docs/capi-vsphere-tmpl-cp-in-vms.yaml
@@ -12,7 +12,7 @@ spec:
       - 192.168.0.0/16
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-    kind: K0sControlPlane 
+    kind: K0sControlPlane
     name: '${CLUSTER_NAME}'
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -103,7 +103,7 @@ kind: K0sControlPlane
 metadata:
   name: '${CLUSTER_NAME}'
 spec:
-  k0sVersion: '${K0S_VERSION}' 
+  k0sVersion: '${K0S_VERSION}'
   replicas: 3
   k0sConfigSpec:
     # Those args are mandatory since kube-vip should be running on controllers
@@ -124,7 +124,7 @@ spec:
           # WA for NLLB
             - ${CONTROL_PLANE_ENDPOINT_IP}
           extraArgs:
-            anonymous-auth: "true" 
+            anonymous-auth: "true"
         extensions:
           helm:
             repositories:
@@ -151,7 +151,7 @@ spec:
                   cp_enable: "true"                             # Enable control-plane mode
                   svc_enable: "true"                            # Enable service mode
                   svc_election: "true"                          # Enable service election
-                  vip_leaderelection: "true" 
+                  vip_leaderelection: "true"
                 extraArgs:
                   prometheusHTTPServer: "0.0.0.0:2112"
                 serviceAccount:
@@ -212,7 +212,7 @@ spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-          kind: K0sWorkerConfigTemplate 
+          kind: K0sWorkerConfigTemplate
           name: '${CLUSTER_NAME}'
       clusterName: '${CLUSTER_NAME}'
       infrastructureRef:

--- a/docs/capi-vsphere.md
+++ b/docs/capi-vsphere.md
@@ -105,14 +105,14 @@ spec:
   end: 192.168.117.180
 ```
 
-2. Deploy the IPAM configuration: 
+2. Deploy the IPAM configuration:
 ```
 kubectl apply -f capi-ipam.yaml
 ```
 
 ## (Optional) MetalLB as Load Balancer solution in the management cluster
 
-You may require to deploy MetalLB if you don't have Load Balancer solution in your management cluster. 
+You may require to deploy MetalLB if you don't have Load Balancer solution in your management cluster.
 *NOTE:* Load Balancer service type will be used only for the scenario, when you put you k0s control plane in pods (see [Control plane in Pods](#control-plane-in-pods) section)
 
 Classic vSphere does not have a built-in solution that can be leveraged on Kubernetes level to create LoadBalancer service type. In order to make it possible, one of the common solution is to use MetalLB (please find it's docs [here](https://metallb.universe.tf/))
@@ -154,7 +154,7 @@ There are two options for child cluster control plane with k0smotron:
 
 #### Control plane in Pods:
 
-If you want to have child cluster [control plane in a Pods](https://docs.k0smotron.io/stable/capi-controlplane/), use the following [template](capi-vsphere-tmpl-cp-in-pods.yaml): 
+If you want to have child cluster [control plane in a Pods](https://docs.k0smotron.io/stable/capi-controlplane/), use the following [template](capi-vsphere-tmpl-cp-in-pods.yaml):
 
 ```sh
 clusterctl generate cluster my-cluster --control-plane-machine-count 1 --worker-machine-count 1 --from k0scluster-tmpl-cp-in-pods.yaml > my-cluster.yaml
@@ -165,7 +165,7 @@ clusterctl generate cluster my-cluster --control-plane-machine-count 1 --worker-
 If you want to have child cluster [control plane in separate VMs](https://docs.k0smotron.io/stable/capi-controlplane-bootstrap/), use the following [template](capi-vsphere-tmpl-cp-in-vms.yaml) (Control Plane will consist of 3 nodes):
 
 ```sh
-clusterctl generate cluster my-cluster --worker-machine-count 1 --from k0scluster-tmpl-cp-in-vms.yaml > my-cluster.yaml 
+clusterctl generate cluster my-cluster --worker-machine-count 1 --from k0scluster-tmpl-cp-in-vms.yaml > my-cluster.yaml
 ```
 
 ### Deploy the child clusters
@@ -177,10 +177,10 @@ clusterctl generate cluster my-cluster --worker-machine-count 1 --from k0scluste
 ### Observe the child cluster objects
 
 ```shell
-# kubectl get cluster,machine,kmc                                                                                                                   
+# kubectl get cluster,machine,kmc
 
 NAME                                  CLUSTERCLASS   PHASE         AGE   VERSION
-cluster.cluster.x-k8s.io/my-cluster                  Provisioned   13h   
+cluster.cluster.x-k8s.io/my-cluster                  Provisioned   13h
 
 NAME                                                   CLUSTER      NODENAME                      PROVIDERID                                       PHASE         AGE   VERSION
 machine.cluster.x-k8s.io/my-cluster-0                  my-cluster                                 vsphere://4215e794-c281-5cde-8193-95df9521cf08   Provisioned   13h   v1.29.1
@@ -193,15 +193,15 @@ machine.cluster.x-k8s.io/my-cluster-md-0-vr6s6-ndl64   my-cluster   my-cluster-m
 You can also check the status of the cluster deployment with `clusterctl`:
 ```shell
 # clusterctl describe cluster my-cluster
-NAME                                                        READY  SEVERITY  REASON  SINCE  MESSAGE                             
-Cluster/my-cluster                                          True                     13h                                         
-├─ClusterInfrastructure - VSphereCluster/my-cluster         True                     13h                                         
-├─ControlPlane - K0sControlPlane/my-cluster                                                                                      
-│ └─3 Machines...                                           True                     13h    See my-cluster-0, my-cluster-1, ...  
-└─Workers                                                                                                                        
-  └─MachineDeployment/my-cluster-md-0                       True                     12h                                         
-    └─Machine/my-cluster-md-0-vr6s6-ndl64                   True                     12h                                         
-      └─BootstrapConfig - K0sWorkerConfig/my-cluster-htrzb                                                          
+NAME                                                        READY  SEVERITY  REASON  SINCE  MESSAGE
+Cluster/my-cluster                                          True                     13h
+├─ClusterInfrastructure - VSphereCluster/my-cluster         True                     13h
+├─ControlPlane - K0sControlPlane/my-cluster
+│ └─3 Machines...                                           True                     13h    See my-cluster-0, my-cluster-1, ...
+└─Workers
+  └─MachineDeployment/my-cluster-md-0                       True                     12h
+    └─Machine/my-cluster-md-0-vr6s6-ndl64                   True                     12h
+      └─BootstrapConfig - K0sWorkerConfig/my-cluster-htrzb
 ```
 
 ### Deleting the child cluster

--- a/docs/cluster-api.md
+++ b/docs/cluster-api.md
@@ -31,7 +31,7 @@ k0smotron also provides a ClusterAPI provider to manage and bootstrap cluster `M
 
 !!! note "RBAC finetuning needed with Helm deployed autoscaler"
      The Helm chart does not take into account the need for autoscaler to access the implementation specific resources in `infrastructure.cluster.x-k8s.io` group. To fix that you need to modify* the `ClusterRole` to include e.g.
-     
+
      ```yaml
      - verbs:
         - get

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ For full reference of the fields check out the [reference docs](resource-referen
 
 ## Persistence
 
-K0smotron persists data related to each Cluster. Specifically, it persists the `/var/lib/k0s` directory of the k0s controller which is the default data directory used by k0s. 
+K0smotron persists data related to each Cluster. Specifically, it persists the `/var/lib/k0s` directory of the k0s controller which is the default data directory used by k0s.
 
 The `/var/lib/k0s` directory contains essential data for the operation of the k0s controller, but its growth over time is primarily driven by the addition of small [manifest](https://docs.k0sproject.io/stable/manifests/) files. Since these manifests are lightweight and in text format, the directory tends to grow gradually and not excessively. Typically, 250 MB of space is sufficient to handle its growth, as the main additions are these small manifests, keeping the overall size manageable.
 
@@ -37,11 +37,11 @@ Refer to [k0s docs](https://docs.k0sproject.io/stable/configuration/) for a refe
 
 **Note**: Some fields will be overwritten by k0smotron. K0smotron will set the following fields:
 
-- `spec.k0sConfig.spec.api.externalAddress` will be set to the value of `spec.externalAddress` if `spec.externalAddress` is set. 
-   If not, k0smotron will use load balancer IP or try to detect `externalAddress` out of nodes IP addresses. 
+- `spec.k0sConfig.spec.api.externalAddress` will be set to the value of `spec.externalAddress` if `spec.externalAddress` is set.
+   If not, k0smotron will use load balancer IP or try to detect `externalAddress` out of nodes IP addresses.
 - `spec.k0sConfig.spec.api.port` will be set to the value of `spec.service.apiPort`.
 - `spec.k0sConfig.spec.konnectivity.port` will be set to the value of `spec.service.konnectivityPort`.
-- `spec.k0sConfig.spec.storage.kine.dataSource` will be set to the value of `spec.kineDataSourceURL` if `spec.kineDataSourceURL` is set. 
+- `spec.k0sConfig.spec.storage.kine.dataSource` will be set to the value of `spec.kineDataSourceURL` if `spec.kineDataSourceURL` is set.
   `spec.k0sConfig.spec.storage.type` will be set to `kine`.
 
 

--- a/docs/contributing/contribute-testing.md
+++ b/docs/contributing/contribute-testing.md
@@ -14,7 +14,7 @@ K0smotron uses [go test](https://pkg.go.dev/testing) as the foundation for all o
 
 - **Unit Testing**: Focused on isolated components, unit tests validate the correctness of individual functions or methods in a controlled environment, ensuring they behave as expected.
 
-- **Integration Testing**: For integration testing, k0smotron uses [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest), which provides a lightweight Kubernetes control plane with the essential components needed to test interactions between the code and Kubernetes API. This approach allows us to validate the behavior of our controllers and other Kubernetes integrations in a reproducible and efficient manner without requiring a full cluster. 
+- **Integration Testing**: For integration testing, k0smotron uses [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest), which provides a lightweight Kubernetes control plane with the essential components needed to test interactions between the code and Kubernetes API. This approach allows us to validate the behavior of our controllers and other Kubernetes integrations in a reproducible and efficient manner without requiring a full cluster.
 
   Following the best practices suggested in the [Cluster API documentation](https://cluster-api.sigs.k8s.io/developer/core/testing), integration tests are written using [**generic infrastructure providers**](https://cluster-api.sigs.k8s.io/developer/core/testing#generic-providers) rather than a specific provider. This ensures that tests remain agnostic and reusable across different infrastructures, fostering better maintainability and adaptability.
 
@@ -36,8 +36,8 @@ This will perform the following actions:
 2. Install the desired providers. Basically the same achieved by executing the command `clusterctl init ...`, by including:
   - Cluster API for core components.
   - k0smotron as controlplane and bootstrap provider.
-  - Configurable infrastructure provider (currently only docker supported). 
-  
+  - Configurable infrastructure provider (currently only docker supported).
+
 1. Execute the E2E test suite.
 
 > NOTE: This command will run the tests using docker as infrastructure provider but it is intended to make use of the configurability offered by the CAPI E2E framework to add other infrastructure providers that can be used in e2e testing.

--- a/docs/contributing/contribute-workflow.md
+++ b/docs/contributing/contribute-workflow.md
@@ -21,9 +21,9 @@ Create pull requests to contribute to [k0smotron GitHub repository](http://githu
     ``` shell
     git remote set-url --push origin no_push
     ```
-   
+
 3. Set your fork remote as a default push target:
-    
+
     ``` shell
     git push --set-upstream my_fork main
     ```
@@ -34,7 +34,7 @@ Create pull requests to contribute to [k0smotron GitHub repository](http://githu
     git remote -v
     ```
     The origin branch should have `no_push` next to it:
-    
+
     ```shell
     origin  https://github.com/k0sproject/k0smotron (fetch)
     origin  no_push (push)
@@ -119,7 +119,7 @@ For example:
 ```text
 Title that summarizes changes in 50 characters or less
 
-Description that briefly explains the problem your commit is solving. 
+Description that briefly explains the problem your commit is solving.
 Focus on why you are making this change as opposed to how.
 Are there any consequences of this change? Here you can include them.
 

--- a/docs/hcp-autoscaling.md
+++ b/docs/hcp-autoscaling.md
@@ -6,7 +6,7 @@ Horizontal Pod Autoscaler (HPA) automatically scales the number of pods in a Kub
 
 !!! warning
 
-    Due to etcd maintanance challenges, k0smotron **never** scales etcd statefulsets down, only up. 
+    Due to etcd maintanance challenges, k0smotron **never** scales etcd statefulsets down, only up.
     This means that HPA will scale up both control-plane and etcd, but scale down only control-plane pods.
 
 ## Prerequisites

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -18,7 +18,7 @@ metadata:
 spec:
   monitoring:
     enabled: true
-``` 
+```
 
 Once done, two sidecar containers are added to the control plane pods:
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -58,7 +58,7 @@ ul.video-list a .info .description {
 
 ul.video-list a .info .duration, ul.video-list a .info .duration span {
   color: #6e6e6e;
- 
+
 }
 
 ul.video-list a:hover, ul.video-list a:focus {

--- a/docs/update/update-cluster-pod.md
+++ b/docs/update/update-cluster-pod.md
@@ -5,7 +5,7 @@ the k0s version and machine names in the YAML configuration file:
 
 1. Localize the configuration of deployed k0smotron cluster in your repository. For example:
 
-    ```yaml 
+    ```yaml
     apiVersion: cluster.x-k8s.io/v1beta1
     kind: Cluster
     metadata:
@@ -98,18 +98,18 @@ with the new names to create machines for the target k0smotron version. For exam
    spec:
      version: v1.28.7+k0s.0 # new version
    ```
- 
+
 5. Update the resources:
 
    ```bash
    kubectl apply -f ./path-to-file.yaml
    ```
 
-   
+
 6. Remove the machines running the old k0smotron version:
 
    ```bash
    kubectl delete machine docker-test-0
    ```
-   
+
 The update procedure is completed, you now have the target version of k0smotron.

--- a/e2e/data/infrastructure-docker/main/bases/cluster-with-kcp.yaml
+++ b/e2e/data/infrastructure-docker/main/bases/cluster-with-kcp.yaml
@@ -56,11 +56,11 @@ spec:
           enabled: false
         network:
           controlPlaneLoadBalancing:
-            enabled: false 
+            enabled: false
     files:
     - path: /tmp/test-file-secret
-      contentFrom: 
-        secretRef: 
+      contentFrom:
+        secretRef:
           name: test-file-secret
           key: value
   machineTemplate:

--- a/e2e/data/infrastructure-docker/main/bases/machine.yaml
+++ b/e2e/data/infrastructure-docker/main/bases/machine.yaml
@@ -34,8 +34,8 @@ spec:
     - path: /tmp/test-file
       content: test-file
     - path: /tmp/test-file-secret
-      contentFrom: 
-        secretRef: 
+      contentFrom:
+        secretRef:
           name: test-file-secret
           key: value
 ---

--- a/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
+++ b/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
@@ -56,7 +56,7 @@ spec:
           enabled: false
         network:
           controlPlaneLoadBalancing:
-            enabled: false 
+            enabled: false
     files:
     - path: /wait-signal.sh
       content: |
@@ -86,7 +86,7 @@ spec:
       permissions: "0777"
     preStartCommands:
     - ./wait-signal.sh "${TOKEN}" "${SERVER}" "${NAMESPACE}"
-      
+
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/e2e/data/infrastructure-docker/main/cluster-template-webhook-k0s-not-compatible/invalid-kcp-patch.yaml
+++ b/e2e/data/infrastructure-docker/main/cluster-template-webhook-k0s-not-compatible/invalid-kcp-patch.yaml
@@ -23,11 +23,11 @@ spec:
           enabled: false
         network:
           controlPlaneLoadBalancing:
-            enabled: false 
+            enabled: false
     files:
     - path: /tmp/test-file-secret
-      contentFrom: 
-        secretRef: 
+      contentFrom:
+        secretRef:
           name: test-file-secret
           key: value
   machineTemplate:

--- a/e2e/data/infrastructure-docker/main/cluster-template-webhook-recreate-in-single-mode/invalid-kcp-patch.yaml
+++ b/e2e/data/infrastructure-docker/main/cluster-template-webhook-recreate-in-single-mode/invalid-kcp-patch.yaml
@@ -23,11 +23,11 @@ spec:
           enabled: false
         network:
           controlPlaneLoadBalancing:
-            enabled: false 
+            enabled: false
     files:
     - path: /tmp/test-file-secret
-      contentFrom: 
-        secretRef: 
+      contentFrom:
+        secretRef:
           name: test-file-secret
           key: value
   machineTemplate:

--- a/internal/controller/k0smotron.io/k0smotroncluster_monitoring_config.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_monitoring_config.go
@@ -89,10 +89,10 @@ global:
 scrape_configs:
   - job_name: "k0smotron_cluster_metrics"
     scheme: https
-    tls_config: 
+    tls_config:
       insecure_skip_verify: true
       cert_file: /var/lib/k0s/pki/admin.crt
-      key_file: /var/lib/k0s/pki/admin.key 
+      key_file: /var/lib/k0s/pki/admin.key
     static_configs:
       - targets: ["localhost:{{ .Kmc.Spec.Service.APIPort }}"]
         labels:
@@ -108,7 +108,7 @@ scrape_configs:
           k0smotron_cluster: "{{ .Kmc.Name }}"
   - job_name: "k0smotron_etcd_metrics"
     scheme: https
-    tls_config: 
+    tls_config:
       insecure_skip_verify: true
       cert_file: /var/lib/k0s/pki/etcd-ca.crt
       key_file: /var/lib/k0s/pki/etcd-ca.key

--- a/inttest/capi-docker-machine-template-update-recreate-kine/capi_docker_machine_template_update_recreate_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate-kine/capi_docker_machine_template_update_recreate_test.go
@@ -281,7 +281,7 @@ spec:
       spec:
         storage:
           type: kine
-          kine: 
+          kine:
             datasource: postgres://postgres:postgres@%s/kine?sslmode=disable
         api:
           extraArgs:
@@ -356,7 +356,7 @@ spec:
       spec:
         storage:
           type: kine
-          kine: 
+          kine:
             datasource: postgres://postgres:postgres@%s/kine?sslmode=disable
         api:
           extraArgs:

--- a/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
+++ b/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
@@ -337,9 +337,9 @@ spec:
                     readOnly: true
             volumes:
               - name: ssh-key
-                secret: 
+                secret:
                   secretName: footloose-key
-                  items: 
+                  items:
                     - key: id_rsa
                       path: id_rsa
                       mode: 0600

--- a/inttest/capi-remote-machine-template-update/capi_remote_machine_template_update_test.go
+++ b/inttest/capi-remote-machine-template-update/capi_remote_machine_template_update_test.go
@@ -364,7 +364,7 @@ metadata:
   namespace: default
 spec:
   template:
-    spec: 
+    spec:
       pool: default
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/inttest/capi-remote-machine-template/capi_remote_machine_template_test.go
+++ b/inttest/capi-remote-machine-template/capi_remote_machine_template_test.go
@@ -339,7 +339,7 @@ metadata:
   namespace: default
 spec:
   template:
-    spec: 
+    spec:
       pool: default
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/inttest/footloose-alpine/cert-manager.yaml
+++ b/inttest/footloose-alpine/cert-manager.yaml
@@ -13113,7 +13113,7 @@ spec:
           - --dynamic-serving-dns-names=cert-manager-webhook
           - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE)
           - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE).svc
-          
+
           ports:
           - name: https
             protocol: TCP

--- a/inttest/footloose-alpine/seaweedfs.yaml
+++ b/inttest/footloose-alpine/seaweedfs.yaml
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/instance: release-name
 data:
   master.toml: |-
-    
+
     # Enter any extra configuration for master.toml here.
     # It may be a multi-line string.
 ---

--- a/inttest/pvc/seaweedfs.yaml
+++ b/inttest/pvc/seaweedfs.yaml
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/instance: release-name
 data:
   master.toml: |-
-    
+
     # Enter any extra configuration for master.toml here.
     # It may be a multi-line string.
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,7 @@ nav:
       - Testing: contributing/contribute-testing.md
   - Known Limitations: known-limitations.md
   - Reference:
-    - Custom resources: 
+    - Custom resources:
       - bootstrap.cluster.x-k8s.io/v1beta1: resource-reference/bootstrap.cluster.x-k8s.io-v1beta1.md
       - controlplane.cluster.x-k8s.io/v1beta1: resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
       - infrastructure.cluster.x-k8s.io/v1beta1: resource-reference/infrastructure.cluster.x-k8s.io-v1beta1.md

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -61,7 +61,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   template:
-    spec: 
+    spec:
       pool: ${POOL_NAME:=default}
 ---
 # It is necessary to have previously created a control plane node since k0smotron does not take care of its creation.


### PR DESCRIPTION
## Motivation

When multiple contributors edited the same files, automatic formatting by editors often led to simultaneous removal of the same trailing whitespace, increasing the risk of unnecessary merge conflicts.

By proactively removing all unnecessary whitespace, we aim to reduce friction in collaboration and prevent avoidable conflicts.