### PR TITLE
Fix labels and annotations propagation from pooledremotemachine to re…

### DIFF
--- a/internal/controller/infrastructure/remote_machine_controller.go
+++ b/internal/controller/infrastructure/remote_machine_controller.go
@@ -345,8 +345,12 @@ func (r *RemoteMachineController) reservePooledMachine(ctx context.Context, rm *
 		}
 	}
 
-	rm.Labels = foundPooledMachine.Labels
-	rm.Annotations = foundPooledMachine.Annotations
+	for k, v := range foundPooledMachine.Labels {
+		rm.Labels[k] = v
+	}
+	for k, v := range foundPooledMachine.Annotations {
+		rm.Annotations[k] = v
+	}
 	rm.Spec.Address = foundPooledMachine.Spec.Machine.Address
 	rm.Spec.Port = foundPooledMachine.Spec.Machine.Port
 	rm.Spec.User = foundPooledMachine.Spec.Machine.User


### PR DESCRIPTION
…motemachine

Annotations and labels set by the controlplane controller are removed by the pooledremotemachine annotations. This creates a bad state when trying to get `cluster.x-k8s.io/cloned-from-name` and `cluster.x-k8s.io/cloned-from-groupkind` to check if a rollout is needed