### PR TITLE
refactor(ci): reduce steps duplication

### DIFF
--- a/.github/workflows/capi-smoke-tests.yml
+++ b/.github/workflows/capi-smoke-tests.yml
@@ -24,15 +24,14 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Create image bundle
-        run: |
-          make release
-          make k0smotron-image-bundle.tar
+      - name: Download image bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: k0smotron-image-bundle
 
-      - name: Create kind network with IPv4 only
+      - name: Load k0smotron image bundle
         run: |
-          docker network create kind --opt com.docker.network.bridge.enable_ip_masquerade=true
-
+          docker load -i k0smotron-image-bundle.tar
 
       - name: Download kind
         uses: supplypike/setup-bin@v4
@@ -62,31 +61,28 @@ jobs:
           version: v1.4.3
           uri: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.3/clusterctl-linux-amd64
 
-      - name: Prepare cluster api components
-        run: |
-          make bootstrap-components.yaml control-plane-components.yaml infrastructure-components.yaml
-          mkdir -p v0.0.0 k0sproject-k0smotron/control-plane-k0sproject-k0smotron/ k0sproject-k0smotron/bootstrap-k0sproject-k0smotron/ k0sproject-k0smotron/infrastructure-k0sproject-k0smotron/
-
-          mv bootstrap-components.yaml v0.0.0
-          mv control-plane-components.yaml v0.0.0
-          mv infrastructure-components.yaml v0.0.0
-          mv ./hack/capi-ci/metadata.yaml v0.0.0
-
-          cp -r v0.0.0 k0sproject-k0smotron/bootstrap-k0sproject-k0smotron/
-          cp -r v0.0.0 k0sproject-k0smotron/control-plane-k0sproject-k0smotron/
-          cp -r v0.0.0 k0sproject-k0smotron/infrastructure-k0sproject-k0smotron/
-          sed -e 's#%pwd%#'`pwd`'#g' ./hack/capi-ci/config.yaml > config.yaml
+      - name: Download cluster-api components
+        uses: actions/download-artifact@v4
+        with:
+          name: cluster-api-components
+          path: .
 
       - name: Install cluster api components
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CLUSTER_TOPOLOGY=true clusterctl init --control-plane k0sproject-k0smotron --bootstrap k0sproject-k0smotron --infrastructure k0sproject-k0smotron,docker --config config.yaml
+          export CLUSTERCTL_REPOSITORY_PATH="$GITHUB_WORKSPACE"
+          CLUSTER_TOPOLOGY=true clusterctl init --control-plane k0sproject-k0smotron --bootstrap k0sproject-k0smotron --infrastructure k0sproject-k0smotron,docker --config ./hack/capi-ci/config.yaml
           kubectl wait --for=condition=available -n cert-manager deployment/cert-manager-webhook --timeout=300s
 
       - name: Install PVC provider
         run: |
           kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.24/deploy/local-path-storage.yaml
+
+      - name: Download install manifest for k0smotron
+        uses: actions/download-artifact@v4
+        with:
+          name: install-yaml
 
       - name: Run inttest for CAPI with docker provider
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,10 +2,10 @@ name: Go build
 
 on:
   push:
-    branches:
+    branches: &protected_branches
       - main
       - release-*
-    paths-ignore:
+    paths-ignore: &common_ignores
       - 'config/**'
       - 'docs/**'
       - 'mkdocs.yml'
@@ -13,20 +13,12 @@ on:
       - LICENSE
       - '**.svg'
   pull_request:
-    branches:
-      - main
-      - release-*
-    paths-ignore:
-      - 'config/**'
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - '**.md'
-      - LICENSE
-      - '**.svg'
+    branches: *protected_branches
+    paths-ignore: *common_ignores
 
 jobs:
   build:
-    name: Build
+    name: Build artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -43,33 +35,58 @@ jobs:
       - name: Build
         run: |
           make build
