### PR TITLE
Concurrency level configuration

### DIFF
--- a/internal/controller/bootstrap/controlplane_bootstrap_controller.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/secret"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/go-logr/logr"
@@ -599,8 +600,10 @@ func createTokenSecret(tokenID, tokenSecret string) *corev1.Secret {
 	}
 }
 
-func (c *ControlPlaneController) SetupWithManager(mgr ctrl.Manager) error {
+// SetupWithManager sets up the controller with the Manager.
+func (c *ControlPlaneController) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&bootstrapv1.K0sControllerConfig{}).
 		Complete(c)
 }

--- a/internal/controller/bootstrap/providerid_controller.go
+++ b/internal/controller/bootstrap/providerid_controller.go
@@ -14,6 +14,7 @@ import (
 	capiutil "sigs.k8s.io/cluster-api/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	k0smoutil "github.com/k0sproject/k0smotron/internal/controller/util"
@@ -91,7 +92,8 @@ func (p *ProviderIDController) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{}, nil
 }
 
-func (p *ProviderIDController) SetupWithManager(mgr ctrl.Manager) error {
+// SetupWithManager sets up the controller with the Manager.
+func (p *ProviderIDController) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	apiResources, err := p.ClientSet.Discovery().ServerResourcesForGroupVersion(clusterv1.GroupVersion.String())
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
@@ -102,6 +104,7 @@ func (p *ProviderIDController) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&clusterv1.Machine{}).
 		Complete(p)
 }

--- a/internal/controller/bootstrap/worker_bootstrap_controller.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/secret"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/go-logr/logr"
@@ -438,8 +439,10 @@ func createInstallCmd(scope *Scope) string {
 	return strings.Join(installCmd, " ")
 }
 
-func (r *Controller) SetupWithManager(mgr ctrl.Manager) error {
+// SetupWithManager sets up the controller with the Manager.
+func (r *Controller) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&bootstrapv1.K0sWorkerConfig{}).
 		Complete(r)
 }

--- a/internal/controller/controlplane/k0s_controlplane_controller.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"strings"
 	"time"
 
@@ -1012,9 +1013,10 @@ func (c *K0sController) createFRPToken(ctx context.Context, cluster *clusterv1.C
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (c *K0sController) SetupWithManager(mgr ctrl.Manager) error {
+func (c *K0sController) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	// Check if the cluster.x-k8s.io API is available and if not, don't try to watch for Machine objects
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&cpv1beta1.K0sControlPlane{}).
 		Owns(&clusterv1.Machine{}).
 		Complete(c)

--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -697,8 +698,9 @@ func (c *K0smotronController) getKmcScope(ctx context.Context, kcp *cpv1beta1.K0
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (c *K0smotronController) SetupWithManager(mgr ctrl.Manager) error {
+func (c *K0smotronController) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&cpv1beta1.K0smotronControlPlane{}).
 		Owns(&kapi.Cluster{}, builder.MatchEveryOwner).
 		Complete(c)

--- a/internal/controller/infrastructure/cluster_controller.go
+++ b/internal/controller/infrastructure/cluster_controller.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	infrastructure "github.com/k0sproject/k0smotron/api/infrastructure/v1beta1"
@@ -62,8 +63,10 @@ func (r *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (re
 	return ctrl.Result{}, nil
 }
 
-func (r *ClusterController) SetupWithManager(mgr ctrl.Manager) error {
+// SetupWithManager sets up the controller with the Manager.
+func (r *ClusterController) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&infrastructure.RemoteCluster{}).
 		Complete(r)
 }

--- a/internal/controller/infrastructure/remote_machine_controller.go
+++ b/internal/controller/infrastructure/remote_machine_controller.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -415,8 +416,10 @@ func (r *RemoteMachineController) getBootstrapData(ctx context.Context, machine 
 	return secret.Data["value"], nil
 }
 
-func (r *RemoteMachineController) SetupWithManager(mgr ctrl.Manager) error {
+// SetupWithManager sets up the controller with the Manager.
+func (r *RemoteMachineController) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&infrastructure.RemoteMachine{}).
 		Complete(r)
 }

--- a/internal/controller/k0smotron.io/jointokenrequest_controller.go
+++ b/internal/controller/k0smotron.io/jointokenrequest_controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -201,8 +202,9 @@ func (r *JoinTokenRequestReconciler) updateStatus(ctx context.Context, jtr km.Jo
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *JoinTokenRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *JoinTokenRequestReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&km.JoinTokenRequest{}).
 		Complete(r)
 }

--- a/internal/controller/k0smotron.io/k0smotroncluster_controller.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_controller.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/secret"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -345,8 +346,9 @@ func (r *ClusterReconciler) getKmcScope(ctx context.Context, kmc *km.Cluster) (*
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&km.Cluster{}).
 		Owns(&apps.StatefulSet{}).
 		Complete(r)


### PR DESCRIPTION
Currently we use the default value, which is 1. It can be slow in cases like big RemoteCluster deletion (running k0s reset one-by-one), provisioning several clusters, etc.

The new default is 5, which is the same as AWS infra provider uses. It looks reasonable