### PR TITLE
Auto-create namespace in remote cluster for remote HCP

### DIFF
--- a/e2e/remote_hcp_test.go
+++ b/e2e/remote_hcp_test.go
@@ -72,15 +72,6 @@ func remoteHCPSpec(t *testing.T) {
 
 	// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
 	namespace, _ := util.SetupSpecNamespace(ctx, testName, bootstrapClusterProxy, artifactFolder)
-	// Create same namespace in hosting cluster
-	nsForHostingCluster := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace.GetName(),
-		},
-	}
-	err = hostingClusterProxy.GetClient().Create(ctx, nsForHostingCluster)
-	require.NoError(t, err)
-
 	clusterName := fmt.Sprintf("%s-%s", testName, capiutil.RandomString(6))
 
 	workloadClusterTemplate := clusterctl.ConfigCluster(ctx, clusterctl.ConfigClusterInput{

--- a/internal/controller/k0smotron.io/k0smotroncluster_controller.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_controller.go
@@ -155,6 +155,12 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				}
 			}
 		} else {
+			// Ensure the namespace exists in the remote cluster before creating any resources
+			if err := kutil.EnsureNamespaceExists(ctx, kmcScope.client, kmc.Namespace); err != nil {
+				logger.Error(err, "Error ensuring namespace exists in remote cluster")
+				return ctrl.Result{}, err
+			}
+
 			kmcScope.externalOwner, err = kutil.EnsureExternalOwner(ctx, kmc.Name, kmc.Namespace, kmcScope.client)
 			if err != nil {
 				logger.Error(err, "Error ensuring external owner")

--- a/internal/controller/util/namespace.go
+++ b/internal/controller/util/namespace.go
@@ -1,0 +1,68 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EnsureNamespaceExists ensures that a namespace exists in the remote cluster.
+// It first checks if the namespace exists by calling Get. If the namespace is not found,
+// it creates the namespace. If Get returns Forbidden, it returns an error as we cannot
+// verify the namespace existence or create it.
+func EnsureNamespaceExists(ctx context.Context, c client.Client, namespace string) error {
+	ns := &corev1.Namespace{}
+	key := client.ObjectKey{Name: namespace}
+
+	err := c.Get(ctx, key, ns)
+	if err == nil {
+		// Namespace exists, we're done
+		return nil
+	}
+
+	if apierrors.IsNotFound(err) {
+		// Namespace doesn't exist, create it
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		createErr := c.Create(ctx, ns)
+		if createErr != nil {
+			if apierrors.IsAlreadyExists(createErr) {
+				// Namespace was created by another process, that's fine
+				return nil
+			}
+			return fmt.Errorf("failed to create namespace %s: %w", namespace, createErr)
+		}
+		return nil
+	}
+
+	if apierrors.IsForbidden(err) {
+		// Cannot verify namespace existence due to insufficient permissions
+		return fmt.Errorf("cannot verify or create namespace %s: insufficient permissions to get namespaces: %w", namespace, err)
+	}
+
+	// Other errors are returned as-is
+	return fmt.Errorf("failed to get namespace %s: %w", namespace, err)
+}


### PR DESCRIPTION
fixes: https://github.com/k0sproject/k0smotron/issues/1326

## What this PR does
This PR removes the manual prerequisite of creating the namespace in the hosting (remote) cluster when deploying Remote HCPs.

## Key changes
- Add a small utility that ensures a namespace exists in the remote cluster (GET first; if NotFound → Create).

## Why this is needed
Users currently hit reconciliation failures if the namespace is missing in the hosting cluster, e.g. `namespaces "<ns>" not found`. This PR makes the Remote HCP workflow smoother and less error-prone by automatically creating the namespace when required.

## Testing
The container image for this PR has been published at `quay.io/kahirokunn/k0smotron:auto-create-ns` and has been tested.
