### PR TITLE
Revert "add probe timeout (#1147)"

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -314,14 +314,12 @@ data:
 		InitialDelaySeconds: 60,
 		PeriodSeconds:       10,
 		FailureThreshold:    15,
-		TimeoutSeconds:      5,
 		ProbeHandler:        v1.ProbeHandler{Exec: &v1.ExecAction{Command: []string{"k0s", "status"}}},
 	}
 	statefulSet.Spec.Template.Spec.Containers[0].LivenessProbe = &v1.Probe{
 		InitialDelaySeconds: 90,
 		FailureThreshold:    10,
 		PeriodSeconds:       10,
-		TimeoutSeconds:      5,
 		ProbeHandler:        v1.ProbeHandler{Exec: &v1.ExecAction{Command: []string{"k0s", "status"}}},
 	}
 


### PR DESCRIPTION
This reverts commit f457b7a9d0b3aaa93af2e6a05bbb3f8c783b3353.

It's a bit tricky to understand why increasing the timeout can actually make the probe fail more often. My understanding is that by raising the timeout we relax the probe’s restrictions, which means more probes succeed overall. But this also leads to more frequent transitions between Ready and NotReady compared to the previous setup. Best option is to dive in the case when probes could need to increase the timeout and why