### PR TITLE
fix aws e2e by using current installation path for each provider

### DIFF
--- a/e2e/config/aws.yaml
+++ b/e2e/config/aws.yaml
@@ -66,7 +66,7 @@ providers:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
       - name: v1.10.99 # potentially next release. Manifest from source files (development) are used.
-        value: ../../config/default
+        value: ../../config/clusterapi/controlplane
         contract: v1beta1
         files:
           - sourcePath: "../../metadata.yaml"
@@ -106,7 +106,7 @@ providers:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
       - name: v1.10.99 # potentially next release. Manifest from source files (development) are used.
-        value: ../../config/default
+        value: ../../config/clusterapi/bootstrap
         contract: v1beta1
         files:
           - sourcePath: "../../metadata.yaml"


### PR DESCRIPTION
AWS e2e[ is failing](https://github.com/k0sproject/k0smotron/actions/runs/21463835330/job/61821981001) after merge https://github.com/k0sproject/k0smotron/pull/1188. CRDs configs have been reordered, so aws e2e needs to change the configuration too.