### PR TITLE
Add failureDomain to cluster configuration

### DIFF
--- a/docs/capi-hetzner.md
+++ b/docs/capi-hetzner.md
@@ -6,10 +6,10 @@ This example demonstrates how k0smotron can be used with CAPH (Cluster API Provi
 
 Before starting this example, ensure that you have met the [general prerequisites](capi-examples.md#prerequisites).
 
-To initialize the management cluster with Hetzner infrastrcture provider you can run:
+To initialize the management cluster with Hetzner infrastructure provider you can run:
 
 ```
-clusterctl init --core cluster-api --infrastructure hetzner
+clusterctl init --core cluster-api:v1.11.2 --infrastructure hetzner:v1.0.7
 ```
 
 For more details on Cluster API Provider Hetzner see it's [docs](https://github.com/syself/cluster-api-provider-hetzner/tree/main/docs).


### PR DESCRIPTION
fixes the issue with CAPH v1.0.7 / CAPI v1.11.2 / k0smotron v1.9.0

https://cluster-api-gcp.sigs.k8s.io/topics/machine-locations

`{"level":"ERROR","file":"controller/controller.go:324","message":"Reconciler error","controller":"hcloudmachine","controllerGroup":"infrastructure.cluster.x-k8s.io","controllerKind":"HCloudMachine","HCloudMachine":{"name":"hetzner-test-md-qsx6t-mn9mx","namespace":"default"},"namespace":"default","name":"hetzner-test-md-qsx6t-mn9mx","reconcileID":"f57554a7-0d92-4bb3-9b75-c6c485cac047","error":"failed to reconcile server for HCloudMachine default/hetzner-test-md-qsx6t-mn9mx: failed to get failure domain: error no failure domain available","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:324\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:222"}`