### PR TITLE
Add nightly e2e suite against aws infra provider

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,149 @@
+name: Nightly E2E Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'  # Runs every day at 02:00 UTC
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+  
+jobs:
+  # TODO: instead of building the image for the nightly tests, we could cuse the one published to ttl.sh. If the image no longer exists there,
+  # the tests would fail, which is acceptable, meaning that the development version has already been tested against AWS the night before.
+  build:
+    name: Build artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # for `git describe`
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: |
+          make build
+
+      - name: Upload manager binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: manager-binary
+          path: bin/manager
+
+      - name: Build image bundle
+        run: |
+          # Build Docker image and create image bundle
+          make k0smotron-image-bundle.tar
+
+      - name: Publish the previously built imageto ttl.sh with the commit sha
+        run: |
+          docker tag quay.io/k0sproject/k0smotron:latest ttl.sh/k0smotron-${{ github.sha }}
+          docker push ttl.sh/k0smotron-${{ github.sha }}
+
+      - name: Upload image bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: k0smotron-image-bundle
+          path: k0smotron-image-bundle.tar
+
+      - name: Build cluster api components
+        run: |
+          make bootstrap-components.yaml control-plane-components.yaml infrastructure-components.yaml
+          mkdir -p v0.0.0 k0sproject-k0smotron/control-plane-k0sproject-k0smotron/ k0sproject-k0smotron/bootstrap-k0sproject-k0smotron/ k0sproject-k0smotron/infrastructure-k0sproject-k0smotron/
+
+          mv bootstrap-components.yaml v0.0.0
+          mv control-plane-components.yaml v0.0.0
+          mv infrastructure-components.yaml v0.0.0
+          mv ./hack/capi-ci/metadata.yaml v0.0.0
+
+          cp -r v0.0.0 k0sproject-k0smotron/bootstrap-k0sproject-k0smotron/
+          cp -r v0.0.0 k0sproject-k0smotron/control-plane-k0sproject-k0smotron/
+          cp -r v0.0.0 k0sproject-k0smotron/infrastructure-k0sproject-k0smotron/
+
+      - name: Upload cluster api components
+        uses: actions/upload-artifact@v4
+        with:
+          name: cluster-api-components
+          path: |
+            config.yaml
+            k0sproject-k0smotron/
+
+      - name: Generate install yaml
+        run: |
+          make release
+
+      - name: Upload install yaml
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-yaml
+          path: install.yaml
+
+  e2e:
+    name: E2E test
+    needs: [build]
+    runs-on: oracle-vm-16cpu-64gb-x86-64
+    strategy:
+      fail-fast: false
+      matrix:
+        e2e-suite:
+          - TestIgnitionProvisioning
+    env:
+      SSH_KEY_NAME: ${{ secrets.SSH_KEY_NAME }}
+      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download image bundle
+        uses: actions/download-artifact@v5
+        with:
+          name: k0smotron-image-bundle
+
+      - name: Load k0smotron image bundle
+        run: |
+          docker load -i k0smotron-image-bundle.tar
+
+      - name: Download install manifest
+        uses: actions/download-artifact@v5
+        with:
+          name: install-yaml
+
+      - name: Download clusterawsadm
+        uses: supplypike/setup-bin@v4
+        with:
+          name: clusterawsadm
+          version: v2.9.2
+          uri: https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v2.9.2/clusterawsadm-linux-amd64
+
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Run e2e test
+        run: |
+          export AWS_B64ENCODED_CREDENTIALS=$(clusterawsadm bootstrap credentials encode-as-profile)
+          make e2e TEST_NAME="${{ matrix.e2e-suite }}" E2E_CONF_FILE="$(pwd)/e2e/config/aws.yaml"
+
+      - name: Archive artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4.3.2
+        with:
+          name: e2e-artifacts
+          path: _artifacts
+          if-no-files-found: ignore

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -242,16 +242,16 @@ jobs:
       fail-fast: false
       matrix:
         e2e-suite:
-          - controlplane-remediation
-          - controlplane-conditions
-          - workload-cluster-inplace-upgrade
-          - workload-cluster-recreate-upgrade
-          - workload-cluster-recreate-delete-first-upgrade
-          - admission-webhook-recreate-strategy-in-single-mode
-          - admission-webhook-k0s-not-compatible
-          - k0smotron-upgrade
-          - machinedeployment
-          - remote-hosted-control-planes
+          - TestControlplaneRemediation
+          - TestControlplaneConditions
+          - TestWorkloadClusterInplaceUpgrade
+          - TestWorkloadClusterRecreateUpgrade
+          - TestWorkloadClusterRecreateDeleteFirstUpgrade
+          - TestAdmissionWebhookRecreateStrategyInSingleMode
+          - TestAdmissionWebhookK0sNotCompatible
+          - TestK0smotronUpgrade
+          - TestMachineDeployment
+          - TestRemoteHostedControlPlanes
 
     steps:
       - name: Check out code into the Go module directory
