### PR TITLE
fix(entrypoint): escape amp in sed

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_entrypoint.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_entrypoint.go
@@ -113,7 +113,8 @@ const entrypointTemplate = `
 mkdir /etc/k0s && echo "$K0SMOTRON_K0S_YAML" > /etc/k0s/k0s.yaml
 
 # Substitute the kine datasource URL from the env var
-sed -i "s {{ .KineDataSourceURLPlaceholder }} ${K0SMOTRON_KINE_DATASOURCE_URL} g" /etc/k0s/k0s.yaml
+escaped_url=$(printf '%s' "$K0SMOTRON_KINE_DATASOURCE_URL" | sed 's/[&/\]/\\&/g')
+sed -i "s {{ .KineDataSourceURLPlaceholder }} $escaped_url g" /etc/k0s/k0s.yaml
 
 {{if .PrivilegedPortIsUsed}}
 apk add --no-cache libcap

--- a/internal/controller/k0smotron.io/k0smotroncluster_entrypoint_test.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_entrypoint_test.go
@@ -17,14 +17,21 @@ limitations under the License.
 package k0smotronio
 
 import (
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 
 	km "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetControllerFlags(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name   string
 		kmc    km.Cluster
 		result string
@@ -58,5 +65,132 @@ func TestGetControllerFlags(t *testing.T) {
 
 	for _, test := range tests {
 		assert.Equal(t, test.result, getControllerFlags(&test.kmc), test.name)
+	}
+}
+
+func TestKineDataSourceURLSubstitution(t *testing.T) {
+	if _, err := exec.LookPath("sed"); err != nil {
+		t.Skip("sed command not available, skipping test")
+	}
+
+	tests := []struct {
+		name                 string
+		kineDataSourceURL    string
+		expectedSubstitution string
+	}{
+		{
+			name:                 "URL without ampersands",
+			kineDataSourceURL:    "postgres://user:pass@host:5432/db?sslmode=disable",
+			expectedSubstitution: "postgres://user:pass@host:5432/db?sslmode=disable",
+		},
+		{
+			name:                 "URL with single ampersand",
+			kineDataSourceURL:    "postgres://user:pass@host:5432/db?param1=value1&param2=value2",
+			expectedSubstitution: "postgres://user:pass@host:5432/db?param1=value1&param2=value2",
+		},
+		{
+			name:                 "URL with multiple ampersands",
+			kineDataSourceURL:    "postgres://user:pass@host:5432/db?param1=value1&param2=value2&param3=value3",
+			expectedSubstitution: "postgres://user:pass@host:5432/db?param1=value1&param2=value2&param3=value3",
+		},
+		{
+			name:                 "URL with ampersand in password",
+			kineDataSourceURL:    "postgres://user:pa&ss@host:5432/db",
+			expectedSubstitution: "postgres://user:pa&ss@host:5432/db",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kmc := &km.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: km.ClusterSpec{
+					Service: km.ServiceSpec{
+						APIPort: 6443,
+					},
+					KineDataSourceURL: tc.kineDataSourceURL,
+				},
+			}
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, km.AddToScheme(scheme))
+
+			client := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(kmc).
+				Build()
+
+			scope := &kmcScope{
+				client: client,
+			}
+
+			cm, err := scope.generateEntrypointCM(kmc)
+			require.NoError(t, err)
+
+			entrypointScript := cm.Data["k0smotron-entrypoint.sh"]
+
+			lines := strings.Split(entrypointScript, "\n")
+			var printfLine, sedLine string
+			for _, line := range lines {
+				line = strings.TrimSpace(line)
+				if strings.Contains(line, "escaped_url=$(printf") && strings.Contains(line, "K0SMOTRON_KINE_DATASOURCE_URL") {
+					printfLine = line
+				}
+				if strings.Contains(line, "sed -i") && strings.Contains(line, "$escaped_url") {
+					sedLine = line
+				}
+			}
+			require.NotEmpty(t, printfLine, "printf command not found in entrypoint script")
+			require.NotEmpty(t, sedLine, "sed command not found in entrypoint script")
+
+			testK0sConfig := `apiVersion: k0s.k0sproject.io/v1beta1
+kind: ClusterConfig
+metadata:
+  name: k0s
+spec:
+  storage:
+    type: kine
+    kine:
+      dataSource: ` + kineDataSourceURLPlaceholder + `
+  api:
+    port: 6443`
+
+			tmpFile, err := os.CreateTemp("", "k0s-test-*.yaml")
+			require.NoError(t, err)
+			t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+
+			_, err = tmpFile.WriteString(testK0sConfig)
+			require.NoError(t, err)
+			require.NoError(t, tmpFile.Close())
+
+			os.Setenv("K0SMOTRON_KINE_DATASOURCE_URL", tc.kineDataSourceURL)
+			t.Cleanup(func() { os.Unsetenv("K0SMOTRON_KINE_DATASOURCE_URL") })
+
+			actualSedCmd := strings.Replace(sedLine, "/etc/k0s/k0s.yaml", tmpFile.Name(), 1)
+
+			combinedScript := printfLine + "\n" + actualSedCmd
+
+			cmd := exec.Command("sh", "-c", combinedScript)
+			cmd.Env = append(os.Environ(), "K0SMOTRON_KINE_DATASOURCE_URL="+tc.kineDataSourceURL)
+
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Logf("Combined script: %s", combinedScript)
+				t.Logf("Script output: %s", string(output))
+			}
+			require.NoError(t, err, "Shell script failed: %s", string(output))
+
+			modifiedContent, err := os.ReadFile(tmpFile.Name())
+			require.NoError(t, err)
+
+			modifiedStr := string(modifiedContent)
+			assert.Contains(t, modifiedStr, tc.expectedSubstitution,
+				"Expected URL %q not found in modified config", tc.expectedSubstitution)
+			assert.NotContains(t, modifiedStr, kineDataSourceURLPlaceholder,
+				"Placeholder should be completely replaced")
+		})
 	}
 }


### PR DESCRIPTION
Escapes ampersand (&) symbol in the entrypoint.sh for the k0s, to avoid incorrect substitutions in case kine data source url has two or more options to connect.

Fixes #1299