### PR TITLE
fix docs for head references using 'None'

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -51,7 +51,8 @@ jobs:
       - name: mike deploy head
         if: contains(github.ref, 'refs/heads/main')
         run: |
-          mike deploy --push head
+          VERSION=$(git describe --tags --abbrev=0) 
+          K0SMOTRON_VERSION="$VERSION" mike deploy --push head
 
       # If a release has been published, deploy it as a new version
       - name: mike deploy new version

--- a/docs/capi-remotemachine-teleport.md
+++ b/docs/capi-remotemachine-teleport.md
@@ -183,7 +183,7 @@ spec:
 ```
 
 More information about Teleport's Machine ID and how to set it up with Kubernetes can be found [here](https://goteleport.com/docs/machine-id/deployment/kubernetes/).
-Also, you can use [this example](https://github.com/k0sproject/k0smotron/blob/{{{ extra.k0smotron_version }}}/config/samples/capi/remotemachine/capi-remotemachine-teleport.yaml) as a reference.
+Also, you can use [this example](https://github.com/k0sproject/k0smotron/blob/{{{ extra.k0smotron_version }}}/config/samples/capi/remotemachine/remotemachine-teleport-access.yaml) as a reference.
 
 ## Create a RemoteMachine
 


### PR DESCRIPTION
"head" docs version displays "None": https://docs.k0smotron.io/head/install/#:~:text=TL%3BDR-,kubectl%20apply%20%2D%2Dserver%2Dside%3Dtrue%20%2Df%20https%3A//docs.k0smotron.io/None/install.yaml,-Known%20limitations

Use latest k0smotron instead