-
-      - name: Build image
-        run: |
-          make docker-build
-
-  generate-sbom:
-    name: "Build :: SBOM"
-    needs: [ build ]
-
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Generate SBOM
-        run: |
-          mkdir -p sbom && chmod 777 sbom
-          make sbom/spdx.json
-
-      - uses: actions/upload-artifact@v4
+      
+      - name: Upload manager binary
+        uses: actions/upload-artifact@v4
         with:
-          name: spdx.json
-          path: sbom/spdx.json
+          name: manager-binary
+          path: bin/manager
+
+      - name: Build image bundle
+        run: |
+          # Build Docker image and create image bundle
+          make k0smotron-image-bundle.tar
+
+      - name: Upload image bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: k0smotron-image-bundle
+          path: k0smotron-image-bundle.tar
+
+      - name: Build cluster api components
+        run: |
+          make bootstrap-components.yaml control-plane-components.yaml infrastructure-components.yaml
+          mkdir -p v0.0.0 k0sproject-k0smotron/control-plane-k0sproject-k0smotron/ k0sproject-k0smotron/bootstrap-k0sproject-k0smotron/ k0sproject-k0smotron/infrastructure-k0sproject-k0smotron/
+
+          mv bootstrap-components.yaml v0.0.0
+          mv control-plane-components.yaml v0.0.0
+          mv infrastructure-components.yaml v0.0.0
+          mv ./hack/capi-ci/metadata.yaml v0.0.0
+
+          cp -r v0.0.0 k0sproject-k0smotron/bootstrap-k0sproject-k0smotron/
+          cp -r v0.0.0 k0sproject-k0smotron/control-plane-k0sproject-k0smotron/
+          cp -r v0.0.0 k0sproject-k0smotron/infrastructure-k0sproject-k0smotron/
+
+      - name: Upload cluster api components
+        uses: actions/upload-artifact@v4
+        with:
+          name: cluster-api-components
+          path: |
+            config.yaml
+            k0sproject-k0smotron/
+
+      - name: Generate install yaml
+        run: |
+          make release
+
+      - name: Upload install yaml
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-yaml
+          path: install.yaml
 
   unittest:
-    name: Unit test
+    name: Unit & Integration tests
     needs: build
     runs-on: ubuntu-latest
 
@@ -85,6 +102,37 @@ jobs:
       - name: Run unit tests
         run: |
           make test
+
+  generate-sbom:
+    name: "Build :: SBOM"
+    needs: [ build ]
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Download manager binary
+        uses: actions/download-artifact@v4
+        with:
+          name: manager-binary
+          path: bin
+
+      - name: Prepare embedded binary for SBOM
+        run: |
+          mkdir -p embedded-bins/staging/linux/bin
+          cp bin/manager embedded-bins/staging/linux/bin/manager
+
+      - name: Generate SBOM
+        run: |
+          mkdir -p sbom && chmod 777 sbom
+          make sbom/spdx.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: spdx.json
+          path: sbom/spdx.json
 
   smoketest:
     name: Smoke test
@@ -115,10 +163,19 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Create image bundle
+      - name: Download image bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: k0smotron-image-bundle
+
+      - name: Download install manifest for k0smotron
+        uses: actions/download-artifact@v4
+        with:
+          name: install-yaml
+
+      - name: Load k0smotron image bundle
         run: |
-          make release
-          make k0smotron-image-bundle.tar
+          docker load -i k0smotron-image-bundle.tar
 
       - name: Run inttest
         run: |
@@ -198,11 +255,24 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Download image bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: k0smotron-image-bundle
+
+      - name: Load k0smotron image bundle
+        run: |
+          docker load -i k0smotron-image-bundle.tar
+
+      - name: Download install manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: install-yaml
+
       - name: Run e2e test
         run: |
           export TEST_NAME=Test$(echo "${{ matrix.e2e-suite }}" | awk -F'-' '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1' OFS='')
           echo "Running E2E tests with TEST_NAME=$TEST_NAME"