@@ -278,9 +278,7 @@ jobs:
 
       - name: Run e2e test
         run: |
-          export TEST_NAME=Test$(echo "${{ matrix.e2e-suite }}" | awk -F'-' '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1' OFS='')
-          echo "Running E2E tests with TEST_NAME=$TEST_NAME"
-          make e2e TEST_NAME="$TEST_NAME"
+          make e2e TEST_NAME="${{ matrix.e2e-suite }}"
 
       - name: Archive artifacts
         if: failure()

--- a/e2e/config/aws.yaml
+++ b/e2e/config/aws.yaml
@@ -160,3 +160,5 @@ intervals:
   machinedeployment/wait-cluster: ["20m", "10s"]
   machinedeployment/wait-control-plane: ["20m", "10s"]
   machinedeployment/wait-delete-cluster: ["20m", "10s"]
+  ignition/wait-controllers: ["10m", "10s"]
+  ignition/wait-machines: ["10m", "10s"]

--- a/e2e/data/infrastructure-aws/cluster-template-ignition.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition.yaml
@@ -36,7 +36,7 @@ spec:
         id: ami-00d12617b68dbc62f # Flatcar Container Linux stable 3975.2.1 (HVM) in eu-west-1
       instanceType: ${AWS_INSTANCE_TYPE}
       publicIP: true
-      iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
+      iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
       uncompressedUserData: false
       sshKeyName: ${SSH_KEY_NAME}
 ---

--- a/e2e/ignition_provisioning_test.go
+++ b/e2e/ignition_provisioning_test.go
@@ -45,10 +45,14 @@ func ignitionProvisioningSpec(t *testing.T) {
 
 	clusterName := fmt.Sprintf("%s-%s", testName, capiutil.RandomString(6))
 
-	// A SSH is not really needed for using AWS, but for debugging purposes it is useful to have it configured.
-	SSHPublicKey := e2eConfig.MustGetVariable(SSHPublicKey)
-	if SSHPublicKey == "" {
+	// // A SSH is not really needed for using AWS, but for debugging purposes it is useful to have it configured.
+	sshPublicKey := e2eConfig.MustGetVariable(SSHPublicKey)
+	if sshPublicKey == "" {
 		t.Fatal("SSH public key is not set")
+	}
+	sshKeyName := e2eConfig.MustGetVariable(SSHKeyName)
+	if sshKeyName == "" {
+		t.Fatal("SSH key name is not set")
 	}
 
 	workloadClusterTemplate := clusterctl.ConfigCluster(ctx, clusterctl.ConfigClusterInput{
@@ -60,13 +64,14 @@ func ignitionProvisioningSpec(t *testing.T) {
 		ClusterName:              clusterName,
 		KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
 		ControlPlaneMachineCount: ptr.To[int64](3),
-		// CAPD doesn't support ignition, so we use AWS as infrastructure provider
+		// CAPD doesn't support ignition, so we hardcode AWS as infrastructure provider
 		InfrastructureProvider: "aws",
 		LogFolder:              filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
 		ClusterctlVariables: map[string]string{
 			"CLUSTER_NAME":   clusterName,
 			"NAMESPACE":      namespace.Name,
-			"SSH_PUBLIC_KEY": SSHPublicKey,
+			"SSH_PUBLIC_KEY": sshPublicKey,
+			"SSH_KEY_NAME":   sshKeyName,
 		},
 	})
 	require.NotNil(t, workloadClusterTemplate)

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -52,6 +52,7 @@ const (
 	ControlPlaneMachineCount         = "CONTROL_PLANE_MACHINE_COUNT"
 	IPFamily                         = "IP_FAMILY"
 	SSHPublicKey                     = "SSH_PUBLIC_KEY"
+	SSHKeyName                       = "SSH_KEY_NAME"
 )
 
 var (

--- a/e2e/util/machine.go
+++ b/e2e/util/machine.go
@@ -173,8 +173,14 @@ func WaitForWorkerMachine(ctx context.Context, input WaitForWorkersMachineInput)
 					break
 				}
 			}
-			if isWorker && *m.Spec.ProviderID != "" {
-				currentWorkerMachines += 1
+
+			if isWorker {
+				mProviderId := m.Spec.ProviderID
+				if mProviderId == nil || *mProviderId == "" {
+					continue
+				}
+
+				currentWorkerMachines++
 			}
 		}
 		if input.ExpectedWorkers != currentWorkerMachines {


### PR DESCRIPTION
### Changes
- add workflow to exec ignition e2e using aws
- use OIDC as auth protocol
- Updated CloudFormation stack to include s3 actions because ignition user data stored in s3 requires them for the CAPA controller

Im not sure if excluding aws e2e to run it only at night is a good idea and not including it more often, but this certainly increases our current testing

Execution success before remove manual triggering of the workflow -> https://github.com/k0sproject/k0smotron/actions/runs/19037993893/job/54367814464 