### PR TITLE
Fix etcd cert secrets owner in remote host cluster mode

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_certs.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_certs.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/secret"
 
 	km "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
+	kutil "github.com/k0sproject/k0smotron/internal/controller/util"
 )
 
 func (scope *kmcScope) ensureEtcdCertificates(ctx context.Context, kmc *km.Cluster) error {
@@ -114,5 +115,10 @@ func (scope *kmcScope) ensureEtcdCertificates(ctx context.Context, kmc *km.Clust
 		}
 	}
 
-	return etcdCerts.SaveGenerated(ctx, scope.client, util.ObjectKey(kmc), *metav1.NewControllerRef(kmc, km.GroupVersion.WithKind("Cluster")))
+	owner := *metav1.NewControllerRef(kmc, km.GroupVersion.WithKind("Cluster"))
+	if scope.externalOwner != nil {
+		owner = *kutil.GetExternalControllerRef(scope.externalOwner)
+	}
+
+	return etcdCerts.SaveGenerated(ctx, scope.client, util.ObjectKey(kmc), owner)
 }


### PR DESCRIPTION
Fixes #1259

## Problem
  - `ensureEtcdCertificates` saved `*-etcd-server`, `*-etcd-peer`, and `*-apiserver-etcd-client` Secrets with an ownerReference pointing to `k0smotron.io/Cluster`.

## Result
The following Secrets are now correctly created and persist in the hosting cluster:
- `<cluster>-etcd-server`
- `<cluster>-etcd-peer`
- `<cluster>-apiserver-etcd-client`

Verified with:

`kubectl -n mgmt get secret` showing the three Secrets present
<img width="1828" height="308" alt="CleanShot 2025-10-22 at 15 07 49@2x" src="https://github.com/user-attachments/assets/e3ac4e13-a415-47ad-8db6-8a505c39ec42" />
pod is running on external cluster
<img width="3000" height="48" alt="CleanShot 2025-10-22 at 15 08 20@2x" src="https://github.com/user-attachments/assets/354ba992-1f93-4150-bce8-78659669159c" />
<img width="1078" height="130" alt="CleanShot 2025-10-22 at 15 08 44@2x" src="https://github.com/user-attachments/assets/5b007de4-ac0f-41f7-99bb-1ddfa4a5164f" />

Cluster status progressing to Provisioned with ControlPlaneReady = True
<img width="3016" height="44" alt="CleanShot 2025-10-22 at 15 12 47@2x" src="https://github.com/user-attachments/assets/66d700f8-2378-4deb-88e2-b60da3b67a58" />


cluster works good 👍 
<img width="1442" height="306" alt="CleanShot 2025-10-22 at 15 11 33@2x" src="https://github.com/user-attachments/assets/0cc8c43e-330e-4c15-ab43-f3d9f9e5d288" />
