### PR TITLE
Use working dir for join token

### DIFF
--- a/api/bootstrap/v1beta1/k0s_types.go
+++ b/api/bootstrap/v1beta1/k0s_types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/k0sproject/k0smotron/internal/provisioner"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"path/filepath"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -118,6 +119,9 @@ type K0sWorkerConfigSpec struct {
 	// SecretMetadata specifies metadata (labels and annotations) to be propagated to the bootstrap Secret.
 	// +kubebuilder:validation:Optional
 	SecretMetadata *SecretMetadata `json:"secretMetadata,omitempty"`
+
+	// WorkingDir specifies the working directory where k0smotron will place its files.
+	WorkingDir string `json:"workingDir,omitempty"`
 }
 
 // SecretMetadata defines metadata to be propagated to the bootstrap Secret
@@ -294,6 +298,9 @@ type K0sConfigSpec struct {
 	// See: https://cloudinit.readthedocs.io/en/latest/reference/merging.html
 	// +kubebuilder:validation:Optional
 	CustomUserDataRef *ContentSource `json:"customUserDataRef,omitempty"`
+
+	// WorkingDir specifies the working directory where k0smotron will place its files.
+	WorkingDir string `json:"workingDir,omitempty"`
 }
 
 type TunnelingSpec struct {
@@ -339,4 +346,36 @@ type IgnitionSpec struct {
 	// with the generated one. The format follows Butane spec: https://coreos.github.io/butane/
 	// +kubebuilder:validation:Optional
 	AdditionalConfig string `json:"additionalConfig,omitempty"`
+}
+
+// GetK0sConfigPath returns the full path to the k0s.yaml file in the working directory.
+func (kcs *K0sConfigSpec) GetK0sConfigPath() string {
+	if kcs.WorkingDir == "" {
+		return "/etc/k0s.yaml"
+	}
+	return filepath.Join(kcs.WorkingDir, "k0s.yaml")
+}
+
+// GetJoinTokenPath returns the full path to the k0s token file in the working directory.
+func (kcs *K0sConfigSpec) GetJoinTokenPath() string {
+	if kcs.WorkingDir == "" {
+		return "/etc/k0s.token"
+	}
+	return filepath.Join(kcs.WorkingDir, "k0s.token")
+}
+
+// GetK0sConfigPath returns the full path to the k0s.yaml file in the working directory.
+func (k *K0sWorkerConfig) GetK0sConfigPath() string {
+	if k.Spec.WorkingDir == "" {
+		return "/etc/k0s.yaml"
+	}
+	return filepath.Join(k.Spec.WorkingDir, "k0s.yaml")
+}
+
+// GetJoinTokenPath returns the full path to the k0s token file in the working directory.
+func (k *K0sWorkerConfig) GetJoinTokenPath() string {
+	if k.Spec.WorkingDir == "" {
+		return "/etc/k0s.token"
+	}
+	return filepath.Join(k.Spec.WorkingDir, "k0s.token")
 }

--- a/api/infrastructure/v1beta1/remote_machine_types.go
+++ b/api/infrastructure/v1beta1/remote_machine_types.go
@@ -74,6 +74,7 @@ type RemoteMachineSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	CommandsAsScript bool `json:"commandsAsScript,omitempty"`
+
 	// WorkingDir is the directory to use as working directory when connecting to the remote machine.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="/etc/k0smotron"

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -253,6 +253,10 @@ spec:
                   Make sure the version is compatible with the k0s version running on the control plane.
                   For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
                 type: string
+              workingDir:
+                description: WorkingDir specifies the working directory where k0smotron
+                  will place its files.
+                type: string
             type: object
           status:
             properties:

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -220,6 +220,10 @@ spec:
                   Make sure the version is compatible with the k0s version running on the control plane.
                   For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
                 type: string
+              workingDir:
+                description: WorkingDir specifies the working directory where k0smotron
+                  will place its files.
+                type: string
             type: object
           status:
             properties:

--- a/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/clusterapi/bootstrap/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -245,6 +245,10 @@ spec:
                           Make sure the version is compatible with the k0s version running on the control plane.
                           For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
                         type: string
+                      workingDir:
+                        description: WorkingDir specifies the working directory where
+                          k0smotron will place its files.
+                        type: string
                     type: object
                 type: object
             type: object

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -289,6 +289,10 @@ spec:
                       UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
                       By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
                     type: boolean
+                  workingDir:
+                    description: WorkingDir specifies the working directory where
+                      k0smotron will place its files.
+                    type: string
                 type: object
               machineTemplate:
                 properties:

--- a/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
+++ b/config/clusterapi/controlplane/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
@@ -272,6 +272,10 @@ spec:
                               UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
                               By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
                             type: boolean
+                          workingDir:
+                            description: WorkingDir specifies the working directory
+                              where k0smotron will place its files.
+                            type: string
                         type: object
                       machineTemplate:
                         description: |-

--- a/config/crd/bases/bootstrap/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/crd/bases/bootstrap/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -253,6 +253,10 @@ spec:
                   Make sure the version is compatible with the k0s version running on the control plane.
                   For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
                 type: string
+              workingDir:
+                description: WorkingDir specifies the working directory where k0smotron
+                  will place its files.
+                type: string
             type: object
           status:
             properties:

--- a/config/crd/bases/bootstrap/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/crd/bases/bootstrap/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -220,6 +220,10 @@ spec:
                   Make sure the version is compatible with the k0s version running on the control plane.
                   For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
                 type: string
+              workingDir:
+                description: WorkingDir specifies the working directory where k0smotron
+                  will place its files.
+                type: string
             type: object
           status:
             properties:

--- a/config/crd/bases/bootstrap/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -245,6 +245,10 @@ spec:
                           Make sure the version is compatible with the k0s version running on the control plane.
                           For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
                         type: string
+                      workingDir:
+                        description: WorkingDir specifies the working directory where
+                          k0smotron will place its files.
+                        type: string
                     type: object
                 type: object
             type: object

--- a/config/crd/bases/controlplane/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/bases/controlplane/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -289,6 +289,10 @@ spec:
                       UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
                       By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
                     type: boolean
+                  workingDir:
+                    description: WorkingDir specifies the working directory where
+                      k0smotron will place its files.
+                    type: string
                 type: object
               machineTemplate:
                 properties:

--- a/config/crd/bases/controlplane/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
@@ -272,6 +272,10 @@ spec:
                               UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
                               By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.
                             type: boolean
+                          workingDir:
+                            description: WorkingDir specifies the working directory
+                              where k0smotron will place its files.
+                            type: string
                         type: object
                       machineTemplate:
                         description: |-

--- a/docs/resource-reference/bootstrap.cluster.x-k8s.io-v1beta1.md
+++ b/docs/resource-reference/bootstrap.cluster.x-k8s.io-v1beta1.md
@@ -198,6 +198,13 @@ Make sure the version is compatible with the k0s version running on the control 
 For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>workingDir</b></td>
+        <td>string</td>
+        <td>
+          WorkingDir specifies the working directory where k0smotron will place its files.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -853,6 +860,13 @@ By default, k0smotron will use Machine name as a node name. If true, it will pic
 a version field of the Machine object. If it's empty, the latest version is used.
 Make sure the version is compatible with the k0s version running on the control plane.
 For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>workingDir</b></td>
+        <td>string</td>
+        <td>
+          WorkingDir specifies the working directory where k0smotron will place its files.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1583,6 +1597,13 @@ By default, k0smotron will use Machine name as a node name. If true, it will pic
 a version field of the Machine object. If it's empty, the latest version is used.
 Make sure the version is compatible with the k0s version running on the control plane.
 For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>workingDir</b></td>
+        <td>string</td>
+        <td>
+          WorkingDir specifies the working directory where k0smotron will place its files.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
+++ b/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
@@ -254,6 +254,13 @@ By default, k0smotron will use Machine name as a node name. If true, it will pic
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>workingDir</b></td>
+        <td>string</td>
+        <td>
+          WorkingDir specifies the working directory where k0smotron will place its files.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -1367,6 +1374,13 @@ If empty, k0smotron will use /usr/local/bin, which is the default install path u
 By default, k0smotron will use Machine name as a node name. If true, it will pick it from `hostname` command output.<br/>
           <br/>
             <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>workingDir</b></td>
+        <td>string</td>
+        <td>
+          WorkingDir specifies the working directory where k0smotron will place its files.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/controller/bootstrap/worker_bootstrap_controller.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller.go
@@ -234,7 +234,7 @@ func (r *Controller) generateBootstrapDataForWorker(ctx context.Context, log log
 
 	files := []provisioner.File{
 		{
-			Path:        "/etc/k0s.token",
+			Path:        scope.Config.GetJoinTokenPath(),
 			Permissions: "0600",
 			Content:     token,
 		},
@@ -433,7 +433,7 @@ func (r *Controller) setClientScope(ctx context.Context, cluster *clusterv1.Clus
 func createInstallCmd(scope *Scope) string {
 	k0sPath := filepath.Join(scope.Config.Spec.K0sInstallDir, "k0s")
 	installCmd := []string{
-		fmt.Sprintf("%s install worker --token-file /etc/k0s.token", k0sPath),
+		fmt.Sprintf("%s install worker --token-file %s", k0sPath, scope.Config.GetJoinTokenPath()),
 	}
 	installCmd = append(installCmd, mergeExtraArgs(scope.Config.Spec.Args, scope.ConfigOwner, true, scope.Config.Spec.UseSystemHostname)...)
 	return strings.Join(installCmd, " ")

--- a/internal/controller/controlplane/helper.go
+++ b/internal/controller/controlplane/helper.go
@@ -701,7 +701,7 @@ func minVersion(machines collections.Machines) (string, error) {
 func removeArgsGeneratedInControllerConfigReconcile(bootstrapConfig *bootstrapv1.K0sControllerConfig) {
 	argsWithoutConfig := []string{}
 	for _, arg := range bootstrapConfig.Spec.K0sConfigSpec.Args {
-		if arg != "--config" && arg != "/etc/k0s.yaml" {
+		if arg != "--config" && arg != bootstrapConfig.Spec.GetK0sConfigPath() {
 			argsWithoutConfig = append(argsWithoutConfig, arg)
 		}
 	}

--- a/internal/controller/infrastructure/ssh_provisioner.go
+++ b/internal/controller/infrastructure/ssh_provisioner.go
@@ -28,11 +28,12 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	api "github.com/k0sproject/k0smotron/api/infrastructure/v1beta1"
-	"github.com/k0sproject/k0smotron/internal/provisioner"
 	rig "github.com/k0sproject/rig/v2"
 	rigssh "github.com/k0sproject/rig/v2/protocol/ssh"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	api "github.com/k0sproject/k0smotron/api/infrastructure/v1beta1"
+	"github.com/k0sproject/k0smotron/internal/provisioner"
 )
 
 var regex = regexp.MustCompile(`--kubelet-root-dir[ =](/[/a-zA-Z0-9_-]+)+`)


### PR DESCRIPTION
Override some file paths in RemoteMachine provisioner to use the working dir, eg `/etc/k0s.token` -> `/my/working/dir/k0s.token`
