### PR TITLE
Refactor: make `K0sControllerConfig` immutable

### DIFF
--- a/api/controlplane/v1beta1/k0s_types.go
+++ b/api/controlplane/v1beta1/k0s_types.go
@@ -56,6 +56,9 @@ const (
 	// the K0sControlPlane for k0s node resources cleanup: controlnode and etcdmember. This annotation will prevent
 	// Machine controller from deleting the Machine before the cleanup is done.
 	K0ControlPlanePreTerminateHookCleanupAnnotation = clusterv1.PreTerminateDeleteHookAnnotationPrefix + "/kcp-cleanup"
+
+	// MachineK0sConfigAnnotation is the annotation used to store the K0sConfigSpec on the Machine object.
+	MachineK0sConfigAnnotation = "k0s.controlplane.cluster.x-k8s.io/k0s-config"
 )
 
 // +kubebuilder:object:root=true

--- a/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
@@ -79,6 +79,7 @@ func Test_createCPInstallCmd(t *testing.T) {
 						},
 					},
 				},
+				installArgs: []string{"--enable-worker", "--labels=k0sproject.io/foo=bar"},
 				ConfigOwner: &bsutil.ConfigOwner{Unstructured: &unstructured.Unstructured{Object: map[string]interface{}{
 					"metadata": map[string]interface{}{"name": "test-machine"},
 				}}},


### PR DESCRIPTION
fix #1143

### Changes

- Make `K0sControllerConfig` immutable, which means that values related to that resource will not change ever once it is created by the controlplane controller. This way, we dont need to know "external" modifications made by other controllers (bootstrap controller) when comparing if the control plane node needs a rollout because the k0sfig has changed, which improves maintainability.
- Introduce a new `k0s.controlplane.cluster.x-k8s.io/k0s-config` annotation to store k0s config to boot the machine
- Use cmp.Diff for comparisons between kcp k0s config and machine k0s config
- Keep backward compatibility: Deprecate the old comparison method that takes into account changes made outside the controlplane controller