### PR TITLE
Fix: support accepted formats for cluster version when using clsuterc…

### DIFF
--- a/api/k0smotron.io/v1beta1/k0smotroncluster_types.go
+++ b/api/k0smotron.io/v1beta1/k0smotroncluster_types.go
@@ -19,9 +19,10 @@ package v1beta1
 import (
 	"crypto/md5"
 	"fmt"
+	"strings"
+
 	"github.com/k0sproject/version"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -185,6 +186,9 @@ func (c *ClusterSpec) GetImage() string {
 	if k0sVersion == "" {
 		k0sVersion = DefaultK0SVersion
 	}
+
+	// Ensure any version with +k0s. is converted to -k0s. for image tagging
+	k0sVersion = strings.Replace(k0sVersion, "+k0s.", "-k0s.", 1)
 
 	if !strings.Contains(k0sVersion, "-k0s.") {
 		k0sVersion = fmt.Sprintf("%s-%s", k0sVersion, DefaultK0SSuffix)

--- a/api/k0smotron.io/v1beta1/k0smotroncluster_types_test.go
+++ b/api/k0smotron.io/v1beta1/k0smotroncluster_types_test.go
@@ -63,6 +63,14 @@ func TestClusterSpec_GetImage(t *testing.T) {
 			},
 			want: "foobar/k0s:v1.29.4-k0s.0",
 		},
+		{
+			name: "Image and version given with +k0s. suffix",
+			spec: &ClusterSpec{
+				Image:   "foobar/k0s",
+				Version: "v1.29.4+k0s.0",
+			},
+			want: "foobar/k0s:v1.29.4-k0s.0",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/controller/bootstrap/worker_bootstrap_controller.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller.go
@@ -130,9 +130,15 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	if config.Spec.Version == "" && machine.Spec.Version != nil {
 		config.Spec.Version = *machine.Spec.Version
 	}
+
 	// If the version does not contain the k0s suffix, append it.
-	if config.Spec.Version != "" && !strings.Contains(config.Spec.Version, "+k0s.") {
-		config.Spec.Version = fmt.Sprintf("%s+%s", config.Spec.Version, defaultK0sSuffix)
+	if config.Spec.Version != "" {
+		// When machine is created by CAPI, for example by using a clusterclass template, the version
+		// of the cluster may contain '-k0s.' instead of '+k0s.', so we need to replace it first.
+		config.Spec.Version = strings.Replace(config.Spec.Version, "-k0s.", "+k0s.", 1)
+		if !strings.Contains(config.Spec.Version, "+k0s.") {
+			config.Spec.Version = fmt.Sprintf("%s+%s", config.Spec.Version, defaultK0sSuffix)
+		}
 	}
 
 	// Lookup the cluster the config owner is associated with

--- a/internal/controller/controlplane/k0smotron_controlplane_controller_test.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller_test.go
@@ -4,58 +4,10 @@ import (
 	"testing"
 
 	kapi "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
-	"github.com/stretchr/testify/assert"
+	"github.com/k0sproject/version"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
-
-// TestFormatStatusVersion tests the formatStatusVersion function
-func TestFormatStatusVersion(t *testing.T) {
-	tests := []struct {
-		name           string
-		specVersion    string
-		statusVersion  string
-		expectedStatus string
-		description    string
-	}{
-		{
-			name:           "spec without k0s suffix",
-			specVersion:    "v1.33.1",
-			statusVersion:  "v1.33.1-k0s.0",
-			expectedStatus: "v1.33.1",
-			description:    "When spec.version doesn't have -k0s suffix, status.version should also not have it",
-		},
-		{
-			name:           "spec with k0s suffix",
-			specVersion:    "v1.33.1-k0s.0",
-			statusVersion:  "v1.33.1-k0s.0",
-			expectedStatus: "v1.33.1-k0s.0",
-			description:    "When spec.version has -k0s suffix, status.version should keep it",
-		},
-		{
-			name:           "spec with custom k0s suffix",
-			specVersion:    "v1.33.1-k0s.1",
-			statusVersion:  "v1.33.1-k0s.1",
-			expectedStatus: "v1.33.1-k0s.1",
-			description:    "When spec.version has custom -k0s suffix, status.version should keep it",
-		},
-		{
-			name:           "spec without suffix, status with different suffix",
-			specVersion:    "v1.33.1",
-			statusVersion:  "v1.33.1-k0s.1",
-			expectedStatus: "v1.33.1",
-			description:    "When spec.version doesn't have -k0s suffix, status.version should remove it even if it's different",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Use the actual FormatStatusVersion function
-			result := FormatStatusVersion(tt.specVersion, tt.statusVersion)
-			assert.Equal(t, tt.expectedStatus, result, tt.description)
-		})
-	}
-}
 
 func TestIsClusterSpecSynced(t *testing.T) {
 	testCases := []struct {
@@ -244,6 +196,41 @@ func TestIsClusterSpecSynced(t *testing.T) {
 			result, err := isClusterSpecSynced(tc.kmcSpec, tc.kcpSpec)
 			require.NoError(t, err)
 			require.EqualValues(t, tc.expected, result)
+		})
+	}
+}
+
+func Test_alignToSpecVersionFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		specVersion    *version.Version
+		currentVersion *version.Version
+		want           *version.Version
+	}{
+		{
+			name:           "both versions have same format",
+			specVersion:    version.MustParse("v1.33.1-k0s.0"),
+			currentVersion: version.MustParse("v1.33.1-k0s.1"),
+			want:           version.MustParse("v1.33.1-k0s.1"),
+		},
+		{
+			name:           "versions does not have same format: spec with +k0s, current with -k0s",
+			specVersion:    version.MustParse("v1.33.1+k0s.0"),
+			currentVersion: version.MustParse("v1.33.1-k0s.1"),
+			want:           version.MustParse("v1.33.1+k0s.1"),
+		},
+		{
+			name:           "versions does not have same format: spec with -k0s, current with +k0s",
+			specVersion:    version.MustParse("v1.33.1-k0s.0"),
+			currentVersion: version.MustParse("v1.33.1+k0s.1"),
+			want:           version.MustParse("v1.33.1-k0s.1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := alignToSpecVersionFormat(tt.specVersion, tt.currentVersion)
+			require.NoError(t, err)
+			require.True(t, tt.want.Equal(got), "alignToSpecVersionFormat() = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/internal/controller/k0smotron.io/k0smotroncluster_webhook.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_webhook.go
@@ -76,8 +76,9 @@ func (c ClusterValidator) ValidateClusterSpec(kcs *km.ClusterSpec) (warnings adm
 // validateVersionSuffix checks if the version has a k0s suffix and returns a warning if it doesn't
 func (c ClusterValidator) validateVersionSuffix(version string) admission.Warnings {
 	warnings := admission.Warnings{}
-	if version != "" && !strings.Contains(version, "-k0s.") {
-		warnings = append(warnings, fmt.Sprintf("The specified version '%s' requires a k0s suffix (-k0s.<number>). Using '%s-k0s.0' instead.", version, version))
+	// When using CAPI clusterclass version can be specified with a +k0s. suffix.
+	if version != "" && (!strings.Contains(version, "-k0s.") && !strings.Contains(version, "+k0s.")) {
+		warnings = append(warnings, fmt.Sprintf("The specified version '%s' requires a k0s suffix (k0s.<number>). Using '%s-k0s.0' instead.", version, version))
 	}
 
 	return warnings

--- a/internal/controller/k0smotron.io/k0smotroncluster_webhook_test.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_webhook_test.go
@@ -1,0 +1,43 @@
+package k0smotronio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestClusterValidator_validateVersionSuffix(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    admission.Warnings
+	}{
+		{
+			name:    "version without k0s suffix",
+			version: "v1.23.4",
+			want:    admission.Warnings{"The specified version 'v1.23.4' requires a k0s suffix (k0s.<number>). Using 'v1.23.4-k0s.0' instead."},
+		},
+		{
+			name:    "version with k0s suffix",
+			version: "v1.23.4-k0s.2",
+			want:    admission.Warnings{},
+		},
+		{
+			name:    "empty version",
+			version: "",
+			want:    admission.Warnings{},
+		},
+		{
+			name:    "version with +k0s. suffix",
+			version: "v1.23.4+k0s.2",
+			want:    admission.Warnings{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c ClusterValidator
+			require.Equal(t, tt.want, c.validateVersionSuffix(tt.version))
+		})
+	}
+}

--- a/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
+++ b/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
@@ -113,7 +113,7 @@ func (s *CAPIDockerClusterClassK0smotronSuite) TestCAPIDocker() {
 			kcp.Status.UnavailableReplicas == 0 &&
 			kcp.Status.Ready &&
 			kcp.Status.UpdatedReplicas == 2 &&
-			kcp.Status.Version == "v1.27.2"
+			kcp.Status.Version == "v1.27.2+k0s.0"
 
 		return ready, nil
 	})


### PR DESCRIPTION
…lass

fix #1268

Support for `*+k0s.*` and `*-k0s.*` formats when using clusterclass. Same format is propagated for controlplane and workers so added checks to take into account each scenario.

Tested with

```yaml
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: ClusterClass
metadata:
  name: k0smotron-clusterclass
spec:
  controlPlane:
    ref:
      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
      kind: K0smotronControlPlaneTemplate
      name: k0s-controlplane-template
      namespace: default
  infrastructure:
    ref:
      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
      kind: DockerClusterTemplate
      name: docker-cluster-template
      namespace: default
  workers:
    machineDeployments:
    - class: default-worker
      template:
        bootstrap:
          ref:
            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
            kind: K0sWorkerConfigTemplate
            name: k0s-worker-config-template
            namespace: default
        infrastructure:
          ref:
            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
            kind: DockerMachineTemplate
            name: worker-docker-machine-template
            namespace: default
---
apiVersion: controlplane.cluster.x-k8s.io/v1beta1
kind: K0smotronControlPlaneTemplate
metadata:
  name: k0s-controlplane-template
  namespace: default
spec:
  template:
    spec:
      persistence:
        type: emptyDir
      service:
        type: NodePort
---
apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
kind: K0sWorkerConfigTemplate
metadata:
  name: k0s-worker-config-template
  namespace: default
spec:
  template:
    spec: {}
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: DockerMachineTemplate
metadata:
  name: worker-docker-machine-template
  namespace: default
spec:
  template:
    spec:
      customImage: kindest/node:v1.31.0
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: DockerClusterTemplate
metadata:
  name: docker-cluster-template
spec:
  template:
    spec: {}
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  name: k0smotron-test-cluster
  namespace: default
spec:
  topology:
    class: k0smotron-clusterclass
    version: v1.27.2-k0s.0 # Use v1.27.2, v1.27.2-k0s.0 or v1.27.2+k0s.0
    workers:
      machineDeployments:
      - class: default-worker
        name: md
        replicas: 3
```