-          make release
           make e2e TEST_NAME="$TEST_NAME"
 
       - name: Archive artifacts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,11 @@
 name: Go lint
+
 on:
   push:
-    branches:
+    branches: &protected_branches
       - main
       - release-*
-    paths-ignore:
+    paths-ignore: &common_ignores
       - 'docs/**'
       - 'examples/**'
       - '**.md'
@@ -12,16 +13,8 @@ on:
       - '.github/workflows/publish-docs.yml'
       - 'mkdocs.yml'
   pull_request:
-    branches:
-      - main
-      - release-*
-    paths-ignore:
-      - 'docs/**'
-      - 'examples/**'
-      - '**.md'
-      - '**.svg'
-      - '.github/workflows/publish-docs.yml'
-      - 'mkdocs.yml'
+    branches: *protected_branches
+    paths-ignore: *common_ignores
 
 jobs:
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 install.yaml
 bootstrap-components.yaml
 control-plane-components.yaml
+infrastructure-components.yaml
 
 # Binaries for programs and plugins
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ vet: ## Run go vet against code.
 	go vet $(GO_PKGS)
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: $(ENVTEST)
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(GO_TEST_DIRS) -coverprofile cover.out
 
 DOCKER_TEMPLATES := e2e/data/infrastructure-docker
@@ -121,7 +121,7 @@ generate-e2e-templates-main: $(KUSTOMIZE)
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-webhook-k0s-not-compatible --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-webhook-k0s-not-compatible.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-machinedeployment --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-machinedeployment.yaml
 
-e2e: k0smotron-image-bundle.tar install.yaml kustomize generate-e2e-templates-main
+e2e: generate-e2e-templates-main
 	set +x;
 	PATH="${LOCALBIN}:${PATH}" go test -v -tags e2e -run '$(TEST_NAME)' ./e2e  \
 	    -artifacts-folder="$(ARTIFACTS)" \
@@ -132,7 +132,7 @@ e2e: k0smotron-image-bundle.tar install.yaml kustomize generate-e2e-templates-ma
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
+build:
 	go build -o bin/manager cmd/main.go
 
 .PHONY: run
@@ -143,7 +143,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build:
 	docker build \
 	  -t ${IMG} \
 	  --build-arg BUILD_IMG=golang:$(GO_VERSION) \

--- a/hack/capi-ci/config.yaml
+++ b/hack/capi-ci/config.yaml
@@ -1,10 +1,10 @@
 providers:
   - name: "k0sproject-k0smotron"
-    url: "file://%pwd%/k0sproject-k0smotron/bootstrap-k0sproject-k0smotron/v0.0.0/bootstrap-components.yaml"
+    url: "file://${CLUSTERCTL_REPOSITORY_PATH}/k0sproject-k0smotron/bootstrap-k0sproject-k0smotron/v0.0.0/bootstrap-components.yaml"
     type: "BootstrapProvider"
   - name: "k0sproject-k0smotron"
-    url: "file://%pwd%/k0sproject-k0smotron/control-plane-k0sproject-k0smotron/v0.0.0/control-plane-components.yaml"
+    url: "file://${CLUSTERCTL_REPOSITORY_PATH}/k0sproject-k0smotron/control-plane-k0sproject-k0smotron/v0.0.0/control-plane-components.yaml"
     type: "ControlPlaneProvider"
   - name: "k0sproject-k0smotron"
-    url: "file://%pwd%/k0sproject-k0smotron/infrastructure-k0sproject-k0smotron/v0.0.0/infrastructure-components.yaml"
+    url: "file://${CLUSTERCTL_REPOSITORY_PATH}/k0sproject-k0smotron/infrastructure-k0sproject-k0smotron/v0.0.0/infrastructure-components.yaml"
     type: "InfrastructureProvider"


### PR DESCRIPTION
Some CI logic was duplicated—for example, building the k0smotron binary and running unit tests across multiple jobs/steps. This PR adopts a “run it only once” approach so each CI stage executes a single time and its outputs are reused, reducing overall workflow duration.