### PR TITLE
Fix make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,7 @@ smoketests: $(smoketests)
 clean:
 	-$(MAKE) -C inttest clean
 	rm -f hack/lint/.golangci-lint.stamp
+	chmod -R +w ${LOCALBIN} || true # envtest may have created read-only dirs and files
 	rm -rf \
 	  $(generate_targets) \
 	  $(manifests_targets) \


### PR DESCRIPTION
envtest creates read-only dirs, so `make clean` fails with:

```
 ✗ make clean
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C inttest clean
rm -rf .*.stamp
rm -f hack/lint/.golangci-lint.stamp
rm -rf \
          api/k0smotron.io/v1beta1/zz_generated.deepcopy.go api/bootstrap/v1beta1/zz_generated.deepcopy.go api/controlplane/v1beta1/zz_generated.deepcopy.go api/infrastructure/v1beta1/zz_generated.deepcopy.go \
           \
          k0smotron-image-bundle.tar \
          /Users/amakhov/work/k0smotron/bin
rm: /Users/amakhov/work/k0smotron/bin/k8s/1.26.0-darwin-arm64/etcd: Permission denied
rm: /Users/amakhov/work/k0smotron/bin/k8s/1.26.0-darwin-arm64/kube-apiserver: Permission denied
rm: /Users/amakhov/work/k0smotron/bin/k8s/1.26.0-darwin-arm64/kubectl: Permission denied
rm: /Users/amakhov/work/k0smotron/bin/k8s/1.26.0-darwin-arm64: Directory not empty
rm: /Users/amakhov/work/k0smotron/bin/k8s: Directory not empty
rm: /Users/amakhov/work/k0smotron/bin: Directory not empty

```