### PR TITLE
Improve garbage collection for external clusters

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -231,6 +231,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/k0smotron.io/k0smotroncluster_entrypoint.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_entrypoint.go
@@ -26,7 +26,6 @@ import (
 	kcontrollerutil "github.com/k0sproject/k0smotron/internal/controller/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -64,7 +63,7 @@ func (scope *kmcScope) generateEntrypointCM(kmc *km.Cluster) (v1.ConfigMap, erro
 		},
 	}
 
-	_ = ctrl.SetControllerReference(kmc, &cm, scope.client.Scheme())
+	_ = kcontrollerutil.SetExternalOwnerReference(kmc, &cm, scope.client.Scheme(), scope.externalOwner)
 	return cm, nil
 }
 

--- a/internal/controller/k0smotron.io/k0smotroncluster_etcd.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_etcd.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/util/secret"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -100,7 +99,7 @@ func (scope *kmcScope) reconcileEtcdSvc(ctx context.Context, kmc *km.Cluster) er
 		},
 	}
 
-	_ = ctrl.SetControllerReference(kmc, &svc, scope.client.Scheme())
+	_ = kcontrollerutil.SetExternalOwnerReference(kmc, &svc, scope.client.Scheme(), scope.externalOwner)
 
 	return scope.client.Patch(ctx, &svc, client.Apply, patchOpts...)
 }
@@ -182,7 +181,7 @@ func (scope *kmcScope) reconcileEtcdDefragJob(ctx context.Context, kmc *km.Clust
 		},
 	}
 
-	_ = ctrl.SetControllerReference(kmc, &cronJob, scope.client.Scheme())
+	_ = kcontrollerutil.SetExternalOwnerReference(kmc, &cronJob, scope.client.Scheme(), scope.externalOwner)
 
 	return scope.client.Patch(ctx, &cronJob, client.Apply, patchOpts...)
 }
@@ -213,7 +212,7 @@ func (scope *kmcScope) reconcileEtcdStatefulSet(ctx context.Context, kmc *km.Clu
 
 	statefulSet := generateEtcdStatefulSet(kmc, foundStatefulSet, desiredReplicas)
 
-	_ = ctrl.SetControllerReference(kmc, &statefulSet, scope.client.Scheme())
+	_ = kcontrollerutil.SetExternalOwnerReference(kmc, &statefulSet, scope.client.Scheme(), scope.externalOwner)
 
 	return scope.client.Patch(ctx, &statefulSet, client.Apply, patchOpts...)
 }

--- a/internal/controller/k0smotron.io/k0smotroncluster_kubeconfig.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_kubeconfig.go
@@ -61,7 +61,8 @@ func (scope *kmcScope) reconcileKubeConfigSecret(ctx context.Context, management
 		Type:       clusterv1.ClusterSecretType,
 	}
 
-	_ = ctrl.SetControllerReference(kmc, &secret, managementClusterClient.Scheme())
+	// workload cluster kubeconfig is always created in the management cluster so we set k0smotron cluster as owner
+	_ = ctrl.SetControllerReference(kmc, &secret, scope.client.Scheme())
 
 	return managementClusterClient.Patch(ctx, &secret, client.Apply, patchOpts...)
 }

--- a/internal/controller/k0smotron.io/k0smotroncluster_monitoring_config.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_monitoring_config.go
@@ -25,7 +25,6 @@ import (
 	kcontrollerutil "github.com/k0sproject/k0smotron/internal/controller/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -66,7 +65,7 @@ func (scope *kmcScope) generateMonitoringCM(kmc *km.Cluster) (v1.ConfigMap, erro
 		},
 	}
 
-	_ = ctrl.SetControllerReference(kmc, &cm, scope.client.Scheme())
+	_ = kcontrollerutil.SetExternalOwnerReference(kmc, &cm, scope.client.Scheme(), scope.externalOwner)
 	return cm, nil
 }
 

--- a/internal/controller/k0smotron.io/k0smotroncluster_service.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_service.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -136,7 +135,7 @@ func (scope *kmcScope) reconcileServices(ctx context.Context, kmc *km.Cluster) e
 	logger.Info("Reconciling services")
 	svc := generateService(kmc)
 
