### PR TITLE
Fix test naming for expected e2e triggering

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -248,7 +248,7 @@ jobs:
           - TestWorkloadClusterRecreateUpgrade
           - TestWorkloadClusterRecreateDeleteFirstUpgrade
           - TestAdmissionWebhookRecreateStrategyInSingleMode
-          - TestAdmissionWebhookK0sNotCompatible
+          - TestAdmissionWebhookK0sVersionNotCompatible
           - TestK0smotronUpgrade
           - TestMachineDeployment
           - TestRemoteHostedControlPlanes

--- a/e2e/machinedeployment_test.go
+++ b/e2e/machinedeployment_test.go
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestMachinedeployment(t *testing.T) {
+func TestMachineDeployment(t *testing.T) {
 	setupAndRun(t, func(t *testing.T) {
 		testName := "machinedeployment"
 
@@ -155,8 +155,8 @@ func verifyK0smotronControlPlaneVersionFormat(ctx context.Context, t *testing.T,
 			return false
 		}
 
-		if version != "v1.32.2" {
-			t.Errorf("Expected version %s, but got: %s", "v1.32.2", version)
+		if version != "v1.32.2+k0s.0" {
+			t.Errorf("Expected version %s, but got: %s", "v1.32.2+k0s.0", version)
 			return false
 		}
 


### PR DESCRIPTION
I noticed that `TestMachineDeployment` and `TestAdmissionWebhookK0sVersionNotCompatible` were not running in our e2e suite because of bad naming in [recent changes](https://github.com/k0sproject/k0smotron/commit/159dbe9bb3244bb531ca4290157b2d44256a3d07) in the workflow matrix 