### PR TITLE
Fix CAPI control-plane deployment

### DIFF
--- a/config/clusterapi/controlplane/manager_config_patch.yaml
+++ b/config/clusterapi/controlplane/manager_config_patch.yaml
@@ -15,4 +15,9 @@ spec:
         k0smotron-provider: control-plane
     spec:
       containers:
-      - name: manager
+        - name: manager
+          args:
+            - "--health-probe-bind-address=:8081"
+            - "--diagnostics-address=127.0.0.1:8080"
+            - "--leader-elect"
+            - "--enable-controller=control-plane"


### PR DESCRIPTION
Currently it enables all controllers and causes race conditions

Fixes #1211