### PR TITLE
feat: add cluster-specific naming to generated kubeconfig

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,11 +6,25 @@ run:
   tests: true
   allow-parallel-runners: true
 linters:
-  default: none 
+  default: none
   enable:
     - goheader
     - revive
   settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - $all
+            - "!internal/controller/k0smotron.io/k0smotroncluster_kubeconfig.go"
+            - "!internal/controller/k0smotron.io/k0smotroncluster_kubeconfig_test.go"
+          deny:
+            - pkg: k8s.io/client-go/tools/clientcmd
+              desc: clientcmd is only allowed in specific files
+            - pkg: k8s.io/client-go/tools/clientcmd/api
+              desc: clientcmd is only allowed in specific files
+            - pkg: k8s.io/client-go/tools/clientcmd/api/latest
+              desc: clientcmd is only allowed in specific files
     revive:
       rules:
         # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
@@ -50,7 +64,7 @@ formatters:
     generated: strict
     paths:
       - zz_generated.*\.go$
-# Warn only about new issues, not existing ones. 
+# Warn only about new issues, not existing ones.
 # TODO: Remove this filter at some point and ensure all old issues are fixed.
 issues:
   new-from-merge-base: HEAD~

--- a/internal/controller/k0smotron.io/k0smotroncluster_kubeconfig_test.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_kubeconfig_test.go
@@ -1,0 +1,76 @@
+package k0smotronio
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const sampleKubeconfig = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Q0FjZXJ0
+    server: https://k8s-default-xxx-xxx-xxx.elb.ap-northeast-1.amazonaws.com:6443
+  name: k0s
+contexts:
+- context:
+    cluster: k0s
+    user: admin
+  name: k0s
+current-context: k0s
+kind: Config
+preferences: {}
+users:
+- name: admin
+  user:
+    client-certificate-data: Q0xJRU5UQ0VSVA==
+    client-key-data: Q0xJRU5US0VZ
+`
+
+const expectedKubeconfig = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Q0FjZXJ0
+    server: https://k8s-default-xxx-xxx-xxx.elb.ap-northeast-1.amazonaws.com:6443
+  name: wl1-k0s
+contexts:
+- context:
+    cluster: wl1-k0s
+    user: wl1-admin
+  name: wl1-admin@wl1-k0s
+current-context: wl1-admin@wl1-k0s
+kind: Config
+preferences: {}
+users:
+- name: wl1-admin
+  user:
+    client-certificate-data: Q0xJRU5UQ0VSVA==
+    client-key-data: Q0xJRU5US0VZ
+`
+
+func TestRewriteKubeconfigNames(t *testing.T) {
+	out, err := rewriteKubeconfigNames(sampleKubeconfig, "wl1")
+	if err != nil {
+		t.Fatalf("rewriteKubeconfigNames returned error: %v", err)
+	}
+
+	gotCfg, err := clientcmd.Load([]byte(out))
+	if err != nil {
+		t.Fatalf("failed to load processed kubeconfig: %v", err)
+	}
+	wantCfg, err := clientcmd.Load([]byte(expectedKubeconfig))
+	if err != nil {
+		t.Fatalf("failed to load expected kubeconfig: %v", err)
+	}
+	gotBytes, err := clientcmd.Write(*gotCfg)
+	if err != nil {
+		t.Fatalf("failed to serialize got kubeconfig: %v", err)
+	}
+	wantBytes, err := clientcmd.Write(*wantCfg)
+	if err != nil {
+		t.Fatalf("failed to serialize expected kubeconfig: %v", err)
+	}
+	if string(gotBytes) != string(wantBytes) {
+		t.Fatalf("kubeconfig mismatch:\nGot:\n%s\nWant:\n%s", string(gotBytes), string(wantBytes))
+	}
+}


### PR DESCRIPTION
Fixes: #1164

`K0smotronCluster` now generates kubeconfigs with **cluster-scoped names** for clusters, contexts, and users.

* cluster: `<cluster-name>-k0s`
* user: `<cluster-name>-admin`
* context: `<cluster-name>-admin@<cluster-name>-k0s`
* current-context: `<cluster-name>-admin@<cluster-name>-k0s`

## Example change

