### PR TITLE
Fix change-template test

### DIFF
--- a/internal/controller/controlplane/helper.go
+++ b/internal/controller/controlplane/helper.go
@@ -609,6 +609,12 @@ func normalizeK0sConfigSpec(kcp *cpv1beta1.K0sControlPlane, bootstrapConfig boot
 }
 
 func uniqueArgs(args []string) []string {
+	// DO NOT REMOVE THIS CHECK
+	// If the slice is empty, we return the slice as is to avoid any modifications.
+	// In callers, we may compare slices and in some cases it may end up in comparing empty and nil slices.
+	if len(args) == 0 {
+		return args
+	}
 	uniqueArgsSlice := []string{}
 	uniqueArgsMap := make(map[string]struct{})
 	for _, arg := range args {


### PR DESCRIPTION
The change fixes uniqueArgs func. Now we hit the usual Golang issue when we compare nil and empty slices. Still have no idea, why it happens only every other time