### PR TITLE
Use kubebuilder's webhook readiness probe

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"os"
 
-	"k8s.io/client-go/discovery"
-
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -32,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -202,6 +201,7 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+	_ = mgr.AddReadyzCheck("webhook-check", mgr.GetWebhookServer().StartedChecker())
 
 	restConfig, err := ctrl.GetConfig()
 	if err != nil {

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,7 @@ spec:
     matchLabels:
       control-plane: controller-manager
   replicas: 1
+  minReadySeconds: 5
   template:
     metadata:
       annotations:

--- a/inttest/util/util.go
+++ b/inttest/util/util.go
@@ -74,6 +74,11 @@ func InstallK0smotronOperator(ctx context.Context, kc *kubernetes.Clientset, rc 
 		return fmt.Errorf("failed to install k0smotron operator: %w", err)
 	}
 
+	err = WaitForDeployment(ctx, kc, "k0smotron-controller-manager", "k0smotron")
+	if err != nil {
+		return fmt.Errorf("failed to wait for k0smotron operator deployment: %w", err)
+	}
+
 	err = InstallWebhookChecker(ctx, kc, rc)
 	if err != nil {
 		return fmt.Errorf("failed to install webhook checker: %w", err)
@@ -107,10 +112,18 @@ func InstallStableK0smotronOperator(ctx context.Context, kc *kubernetes.Clientse
 		return err
 	}
 
-	if err := InstallWebhookChecker(ctx, kc, rc); err != nil {
+	err = WaitForDeployment(ctx, kc, "k0smotron-controller-manager", "k0smotron")
+	if err != nil {
+		return fmt.Errorf("failed to wait for k0smotron operator deployment: %w", err)
+	}
+
+	err = InstallWebhookChecker(ctx, kc, rc)
+	if err != nil {
 		return fmt.Errorf("failed to install webhook checker: %w", err)
 	}
-	if err := WaitForPod(ctx, kc, "webhook-checker", "k0smotron"); err != nil {
+
+	err = WaitForPod(ctx, kc, "webhook-checker", "k0smotron")
+	if err != nil {
 		return fmt.Errorf("failed to wait for k0smotron webhook: %w", err)
 	}
 


### PR DESCRIPTION
Adding webhook health check and minReadySeconds to the manifest.
Fixes #1222 