### PR TITLE
 Enhance the OpenStack CAPO documentation

### DIFF
--- a/docs/capi-openstack.md
+++ b/docs/capi-openstack.md
@@ -4,25 +4,38 @@ This example demonstrates how k0smotron can be used with CAPO (Cluster API Provi
 
 ## Preparations
 
-Before starting this example, ensure that you have met the [general prerequisites](capi-examples.md#prerequisites).
+Before proceeding, ensure your management cluster meets the following requirements:
 
-To initialize the management cluster with OpenStack infrastrcture provider you can run:
+### Management Cluster Requirements
 
-```
-clusterctl init --infrastructure openstack
-```
+- A healthy Kubernetes cluster with cluster-admin access
+- Cluster API initialized with the OpenStack infrastructure provider:
+  ```bash
+  clusterctl init --infrastructure openstack
+  ```
+- k0smotron installed (docs: https://docs.k0smotron.io/stable/install/#software-prerequisites)
+- A LoadBalancer implementation for the hosted control plane service (OpenStack CCM/Octavia or MetalLB)
+- OpenStack Cinder CSI driver installed and operational on the management cluster with:
+  - Valid OpenStack credentials secret in the `kube-system` namespace
+  - A default StorageClass configured (if you install the openstack-cinder-csi helm chart, then the StorageClass will be created for you)
 
 For more details on Cluster API Provider OpenStack see it's [docs](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/tree/main/docs).
 
-### OpenStack Credentials
+### Architecture Considerations
 
-To be able to provision the OpenStack provider infrastructre, you will need to setup your OpenStack tenant credentials.
+The hosted control plane etcd persistent volume resides on the management cluster, requiring functional storage. The workload cluster receives its own Cloud Controller Manager (CCM) and Container Storage Interface (CSI) drivers through k0s configuration extensions.
+
+## Setup Instructions
+
+### 1. OpenStack Credentials
+
+To be able to provision the OpenStack provider infrastructure, you will need to setup your OpenStack credentials.
 
 **Get the openstack Clouds.yaml**
 
 Download your “OpenStack clouds.yaml file” (Login -> API Access -> Download OpenStack clouds.yaml file)
 
-Add "verify: false" to your clouds.yaml to avoir having the "x509: certificate signed by unknown authority" error.
+Add "verify: false" to your clouds.yaml to avoid having the "x509: certificate signed by unknown authority" error.
 
 More information here : [cluster-api-troubleshooting](https://cluster-api-openstack.sigs.k8s.io/topics/troubleshooting)
 
@@ -44,139 +57,318 @@ clouds:
     identity_api_version: 3
 ```
 
-Convert it to base64 to be used in the k0smotron yaml file. See an example below:
+Create a base64-encoded OpenStack configuration file. The cluster manifest expects a secret named `openstack-cloud-config` in the `default` namespace with a `clouds.yaml` key.
 
-```sh
-Y2xvdWRzOgogIG9wZW5zdGFjazoKICAgIGluc2VjdXJlOiB0cnVlCiAgICB2ZXJpZnk6IGZhbHNlCiAgICBhdXRoOgogICAgICBhdXRoX3VybDogaHR0cHM6Ly9rZXlzdG9uZS55b3VyQ2xvdWQueW91ck9yZ2FuaXphdGlvbi5uZXQvCiAgICAgIHVzZXJuYW1lOiAieW91clVzZXJOYW1lIgogICAgICBwcm9qZWN0X2lkOiAieW91clByb2plY3RJRCIKICAgICAgcHJvamVjdF9uYW1lOiAieW91clByb2plY3ROYW1lIgogICAgICBwcm9qZWN0X2RvbWFpbl9pZDogInlvdXJQcm9qZWN0SUQiCiAgICAgIHVzZXJfZG9tYWluX25hbWU6ICJEZWZhdWx0IgogICAgICBwYXNzd29yZDogWW91clBhc3NXb3JkCiAgICByZWdpb25fbmFtZTogIlJlZ2lvbk9uZSIKICAgIGludGVyZmFjZTogInB1YmxpYyIKICAgIGlkZW50aXR5X2FwaV92ZXJzaW9uOiAz
+Encode your `clouds.yaml` file:
+
+**Linux:**
+```bash
+base64 -w0 clouds.yaml > clouds.yaml.b64
 ```
 
-## Creating a child cluster
+**macOS:**
+```bash
+base64 -b0 clouds.yaml > clouds.yaml.b64
+```
 
-Once all the controllers are up and running, you can apply the cluster manifests containing the specifications of the cluster you want to provision.
+Copy the single-line contents of `clouds.yaml.b64` and paste it into the cluster manifest at `data.clouds.yaml` (replace `<BASE64_OF_clouds.yaml_HERE>`).
 
-Here is an example:
+### 2. Install Cinder CSI on Management Cluster
+
+Create the OpenStack credentials secret and install the Cinder CSI driver:
+
+```bash
+kubectl -n kube-system create secret generic openstack-cloud-config \
+  --from-file=clouds.yaml=./clouds.yaml
+
+helm repo add openstack https://kubernetes.github.io/cloud-provider-openstack/
+helm repo update
+
+helm upgrade --install openstack-csi openstack/openstack-cinder-csi -n kube-system \
+  --set secret.enabled=true \
+  --set secret.create=false \
+  --set secret.name=openstack-cloud-config \
+  --set storageClass.enabled=true \
+  --set storageClass.name=cinder-sc \
+  --set storageClass.defaultClass=true \
+  --set storageClass.allowVolumeExpansion=true \
+  --set csi.plugin.nodePlugin.kubeletDir=/var/lib/k0s/kubelet
+```
+
+*Note: If you are using a kubernetes based management cluster, you will need to set the `csi.plugin.nodePlugin.kubeletDir` to `/var/lib/kubelet`.*
+
+Verify the installation:
+
+```bash
+kubectl get csidriver
+kubectl -n kube-system get pods | grep -i cinder
+kubectl get sc
+```
+
+
+### 3. Configure and Deploy the Cluster
+
+Before applying the manifests, update the following fields:
+
+- Update network, router, and subnet names in `OpenStackCluster` and `OpenStackMachineTemplate` to match your OpenStack environment
+- Insert the base64-encoded `clouds.yaml` content prepared in step 1
+
+#### Hosted Control Plane Cluster Manifests (`openstack-hcp-cluster.yaml`)
+
 ```yaml
-# k0smotron-cluster-with-capo.yaml
 apiVersion: v1
 data:
-  cacert: Cg==
-  clouds.yaml: Y2xvdWRzOgogIG9wZW5zdGFjazoKICAgIGluc2VjdXJlOiB0cnVlCiAgICB2ZXJpZnk6IGZhbHNlCiAgICBhdXRoOgogICAgICBhdXRoX3VybDogaHR0cHM6Ly9rZXlzdG9uZS5pYy1wcy5zc2wubWlyYW50aXMubmV0LwogICAgICB1c2VybmFtZTogIndzb3VhbGhpIgogICAgICBwcm9qZWN0X2lkOiA0MTUzYmFiNDQ2YmY0NDRmYjkzMDY3NzEzODIwNDc1NgogICAgICBwcm9qZWN0X25hbWU6ICJ3c291YWxoaSIKICAgICAgcHJvamVjdF9kb21haW5faWQ6IDQxNTNiYWI0NDZiZjQ0NGZiOTMwNjc3MTM4MjA0NzU2CiAgICAgIHVzZXJfZG9tYWluX25hbWU6ICJEZWZhdWx0IgogICAgICBwYXNzd29yZDogWW91clBhc3NXb3JkCiAgICByZWdpb25fbmFtZTogIlJlZ2lvbk9uZSIKICAgIGludGVyZmFjZTogInB1YmxpYyIKICAgIGlkZW50aXR5X2FwaV92ZXJzaW9uOiAzCg==
+  cacert: null
+  clouds.yaml: <BASE64_OF_clouds.yaml_HERE>
 kind: Secret
 metadata:
-  labels:
-    clusterctl.cluster.x-k8s.io/move: "true"
-  name: my-cluster-cloud-config
+  name: openstack-cloud-config
   namespace: default
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: cluster-openstack
+  name: openstack-hcp-cluster
+  namespace: default
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks:
-      - 192.168.0.0/16
+      cidrBlocks: [10.244.0.0/16] # Adjust accordingly
     serviceDomain: cluster.local
+    services:
+      cidrBlocks: [10.96.0.0/12] # Adjust accordingly
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-    kind: K0smotronControlPlane # This tells that k0smotron should create the controlplane
-    name: cluster-openstack
+    kind: K0smotronControlPlane
+    name: openstack-hcp-cluster-cp
+    namespace: default
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
-    kind: OpenStackCluster  # This tells that CAPO should create the the worker
-    name: cluster-openstack
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: OpenStackCluster
+    name: openstack-hcp-cluster
+    namespace: default
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-kind: K0smotronControlPlane # This is the config for the controlplane
-metadata:
-  name: cluster-openstack
-spec:
-  version: v1.27.2-k0s.0
-  persistence:
-    type: emptyDir
-  service:
-    type: LoadBalancer
-    apiPort: 6443
-    konnectivityPort: 8132
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackCluster
 metadata:
-  name: cluster-openstack
+  name: openstack-hcp-cluster
   namespace: default
-  annotations:
-    cluster.x-k8s.io/managed-by: k0smotron # This marks the base infra to be self managed. The value of the annotation is irrelevant, as long as there is a value.
 spec:
-  cloudName: openstack
+  externalNetwork:
+    filter:
+      name: public
   identityRef:
-    kind: Secret
-    name: cluster-openstack-cloud-config
-  nodeCidr: a.b.c.d/24 #This node cidr corresponds to a network already created in OpenStack
+    cloudName: openstack
+    name: openstack-cloud-config
+    region: RegionOne
+  network:
+    filter:
+      name: k8s-clusterapi-cluster-default-capo-test
+  router:
+    filter:
+      name: k8s-clusterapi-cluster-default-capo-test
+  subnets:
+  - filter:
+      name: k8s-clusterapi-cluster-default-capo-test
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: cluster-openstack
-  name: cluster-openstack-worker-vms
+  name: openstack-hcp-cluster-md
   namespace: default
 spec:
-  clusterName: cluster-openstack
+  clusterName: openstack-hcp-cluster
   replicas: 1
   selector:
-    matchLabels: {}
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: openstack-hcp-cluster
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: cluster-openstack
+        cluster.x-k8s.io/cluster-name: openstack-hcp-cluster
     spec:
-      clusterName: cluster-openstack
-      failureDomain: nova
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: K0sWorkerConfigTemplate
-          name: cluster-openstack-machine-config
+          name: openstack-hcp-cluster-machine-config
+          namespace: default
+      clusterName: openstack-hcp-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: cluster-openstack-worker-vm-template
+        name: openstack-hcp-cluster-mt
+        namespace: default
+      version: v1.32.6
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-kind: K0sWorkerConfigTemplate
-metadata:
-  name: cluster-openstack-machine-config
-spec:
-  template:
-    spec:
-      version: v1.27.2+k0s.0
-      args:
-        - --enable-cloud-provider
-        - --kubelet-extra-args="--cloud-provider=external"
-      # More details of the worker configuration can be set here
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
-  name: cluster-openstack-worker-vm-template
+  name: openstack-hcp-cluster-mt
   namespace: default
 spec:
   template:
     spec:
-      cloudName: openstack
-      flavor: dev.cfg # your flavor
+      flavor: m1.medium
       identityRef:
-        kind: Secret
-        name: cluster-openstack-cloud-config
-      image: ubuntu-20.04 # your image
-      sshKeyName: rsa2 # your RSA key name
+        cloudName: openstack
+        name: openstack-cloud-config
+        region: RegionOne
+      image:
+        filter:
+          name: ubuntu-22.04-x86_64
       ports:
       - network:
-          id: YourNetworkID # this corresponds to the network with the cidr provided above a.b.c.d/24
+          filter:
+            name: k8s-clusterapi-cluster-default-capo-test
+      securityGroups:
+      - filter:
+          name: default
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: K0smotronControlPlane
+metadata:
+  name: openstack-hcp-cluster-cp
+  namespace: default
+spec:
+  controllerPlaneFlags:
+  - --enable-cloud-provider=true
+  - --debug=true
+  etcd:
+    autoDeletePVCs: false
+    image: quay.io/k0sproject/etcd:v3.5.13
+    persistence:
+      size: 1Gi
+  image: ghcr.io/k0sproject/k0s:v1.32.6-k0s.0  # pinned GHCR tag to avoid rate limits with docker hub
+  k0sConfig:
+    apiVersion: k0s.k0sproject.io/v1beta1
+    kind: ClusterConfig
+    metadata:
+      name: k0s
+    spec:
+      extensions:
+        helm:
+          charts:
+          - chartname: openstack/openstack-cloud-controller-manager
+            name: openstack-ccm
+            namespace: kube-system
+            order: 1
+            values: |
+              secret:
+                enabled: true
+                name: openstack-cloud-config
+                create: false
+              nodeSelector: null
+              tolerations:
+                - key: node.cloudprovider.kubernetes.io/uninitialized
+                  value: "true"
+                  effect: NoSchedule
+                - key: node-role.kubernetes.io/control-plane
+                  effect: NoSchedule
+                - key: node-role.kubernetes.io/master
+                  effect: NoSchedule
+              extraEnv:
+                - name: OS_CCM_REGIONAL
+                  value: "true"
+              extraVolumes:
+                - name: flexvolume-dir
+                  hostPath:
+                    path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+                - name: k8s-certs
+                  hostPath:
+                    path: /etc/kubernetes/pki
+              extraVolumeMounts:
+                - name: flexvolume-dir
+                  mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+                  readOnly: true
+                - name: k8s-certs
+                  mountPath: /etc/kubernetes/pki
+                  readOnly: true
+            version: 2.31.1
+          - chartname: openstack/openstack-cinder-csi
+            name: openstack-csi
+            namespace: kube-system
+            order: 2
+            values: |
+              storageClass:
+                enabled: true
+                delete:
+                  isDefault: true
+                  allowVolumeExpansion: true
+                retain:
+                  isDefault: false
+                  allowVolumeExpansion: false
+              secret:
+                enabled: true
+                name: openstack-cloud-config
+                create: false   # set to true if you want the chart to create the Secret in workload cluster
+              csi:
+                plugin:
+                  nodePlugin:
+                    kubeletDir: /var/lib/k0s/kubelet   # workload cluster nodes run k0s
+            version: 2.31.2
+          repositories:
+          - name: openstack
+            url: https://kubernetes.github.io/cloud-provider-openstack/
+      network:
+        calico:
+          mode: vxlan
+        clusterDomain: cluster.local
+        podCIDR: 10.244.0.0/16
+        provider: calico
+        serviceCIDR: 10.96.0.0/12
+  replicas: 1
+  service:
+    apiPort: 6443
+    konnectivityPort: 8132
+    type: LoadBalancer
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: K0sWorkerConfigTemplate
+metadata:
+  name: openstack-hcp-cluster-machine-config
+  namespace: default
+spec:
+  template:
+    spec:
+      args:
+      - --enable-cloud-provider
+      - --kubelet-extra-args="--cloud-provider=external"
+      - --debug=true
+      version: v1.32.6+k0s.0
 ```
 
-Once complete, your command line should display output similar to this:
+## Deployment and Monitoring
+
+### Deploy the Cluster
+
+Apply the cluster manifest:
+
+```bash
+kubectl apply -f openstack-hcp-cluster.yaml
+```
+
+### Monitor Cluster Creation
+
+Monitor the hosted control plane deployment:
+
+```bash
+# Watch etcd PVC binding and pod startup on the management cluster
+kubectl -n default get pvc
+kubectl -n default get pods -w
+
+# Verify the LoadBalancer service receives an external IP address
+kubectl -n default get svc openstack-hcp-cluster-cp -o wide
+```
+
+Expected components in the `default` namespace:
+- `kmc-openstack-hcp-cluster-etcd-0` pod in Running state
+- `kmc-openstack-hcp-cluster-0` (controller) pod in Running state  
+- `openstack-hcp-cluster-cp` service (LoadBalancer) with an assigned EXTERNAL-IP
+
+The control plane will become operational within a few minutes, followed by worker nodes joining the cluster.
+
+### Verify Cluster Creation
 
 ```shell
 kubectl get cluster,machine,kmc
@@ -201,13 +393,52 @@ Cluster/cluster3                                                         True   
       └─BootstrapConfig - K0sWorkerConfig/cluster3-machine-config-tlg78
 ```
 
+## Post-Deployment Configuration
 
-## Accessing the workload cluster
+### Retrieve Workload Cluster Access
 
-To access the child cluster we can get the kubeconfig for it with `clusterctl get kubeconfig cluster-openstack`. You can then save it to disk and/or import to your favorite tooling like [Lens](https://k8slens.dev).
+Obtain the workload cluster kubeconfig:
 
+```bash
+kubectl -n default get secrets | grep -i kubeconfig
+kubectl -n default get secret <NAME> -o jsonpath='{.data.value}' | base64 -d > workload-cluster.kubeconfig
+```
+
+You can also save it to disk and/or import to your favorite tooling like [Lens](https://k8slens.dev).
+
+### Configure OpenStack Integration
+
+If the cluster manifest has `create: false` for secrets (as shown in the example), manually create the OpenStack credentials in the workload cluster:
+
+```bash
+kubectl --kubeconfig workload-cluster.kubeconfig -n kube-system create secret generic openstack-cloud-config \
+  --from-file=clouds.yaml=./clouds.yaml
+```
+
+### Accessing the workload cluster
+
+Validate the workload cluster components and nodes:
+
+```bash
+kubectl --kubeconfig workload-cluster.kubeconfig get nodes
+kubectl --kubeconfig workload-cluster.kubeconfig get pods -n kube-system
+```
 ## Deleting the cluster
 
-For cluster deletion, do **NOT** use `kubectl delete -f k0smotron-cluster-with-capo.yaml` as that can result in orphan resources. Instead, delete the top level `Cluster` object. This approach ensures the proper sequence in deleting all child resources, effectively avoid orphan resources.
+For cluster deletion, do **NOT** use `kubectl delete -f openstack-hcp-cluster.yaml` as that can result in orphan resources. Instead, delete the top level `Cluster` object. This approach ensures the proper sequence in deleting all child resources, effectively avoiding orphan resources.
 
-To do that, you can use the command `kubectl delete cluster cluster-openstack`
+To do that, you can use the command `kubectl delete cluster openstack-hcp-cluster`
+
+## Conclusion
+
+This guide demonstrated how to deploy a Kubernetes cluster on OpenStack using a hosted control plane architecture with Cluster API Provider OpenStack (CAPO) and k0smotron. The key benefits of this approach include:
+
+### Advantages of Hosted Control Planes
+
+- **Resource Efficiency**: Control plane components run as pods on the management cluster, reducing the infrastructure footprint
+- **Simplified Management**: Centralized control plane management across multiple workload clusters
+- **High Availability**: Leverages the management cluster's infrastructure for control plane resilience
+- **Cost Optimization**: Eliminates the need for dedicated control plane nodes in each workload cluster
+
+For production deployments, ensure proper sizing of the management cluster to handle multiple hosted control planes and their associated workloads.
+


### PR DESCRIPTION
The current doc lacked a few details that are required to actually provision a cluster using the hosted control plane architecture. This PR improves the doc to provide detailed steps to do this.