### PR TITLE
fix infra provider: add goroutine to handle remotemachine deletion when provisioning…

### DIFF
--- a/api/infrastructure/v1beta1/remote_machine_types.go
+++ b/api/infrastructure/v1beta1/remote_machine_types.go
@@ -140,6 +140,9 @@ type RemoteMachineList struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=infrastructure-k0smotron"
+// +kubebuilder:printcolumn:name="Address",type=string,JSONPath=".spec.machine.address",description="IP address or DNS name of the remote machine"
+// +kubebuilder:printcolumn:name="Reserved",type=string,JSONPath=".status.reserved",description="Indicates if the machine is reserved"
+// +kubebuilder:printcolumn:name="Remote Machine",type=string,JSONPath=".status.machineRef.name",description="Reference to the RemoteMachine"
 
 type PooledRemoteMachine struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/clusterapi/infrastructure/bases/infrastructure.cluster.x-k8s.io_pooledremotemachines.yaml
+++ b/config/clusterapi/infrastructure/bases/infrastructure.cluster.x-k8s.io_pooledremotemachines.yaml
@@ -17,7 +17,20 @@ spec:
     singular: pooledremotemachine
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: IP address or DNS name of the remote machine
+      jsonPath: .spec.machine.address
+      name: Address
+      type: string
+    - description: Indicates if the machine is reserved
+      jsonPath: .status.reserved
+      name: Reserved
+      type: string
+    - description: Reference to the RemoteMachine
+      jsonPath: .status.machineRef.name
+      name: Remote Machine
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:

--- a/config/crd/bases/infrastructure/infrastructure.cluster.x-k8s.io_pooledremotemachines.yaml
+++ b/config/crd/bases/infrastructure/infrastructure.cluster.x-k8s.io_pooledremotemachines.yaml
@@ -17,7 +17,20 @@ spec:
     singular: pooledremotemachine
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: IP address or DNS name of the remote machine
+      jsonPath: .spec.machine.address
+      name: Address
+      type: string
+    - description: Indicates if the machine is reserved
+      jsonPath: .status.reserved
+      name: Reserved
+      type: string
+    - description: Reference to the RemoteMachine
+      jsonPath: .status.machineRef.name
+      name: Remote Machine
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:


### PR DESCRIPTION
… hangs

If a provisioning command hangs, another reconcile cycle for the same resource cannot run (for example triggered by the MHC). This prevents to reconcile the deletion and thus to release back a VM to the pool.

Remediation e2e covers this case, I will try to add e2e working with k0smotron infra provider soon