### PR TITLE
Add tolerations to the HAProxy daemonset

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_ingress.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_ingress.go
@@ -138,6 +138,13 @@ spec:
         app: k0smotron-haproxy
     spec:
       hostNetwork: true
+      tolerations:
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoSchedule"
       containers:
         - name: haproxy
           image: haproxy:2.8


### PR DESCRIPTION
In some setups with custom CNI haproxy pods are not scheduled on node since it's in unreachable or not-ready state. Since CNI plugin can't reach the kube api without haproxy, the node provisioning stuck