### PR TITLE
Workaround konnectivity ingress issue

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
@@ -281,7 +281,7 @@ func getV1Beta1Spec(kmc *km.Cluster, sans []string) map[string]interface{} {
 		}
 		v1beta1Spec["konnectivity"] = map[string]any{
 			"externalAddress": kmc.Spec.Ingress.KonnectivityHost,
-			"agentPort":       kmc.Spec.Ingress.Port,
+			"agentPort":       int64(kmc.Spec.Service.KonnectivityPort),
 		}
 	}
 


### PR DESCRIPTION
There is a bug in ingress implementation for konnectivity. Currently, wbe propagate ingress port to agentPort, and since the default port for ingress is 443, konnectivity tries to run on 443 port. Which is forbidden in konnectivity. 
We missed it in tests since we use a custom port for ingress.

This PR adds a custom and correct manifest to the control plane for konnectivity and sets the usual agentPort instead of ingress one.