-	_ = ctrl.SetControllerReference(kmc, &svc, scope.client.Scheme())
+	_ = util.SetExternalOwnerReference(kmc, &svc, scope.client.Scheme(), scope.externalOwner)
 
 	if err := scope.client.Patch(ctx, &svc, client.Apply, patchOpts...); err != nil {
 		return err

--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -25,6 +25,7 @@ import (
 
 	km "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
 	"github.com/k0sproject/k0smotron/internal/controller/util"
+	kcontrollerutil "github.com/k0sproject/k0smotron/internal/controller/util"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 
@@ -34,7 +35,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/controller"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -284,7 +284,7 @@ data:
 `,
 		},
 	}
-	_ = ctrl.SetControllerReference(kmc, cm, scope.client.Scheme())
+	_ = kcontrollerutil.SetExternalOwnerReference(kmc, cm, scope.client.Scheme(), scope.externalOwner)
 
 	if err := scope.client.Patch(context.Background(), cm, client.Apply, patchOpts...); err != nil {
 		return apps.StatefulSet{}, err
@@ -304,7 +304,7 @@ data:
 		ReadOnly:  true,
 	})
 
-	_ = ctrl.SetControllerReference(kmc, &statefulSet, scope.client.Scheme())
+	_ = kcontrollerutil.SetExternalOwnerReference(kmc, &statefulSet, scope.client.Scheme(), scope.externalOwner)
 
 	// We calculate the hash of the statefulset template and store it in the annotations
 	// This is used to detect changes in the statefulset template and trigger a rollout

--- a/internal/controller/util/ownerreference.go
+++ b/internal/controller/util/ownerreference.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EnsureExternalOwner ensures that an external owner resource with the given name exists in the specified namespace.
+// An external owner resource is used as owner reference for objects that are not in the management cluster. That way
+// we can garbage collect all objects related to a k0smotron cluster deployed in an external cluster by deleting the
+// external owner.
+func EnsureExternalOwner(ctx context.Context, name, namespace string, c client.Client) (client.Object, error) {
+	externalOwner, err := GetExternalOwner(ctx, name, namespace, c)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      getExternalOwnerName(name),
+					Namespace: namespace,
+				},
+				Data: map[string]string{},
+			}
+
+			err := c.Create(ctx, cm)
+			if err != nil {
+				return nil, err
+			}
+
+			return cm, nil
+		}
+		return nil, err
+	}
+
+	return externalOwner, nil
+}
+
+// GetExternalOwner retrieves the external owner used in the external cluster for the given name and namespace.
+func GetExternalOwner(ctx context.Context, name, namespace string, c client.Client) (client.Object, error) {
+	externalOwner := &corev1.ConfigMap{}
+	err := c.Get(ctx, client.ObjectKey{Name: getExternalOwnerName(name), Namespace: namespace}, externalOwner)
+	if err != nil {
+		return nil, err
+	}
+
+	return externalOwner, nil
+}
+
+// SetExternalOwnerReference sets the owner reference for the given object trying to use the external owner if provided.
+func SetExternalOwnerReference(owner metav1.Object, controlled metav1.Object, scheme *runtime.Scheme, externalOwner metav1.Object) error {
+	if externalOwner != nil {
+		return ctrl.SetControllerReference(externalOwner, controlled, scheme)
+	}
+
+	return ctrl.SetControllerReference(owner, controlled, scheme)
+}
+
+// GetExternalControllerRef returns the controller reference for the given external owner object.
+func GetExternalControllerRef(externalOwner metav1.Object) *metav1.OwnerReference {
+	return metav1.NewControllerRef(externalOwner, corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+}
+
+func getExternalOwnerName(kmcName string) string {
+	return kmcName + "-root-owner"
+}


### PR DESCRIPTION
Use a configmap as ownerreference for external resources related to the workload cluster deployed when cluster is out of management cluster (controlplane pods run on an external cluster). Current owner references using main K0smotron Cluster or K0smotronControlPlane cannot be used for background deletions because the child resources lives on the external cluster. Created the configmap for own the child objects in this case and use it as "unique point" enabling background deletion.