```diff
 apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: Q0FjZXJ0
     server: https://k8s-default-xxx-xxx-xxx.elb.ap-northeast-1.amazonaws.com:6443
-  name: k0s
+  name: cluster-name-k0s
 contexts:
 - context:
-    cluster: k0s
-    user: admin
-  name: k0s
-current-context: k0s
+    cluster: cluster-name-k0s
+    user: cluster-name-admin
+  name: cluster-name-admin@cluster-name-k0s
+current-context: cluster-name-admin@cluster-name-k0s
 kind: Config
 preferences: {}
 users:
-- name: admin
+- name: cluster-name-admin
   user:
     client-certificate-data: ...
     client-key-data: ...
```

## Manual test (kind-capi-k0smotron)

A local test was performed using `make kind-capi-k0smotron` and fetching the kubeconfig with `clusterctl get kubeconfig`.

### Secret

```yaml
apiVersion: v1
data:
  value: YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMmFrTkRRV1JMWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkpNVTFFWjNsTlJFVjRUbFJGTVU1V2IxaEVWRTB4VFVSbmVFOUVSWGhPVkZreFRsWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzBGR0NrNUpUVGRhWkhBdlJrMTVTRFZJVEd4SVJWSnRjRGMxZWtsSVdWa3hZemx2YzJzdk1FUTFTVlJDWlRWWVptZ3dPVXdyVms1elRrUnNZaXRKUWtKYVlVWUtTWEJGWVhSS09FdHdWWG8xY2xndmFHaDRjVlZCSzNOWlVEbHRiR3gzSzI5VWNXRXphamxtWVRCaWFVbFlWRmhUU1c1TVJWZHZkRWxPYTA1SmFFaFRRZ3BVTUZCUFRFaEpiVEJSV25FNFNtSXJTRk00VlZkT1MyUk9SWE5OWm1Gck9UbGtURXQ2V2podk1WbGhPWGhNVm0xR2NqSmlWRGhMVVZweWJIRm5hbnBCQ2xkWFEwZzRkRXRUTUZZNVZuZE5WVVZuZWt0dVVTOUlRMlJJVldGWVZYRk5kMVpLV2t4WFNqTlJTRFoxYzBreGJXcHpObFI2ZGpCNU5tWkVRMDFRTVVVS1JWTnRielYyYzBsYWRWcFdUMDFYVERWek9UUlBPRzVpVWtneVRtRlBTVkJuTVdsVFpITnNXRFpRYm5sSlFXMW9ibmhaYmpGaU5XaFVTa3BYVlRKRFN3cG9Ta2hhTUc5NGRtTmFhVVI0WjNCbVR6Tk5RMEYzUlVGQllVNUdUVVZOZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVSkpSMEV4VldSRmQwVkNDaTkzVVVsTlFWbENRV1k0UTBGUlFYZElVVmxFVmxJd1QwSkNXVVZHUTFadWNYSlVNbkJuZVdKUlpqbENiRWx3YTA5cWIwMHZURk5KVFVFd1IwTlRjVWNLVTBsaU0wUlJSVUpEZDFWQlFUUkpRa0ZSUTFOVWVGbHdNMmhSYUVoNlUwRnhZa2RUUnpSNVRqTnZPWFJUVFhOd2FrRnBMMEk1VVVaemFYcFJXUzlhTVFvMmVsQnpOSGRKWlRKRmRHVXhlVGxZTW1ZNFJHWkhUbnBDT1VnNFIwRXpaVlI0ZUd4cVozbE9jbEpoVkZncksxa3ZNWFZYZFRkbVZHNW1hbUZSY0ZWc0NtSmhNV1Z6U1hsSE1FSnVibTVrZDNoeE0zSk9SR1kwV1ZsMmNETTRhVVF5YVVGR1kxQnZVVXhLYkVaMVZrNU1RVGhuTmtkdU5YcHRSa2wxTVRCd1pqUUtRV3QyTUZkRllsVjVWa1JQWWt0WGRHUjZUQzlSUTBFek5XdFlUa3RpVFVWeU5ucDZVR3RJZEVvM1ZUQnNaa2xRYkdSTVQzWTRPVmQ1Y1hKS1prVjZZZ28xWkdGWVYxSkVNMmhoU21WS2FHWm1hREE0ZUZWVVkwUjJhV0UzU1hkYVlXbFplalZqWkVGT1ZrbERWalZFYjFob1dIZGFRalJzYTAwMFp6UnlWMXBUQ201TldVZHpWVUpGU1ZaUVlqVnplblJMVUcxNGJVTndNblJCWm5wUFYweDJSemt5VG5sMmFub0tMUzB0TFMxRlRrUWdRMFZTVkVsR1NVTkJWRVV0TFMwdExRbz0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNzIuMTguMC40OjMwNDQzCiAgbmFtZTogZG9ja2VyLXRlc3QtazBzCmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiBkb2NrZXItdGVzdC1rMHMKICAgIHVzZXI6IGRvY2tlci10ZXN0LWFkbWluCiAgbmFtZTogZG9ja2VyLXRlc3QtYWRtaW5AZG9ja2VyLXRlc3QtazBzCmN1cnJlbnQtY29udGV4dDogZG9ja2VyLXRlc3QtYWRtaW5AZG9ja2VyLXRlc3QtazBzCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZG9ja2VyLXRlc3QtYWRtaW4KICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVJXYWtORFFXbzJaMEYzU1VKQlowbFZUbTUwU25Sc1NFa3dUa2hMYjNKYWEzUkxPRmx5TjJoaWIzVk5kMFJSV1VwTGIxcEphSFpqVGtGUlJVd0tRbEZCZDBaVVJWUk5Ra1ZIUVRGVlJVRjRUVXRoTTFacFdsaEtkVnBZVW14amVrRmxSbmN3ZVU1VVFUUk5ha0Y0VFZSVmVrMUVRbUZHZHpCNVRtcEJOQXBOYWtGNFRWUlZlazFFUW1GTlJGRjRSbnBCVmtKblRsWkNRVzlVUkc1T05XTXpVbXhpVkhCMFdWaE9NRnBZU25wTlVtdDNSbmRaUkZaUlVVUkZlRUp5Q21SWFNteGpiVFZzWkVkV2VreFhSbXRpVjJ4MVRVbEpRa2xxUVU1Q1oydHhhR3RwUnpsM01FSkJVVVZHUVVGUFEwRlJPRUZOU1VsQ1EyZExRMEZSUlVFS2NVMHdNMXBpUzBWeU5pdFZMeXRzWkdwS2JWbGhWRk50VWpaa09FRnRSVWRYYmpoUlYwVnVOMDExWmk5RVdVTkxWRXBzU2tReldXWkdlWEY2V0hSdFFRcDJhRUpHTjJ0UUwydHBiMGhKV1hKRGFtbEtPVzlYZW0xTFV6QXJaMWQxZEcxSFZrOU1TRzVHVWtGWFlUWkhZMjVaTTNaTFNVSmtVemRSVmtwSVZ5OHpDbEo0YlRCRVdsZExhamhHWkd0QlpXbEhSV1JVVVZOeVltcHhXbU5SWWxjek5HeDNZVGxWUkhaWGRuWmtVSFZKV1c1NVNtRlpRa0U0ZDBOeVpscE9ORk1LYzJ4dmFtNTBVRmQxVkVZeldWQTVRMkZIYjFCU0wzRnJXa1ZTYWtsdlN6bDBiakJsYUZsMFQyVnBhWFpGWkc5c1dEWkdRVFZxTDFORE0xazVOa1J3ZUFwWlRYTnVMMlJDYmtoUlZubGlWRmxVUjNNNFJXNVZka0ZuU3pNeFVUTXJVakZJYmxkWlpuWkxWV3BNYjA4dlRscFpkbE5zZEhnMk5XZFRSWE0xVlRsdkNqTktUVzlrVnpsU01IVkNlREJHUzBkRlRIZzNWVkZKUkVGUlFVSnZNemgzWmxSQlQwSm5UbFpJVVRoQ1FXWTRSVUpCVFVOQ1lVRjNTRkZaUkZaU01Hd0tRa0paZDBaQldVbExkMWxDUWxGVlNFRjNSVWREUTNOSFFWRlZSa0ozVFVOTlFYZEhRVEZWWkVWM1JVSXZkMUZEVFVGQmQwaFJXVVJXVWpCUFFrSlpSUXBHUVhsNVFtbElTalozVDJvM04ydzBkblJOTmtwdFVGWldSVzlMVFVJNFIwRXhWV1JKZDFGWlRVSmhRVVpEVm01eGNsUXljR2Q1WWxGbU9VSnNTWEJyQ2s5cWIwMHZURk5KVFVFd1IwTlRjVWRUU1dJelJGRkZRa04zVlVGQk5FbENRVkZDVEdWWGRVMDNhRlp5Vm5JMU9USndVMkV3UlVsTWNIZHBlamhRVVRnS01HSlhXWHBTVjNGUk1tNTJSV0ZyTVVNNGNtNDNLMnQyVEU1bFRFTkJOM3BoUzBsQ1lrWk5UMjEyV0c1VVJYcEdURGQ2VlhRemVHRTVVbXA1UWpWNk5BcFdWRVkyV0RBelNIUnRUMlZyU1VJeGVWTmFjVXRrVjNoS1ZscFZNblZhT0VsVlNYWnVNblVyZDFFMWVXOXhZbXcxVkRGSFN6VjBLMEZhWTBKV2NtUTFDbE5rVGt4M2RWTk5UVzlxYW0xM1NXeG1lSGx4Y0hsdVNHMXFMMnRKUkRGaFZtZHhhRXRCTDBKcFVtcFlVMkpKY25Wc01tMUZRVVJMVjFZemFFWldWallLYzFjemNUQk5aRGhuZEVKR1JVbDFVRFZIVjI1SldqTnFVRVo1ZWpSb1NIQjNOVkZ2YUcxQlRqaDZaSE5tZEdWMlEyZGplamt6U2pJMFRVZGFOR1pVV1FwQmRWZHFMM0ZNUlZwTmVGbE5jVTFXYTNkcVkyWk1jSFZwUWtkaWFHZDNNVGRPUzNGek1tWmhhRWx0VVZkYVowZFdaRFpNZFdwTWFRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIGNsaWVudC1rZXktZGF0YTogTFMwdExTMUNSVWRKVGlCU1UwRWdVRkpKVmtGVVJTQkxSVmt0TFMwdExRcE5TVWxGYjNkSlFrRkJTME5CVVVWQmNVMHdNMXBpUzBWeU5pdFZMeXRzWkdwS2JWbGhWRk50VWpaa09FRnRSVWRYYmpoUlYwVnVOMDExWmk5RVdVTkxDbFJLYkVwRU0xbG1Sbmx4ZWxoMGJVRjJhRUpHTjJ0UUwydHBiMGhKV1hKRGFtbEtPVzlYZW0xTFV6QXJaMWQxZEcxSFZrOU1TRzVHVWtGWFlUWkhZMjRLV1ROMlMwbENaRk0zVVZaS1NGY3ZNMUo0YlRCRVdsZExhamhHWkd0QlpXbEhSV1JVVVZOeVltcHhXbU5SWWxjek5HeDNZVGxWUkhaWGRuWmtVSFZKV1FwdWVVcGhXVUpCT0hkRGNtWmFUalJUYzJ4dmFtNTBVRmQxVkVZeldWQTVRMkZIYjFCU0wzRnJXa1ZTYWtsdlN6bDBiakJsYUZsMFQyVnBhWFpGWkc5c0NsZzJSa0UxYWk5VFF6TlpPVFpFY0hoWlRYTnVMMlJDYmtoUlZubGlWRmxVUjNNNFJXNVZka0ZuU3pNeFVUTXJVakZJYmxkWlpuWkxWV3BNYjA4dlRsb0tXWFpUYkhSNE5qVm5VMFZ6TlZVNWJ6TktUVzlrVnpsU01IVkNlREJHUzBkRlRIZzNWVkZKUkVGUlFVSkJiMGxDUVVGS1JWbGxjbWxZWkZCdlpVRXJhQXB0ZDFCSWVYZG9lWE5xU0ZwTVMwY3hSVGxYZERreVIwOVVVWGx3WWtRNVVpdEtlR1F2YnpaWWFFRjFkRk5STWtFcmVHOWtjMFE1TVRWTlFVeEJlbTV4Q2psR1VVeFlPR1pTVDBSd0wwUnFZa1U0ZWtsM1N6QTJWMHBMSzJSM1RHSXdjSE5qVEVWclNteHhkbXhsVWs5VE9XUTViVE00UW1zMlVWVlBjR0pCY0dNS05tTlBPVFExTUZwNGJsbzNZemRGWW1sR09HOXBhWGs1UW1WclJFdGhObXg2TjFnNFNFTm1NVEEzZDBoQlNsWklNVGRUV25jNU5YZExOV3BTYUd4YVV3cDZibXRJV0hSTlJqbERNRE51VUhkcmVGbHJSR2x2YUhSS1kyOHlXR3hqVTBndk1tNWFNa3RKV0VaTE5sRlNaWGxHTm5ZMVoxaG1iVVUxTlRoRFJIaExDblU0TmpKbGQwaDVOakZZV1VveGF6SldibFp1VWxKclRrZEVlSFpqUmpaMFFuTlhLM2hVYTB0WVF6UXlaWEpZWVVkQ1oyUmpUR1JsYldJME5VbG1TR2NLTnpGWVlXOTRPRU5uV1VWQk1VeElTMUJ2WkhsTVZWQnFNV001UWpkSlJVOUZRbGxUTXpGMlJFRlliVzl3ZEROb0szZHZTVUZxYkhobFIyY3dhVU5DT1FwV1YxUjNlV3hZU2s5U2VuaG9NMWsyZW5WRWJHa3hTM1lyYVZGUVRtdEVPRVZxYkdaQldrZDRPR3BsVFdvMlZUQjRkR2R2TkVsTVdWa3lTbW80WW14SkNsY3hSSFZNZUdwaU9WVnVjMHR1S3pOdVRsSjNTbXA2UTBsSmIyUXpPVXMzT1daMlkxSlNWM05tYUVwMFFWVndObEpqUlRsWVZ6aERaMWxGUVhsNWRXTUtjVmhvWTBGV1QySTVZMHMzT1haQ2VteHBLMlp2T0ROVlF6WnZWbUozVG5KU1F6ZG5VMDVoYW01VmRHZHJkRXBqUjIxVFRUVmFNMVUzVG5WNGJTOVJVd28yTjA1M2RVbDJTM0k0UVhoblprUmljamxPYkVSMVVsb3Zla3c1UjIwd1JESkJTVWxaV2xoa2ExQXllRkpEVmtkSVlYWkJaMnhzTnpFM1RqUnFjWFpUQ21rd2NWWjZZMHMzVDJ0cFUzSnlRekJrTWtKWVVVTlBheXRaU2pockszcFphM1YwWnpCNk9FTm5XVUZyTldGaVNrUkRVV2hsUW5GS1JqaG5LelV2UW5nS2JDOUxNRXh4TXpScWIzUlZWSG9yU214cFltNW5LMGROVjNJNWNVMW5RM05HVEU4d01XZGlkbFZ1WTFBMFpFY3pNamh1VjFSdlZHRndka1JCYmpaMFlRb3labk5EVVdFd1ZqaE5PRUZwUlRsTlp6SnJjamhYWW5GaWMwbGFlQ3RQYldVM1lXMUZka1IwWWpKS05YbFBaMjlYTmpSTk5VSk9iRWszUTJ4RFIwTXdDaTl1YTNGMmRWUkxhR2hZUlRKSkt6TnNRbk0yU0hkTFFtZEVUSFJ1TjNWeVprRlRjRWhNVFdsUFZsQlNUMjFuZGxRcmExUnpNQ3R3VG5VME5VRlROVFlLVVdGaFFXZ3djbkZzYVRZemNFaGlTazVpYUhCTkwwdGljalF6VlZKT2JtOW9Vbm81YW1KVk5HcEVRbmxYT1RsaVRXb3piRm81Ym1OM2FURmFibXhyVEFwVFYyRk5NWEJzT1hadE0wTnRhWHBrTTAxbVVDOXZZek5oWTFRMWRGUkdUbHBRWmt4R1NIVnljbGhyTUhWcloybFZhbmt4YzNGclNUSkpiVTFIVlROaENubHpObkJCYjBkQ1FVbDJWM1UyWkZwTFRteEJZa1ZtY0UxRk1XcHlVa0k1TDFWQ1dUQlVlQ3M1T1hGUWNGTkphbEExUXpSUVRqZDJTeTlaVWtSb1IwWUtja2xxU1M5clVWb3JVRGQ2VEZSQlNtNVZWbUZHWlhwUVpsTlZkbWsyZVZGaldtODBPRTFWY0ZWSE56QkdaR0ZJTWxGbmJVOXljMmR5WWxablVuSllZd3AwYUZSYWJXZFROVTloVG14TVJqVTFTbEJFZEZaMFFVY3pVVXR3VFc1SGRrbDRaMmRJTWpOUGQwOXdiR1pXYUZKWlluUTVDaTB0TFMwdFJVNUVJRkpUUVNCUVVrbFdRVlJGSUV0RldTMHRMUzB0Q2c9PQo=
kind: Secret
metadata:
  creationTimestamp: "2025-08-20T11:58:57Z"
  labels:
    app: k0smotron
    cluster: docker-test
    cluster.x-k8s.io/cluster-name: docker-test
    component: cluster
  name: docker-test-kubeconfig
  namespace: default
  ownerReferences:
  - apiVersion: k0smotron.io/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: Cluster
    name: docker-test
    uid: fbd01cdf-00a3-4e6d-8f3f-6b0f235cfc11
  resourceVersion: "2604"
  uid: eb0de23f-4c24-4191-8a47-0596ec6b7d6c
type: cluster.x-k8s.io/secret
```

### Decoded kubeconfig

```yaml
value: |
  apiVersion: v1
  clusters:
  - cluster:
      certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM2akNDQWRLZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJMU1EZ3lNREV4TlRFMU5Wb1hEVE0xTURneE9ERXhOVFkxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBS0FGCk5JTTdaZHAvRk15SDVITGxIRVJtcDc1eklIWVkxYzlvc2svMEQ1SVRCZTVYZmgwOUwrVk5zTkRsYitJQkJaYUYKSXBFYXRKOEtwVXo1clgvaGh4cVVBK3NZUDltbGx3K29UcWEzajlmYTBiaUlYVFhTSW5MRVdvdElOa05JaEhTQgpUMFBPTEhJbTBRWnE4SmIrSFM4VVdOS2RORXNNZmFrOTlkTEt6WjhvMVlhOXhMVm1GcjJiVDhLUVpybHFnanpBCldXQ0g4dEtTMFY5VndNVUVnektuUS9IQ2RIVWFYVXFNd1ZKWkxXSjNRSDZ1c0kxbWpzNlR6djB5NmZEQ01QMUUKRVNtbzV2c0ladVpWT01XTDVzOTRPOG5iUkgyTmFPSVBnMWlTZHNsWDZQbnlJQW1obnhZbjFiNWhUSkpXVTJDSwpoSkhaMG94dmNaaUR4Z3BmTzNNQ0F3RUFBYU5GTUVNd0RnWURWUjBQQVFIL0JBUURBZ0trTUJJR0ExVWRFd0VCCi93UUlNQVlCQWY4Q0FRQXdIUVlEVlIwT0JCWUVGQ1ZucXJUMnBneWJRZjlCbElwa09qb00vTFNJTUEwR0NTcUcKU0liM0RRRUJDd1VBQTRJQkFRQ1NUeFlwM2hRaEh6U0FxYkdTRzR5TjNvOXRTTXNwakFpL0I5UUZzaXpRWS9aMQo2elBzNHdJZTJFdGUxeTlYMmY4RGZHTnpCOUg4R0EzZVR4eGxqZ3lOclJhVFgrK1kvMXVXdTdmVG5mamFRcFVsCmJhMWVzSXlHMEJubm5kd3hxM3JORGY0WVl2cDM4aUQyaUFGY1BvUUxKbEZ1Vk5MQThnNkduNXptRkl1MTBwZjQKQWt2MFdFYlV5VkRPYktXdGR6TC9RQ0EzNWtYTktiTUVyNnp6UGtIdEo3VTBsZklQbGRMT3Y4OVd5cXJKZkV6Ygo1ZGFYV1JEM2hhSmVKaGZmaDA4eFVUY0R2aWE3SXdaYWlZejVjZEFOVklDVjVEb1hoWHdaQjRsa000ZzRyV1pTCm5NWUdzVUJFSVZQYjVzenRLUG14bUNwMnRBZnpPV0x2RzkyTnl2anoKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
      server: https://172.18.0.4:30443
    name: docker-test-k0s
  contexts:
  - context:
      cluster: docker-test-k0s
      user: docker-test-admin
    name: docker-test-admin@docker-test-k0s
  current-context: docker-test-admin@docker-test-k0s
  kind: Config
  preferences: {}
  users:
  - name: docker-test-admin
    user:
      client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURWakNDQWo2Z0F3SUJBZ0lVTm50SnRsSEkwTkhLb3Jaa3RLOFlyN2hib3VNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekFlRncweU5UQTRNakF4TVRVek1EQmFGdzB5TmpBNApNakF4TVRVek1EQmFNRFF4RnpBVkJnTlZCQW9URG5ONWMzUmxiVHB0WVhOMFpYSnpNUmt3RndZRFZRUURFeEJyCmRXSmxjbTVsZEdWekxXRmtiV2x1TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEKcU0wM1piS0VyNitVLytsZGpKbVlhVFNtUjZkOEFtRUdXbjhRV0VuN011Zi9EWUNLVEpsSkQzWWZGeXF6WHRtQQp2aEJGN2tQL2tpb0hJWXJDamlKOW9Xem1LUzArZ1d1dG1HVk9MSG5GUkFXYTZHY25ZM3ZLSUJkUzdRVkpIVy8zClJ4bTBEWldLajhGZGtBZWlHRWRUUVNyYmpxWmNRYlczNGx3YTlVRHZXdnZkUHVJWW55SmFZQkE4d0NyZlpONFMKc2xvam50UFd1VEYzWVA5Q2FHb1BSL3FrWkVSaklvSzl0bjBlaFl0T2VpaXZFZG9sWDZGQTVqL1NDM1k5NkRweApZTXNuL2RCbkhRVnliVFlUR3M4RW5VdkFnSzMxUTMrUjFIbldZZnZLVWpMb08vTlpZdlNsdHg2NWdTRXM1VTlvCjNKTW9kVzlSMHVCeDBGS0dFTHg3VVFJREFRQUJvMzh3ZlRBT0JnTlZIUThCQWY4RUJBTUNCYUF3SFFZRFZSMGwKQkJZd0ZBWUlLd1lCQlFVSEF3RUdDQ3NHQVFVRkJ3TUNNQXdHQTFVZEV3RUIvd1FDTUFBd0hRWURWUjBPQkJZRQpGQXl5QmlISjZ3T2o3N2w0dnRNNkptUFZWRW9LTUI4R0ExVWRJd1FZTUJhQUZDVm5xclQycGd5YlFmOUJsSXBrCk9qb00vTFNJTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCTGVXdU03aFZyVnI1OTJwU2EwRUlMcHdpejhQUTgKMGJXWXpSV3FRMm52RWFrMUM4cm43K2t2TE5lTENBN3phS0lCYkZNT212WG5URXpGTDd6VXQzeGE5Ump5QjV6NApWVEY2WDAzSHRtT2VrSUIxeVNacUtkV3hKVlpVMnVaOElVSXZuMnUrd1E1eW9xYmw1VDFHSzV0K0FaY0JWcmQ1ClNkTkx3dVNNTW9qam13SWxmeHlxcHluSG1qL2tJRDFhVmdxaEtBL0JpUmpYU2JJcnVsMm1FQURLV1YzaEZWVjYKc1czcTBNZDhndEJGRUl1UDVHV25JWjNqUEZ5ejRoSHB3NVFvaG1BTjh6ZHNmdGV2Q2djejkzSjI0TUdaNGZUWQpBdVdqL3FMRVpNeFlNcU1Wa3dqY2ZMcHVpQkdiaGd3MTdOS3FzMmZhaEltUVdaZ0dWZDZMdWpMaQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
      client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBcU0wM1piS0VyNitVLytsZGpKbVlhVFNtUjZkOEFtRUdXbjhRV0VuN011Zi9EWUNLClRKbEpEM1lmRnlxelh0bUF2aEJGN2tQL2tpb0hJWXJDamlKOW9Xem1LUzArZ1d1dG1HVk9MSG5GUkFXYTZHY24KWTN2S0lCZFM3UVZKSFcvM1J4bTBEWldLajhGZGtBZWlHRWRUUVNyYmpxWmNRYlczNGx3YTlVRHZXdnZkUHVJWQpueUphWUJBOHdDcmZaTjRTc2xvam50UFd1VEYzWVA5Q2FHb1BSL3FrWkVSaklvSzl0bjBlaFl0T2VpaXZFZG9sClg2RkE1ai9TQzNZOTZEcHhZTXNuL2RCbkhRVnliVFlUR3M4RW5VdkFnSzMxUTMrUjFIbldZZnZLVWpMb08vTloKWXZTbHR4NjVnU0VzNVU5bzNKTW9kVzlSMHVCeDBGS0dFTHg3VVFJREFRQUJBb0lCQUFKRVllcmlYZFBvZUEraAptd1BIeXdoeXNqSFpMS0cxRTlXdDkyR09UUXlwYkQ5UitKeGQvbzZYaEF1dFNRMkEreG9kc0Q5MTVNQUxBem5xCjlGUUxYOGZST0RwL0RqYkU4ekl3SzA2V0pLK2R3TGIwcHNjTEVrSmxxdmxlUk9TOWQ5bTM4Qms2UVVPcGJBcGMKNmNPOTQ1MFp4blo3YzdFYmlGOG9paXk5QmVrREthNmx6N1g4SENmMTA3d0hBSlZIMTdTWnc5NXdLNWpSaGxaUwp6bmtIWHRNRjlDMDNuUHdreFlrRGlvaHRKY28yWGxjU0gvMm5aMktJWEZLNlFSZXlGNnY1Z1hmbUU1NThDRHhLCnU4NjJld0h5NjFYWUoxazJWblZuUlJrTkdEeHZjRjZ0QnNXK3hUa0tYQzQyZXJYYUdCZ2RjTGRlbWI0NUlmSGcKNzFYYW94OENnWUVBMUxIS1BvZHlMVVBqMWM5QjdJRU9FQllTMzF2REFYbW9wdDNoK3dvSUFqbHhlR2cwaUNCOQpWV1R3eWxYSk9SenhoM1k2enVEbGkxS3YraVFQTmtEOEVqbGZBWkd4OGplTWo2VTB4dGdvNElMWVkySmo4YmxJClcxRHVMeGpiOVVuc0tuKzNuTlJ3Smp6Q0lJb2QzOUs3OWZ2Y1JSV3NmaEp0QVVwNlJjRTlYVzhDZ1lFQXl5dWMKcVhoY0FWT2I5Y0s3OXZCemxpK2ZvODNVQzZvVmJ3TnJSQzdnU05ham5VdGdrdEpjR21TTTVaM1U3TnV4bS9RUwo2N053dUl2S3I4QXhnZkRicjlObER1Ulovekw5R20wRDJBSUlZWlhka1AyeFJDVkdIYXZBZ2xsNzE3TjRqcXZTCmkwcVZ6Y0s3T2tpU3JyQzBkMkJYUUNPaytZSjhrK3pZa3V0ZzB6OENnWUFrNWFiSkRDUWhlQnFKRjhnKzUvQngKbC9LMExxMzRqb3RVVHorSmxpYm5nK0dNV3I5cU1nQ3NGTE8wMWdidlVuY1A0ZEczMjhuV1RvVGFwdkRBbjZ0YQoyZnNDUWEwVjhNOEFpRTlNZzJrcjhXYnFic0laeCtPbWU3YW1FdkR0YjJKNXlPZ29XNjRNNUJObEk3Q2xDR0MwCi9ua3F2dVRLaGhYRTJJKzNsQnM2SHdLQmdETHRuN3VyZkFTcEhMTWlPVlBST21ndlQra1RzMCtwTnU0NUFTNTYKUWFhQWgwcnFsaTYzcEhiSk5iaHBNL0ticjQzVVJObm9oUno5amJVNGpEQnlXOTliTWozbFo5bmN3aTFabmxrTApTV2FNMXBsOXZtM0NtaXpkM01mUC9vYzNhY1Q1dFRGTlpQZkxGSHVyclhrMHVrZ2lVankxc3FrSTJJbU1HVTNhCnlzNnBBb0dCQUl2V3U2ZFpLTmxBYkVmcE1FMWpyUkI5L1VCWTBUeCs5OXFQcFNJalA1QzRQTjd2Sy9ZUkRoR0YKcklqSS9rUVorUDd6TFRBSm5VVmFGZXpQZlNVdmk2eVFjWm80OE1VcFVHNzBGZGFIMlFnbU9yc2dyYlZnUnJYYwp0aFRabWdTNU9hTmxMRjU1SlBEdFZ0QUczUUtwTW5Hdkl4Z2dIMjNPd09wbGZWaFJZYnQ5Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
```

### Verification

```bash
$ clusterctl get kubeconfig docker-test > kubeconfig
$ export KUBECONFIG=./kubeconfig
$ kubectl get po -A
NAMESPACE     NAME                             READY   STATUS              RESTARTS   AGE
kube-system   coredns-5c8cb48c4-b6hvq          0/1     Running             0          5m26s
kube-system   konnectivity-agent-llbp8         0/1     ContainerCreating   0          4m8s
kube-system   kube-proxy-bl4pj                 1/1     Running             0          4m8s
kube-system   kube-router-vzjdh                1/1     Running             0          4m8s
kube-system   metrics-server-7db8586f5-fs68g   0/1     Running             0          5m19s
```

The generated kubeconfig matches the expected format, and access with `kubectl` works as intended.

## Impact

* On reconciliation, existing kubeconfigs are updated so that only the **keys (context/user names)** change.
* **No behavioral impact**: credentials, cluster endpoints, and permissions remain the same; no downtime.
