### PR TITLE
fix: support all Ignition spec versions during provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ _artifacts
 
 # E2E test templates
 e2e/data/infrastructure-docker/**/cluster-template*.yaml
+e2e/data/infrastructure-aws/**/cluster-template*.yaml
 
 # Development environment files
 .tiltbuild/
+

--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,14 @@ generate-e2e-templates-main: $(KUSTOMIZE)
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-remote-hcp --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-remote-hcp.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-ingress --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-ingress.yaml
 
+AWS_TEMPLATES := e2e/data/infrastructure-aws
 
-e2e: generate-e2e-templates-main
+.PHONY: generate-aws-e2e-templates
+generate-aws-e2e-templates: $(KUSTOMIZE)
+	$(KUSTOMIZE) build $(AWS_TEMPLATES)/cluster-template-ignition-fedora --load-restrictor LoadRestrictionsNone > $(AWS_TEMPLATES)/cluster-template-ignition-fedora.yaml
+	$(KUSTOMIZE) build $(AWS_TEMPLATES)/cluster-template-ignition-flatcar --load-restrictor LoadRestrictionsNone > $(AWS_TEMPLATES)/cluster-template-ignition-flatcar.yaml
+
+e2e: generate-e2e-templates-main generate-aws-e2e-templates
 	set +x;
 	PATH="${LOCALBIN}:${PATH}" go test -v -tags e2e -run '$(TEST_NAME)' ./e2e  \
 	    -artifacts-folder="$(ARTIFACTS)" \

--- a/e2e/config/aws.yaml
+++ b/e2e/config/aws.yaml
@@ -34,7 +34,8 @@ providers:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
     files:
-      - sourcePath: "../data/infrastructure-aws/cluster-template-ignition.yaml"
+      - sourcePath: "../data/infrastructure-aws/cluster-template-ignition-flatcar.yaml"
+      - sourcePath: "../data/infrastructure-aws/cluster-template-ignition-fedora.yaml"
   - name: k0sproject-k0smotron
     type: ControlPlaneProvider
     versions:
@@ -126,7 +127,6 @@ variables:
   # Enabling the feature flags by setting the env variables.
   CLUSTER_TOPOLOGY: "true"
   EXP_MACHINE_POOL: "true"
-  AWS_INSTANCE_TYPE: "t3.large" 
   # Following feature flags are required to use Ignition as bootstrap data format in CAPA.
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   EXP_BOOTSTRAP_FORMAT_IGNITION: "true"

--- a/e2e/data/infrastructure-aws/bases/cluster-with-ignition-provisioner.yaml
+++ b/e2e/data/infrastructure-aws/bases/cluster-with-ignition-provisioner.yaml
@@ -34,7 +34,6 @@ spec:
         version: "3.4"
       ami:
         id: ami-00d12617b68dbc62f # Flatcar Container Linux stable 3975.2.1 (HVM) in eu-west-1
-      instanceType: ${AWS_INSTANCE_TYPE}
       publicIP: true
       iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
       uncompressedUserData: false
@@ -50,19 +49,6 @@ spec:
   version: v1.30.2+k0s.0
   updateStrategy: Recreate
   k0sConfigSpec:
-    # Flatcar, as inmutable OS, needs k0s in /opt/bin. It cannot write k0s binary in the default /usr/local/bin.
-    k0sInstallDir: /opt/bin 
-    ignition:
-      variant: flatcar
-      version: 1.1.0
-      additionalConfig: |
-        variant: flatcar
-        version: 1.1.0
-        passwd:
-          users:
-            - name: core
-              ssh_authorized_keys:
-                - ssh-rsa ${SSH_PUBLIC_KEY}
     args:
       - --enable-worker
       - --debug
@@ -141,18 +127,4 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   template:
-    spec:
-      version: v1.30.2+k0s.0
-      # Flatcar, as inmutable OS, needs k0s in /opt/bin. It cannot write k0s binary in the default /usr/local/bin.
-      k0sInstallDir: /opt/bin 
-      ignition:
-        variant: flatcar
-        version: 1.1.0
-        additionalConfig: |
-          variant: flatcar
-          version: 1.1.0
-          passwd:
-            users:
-              - name: core
-                ssh_authorized_keys:
-                  - ssh-rsa ${SSH_PUBLIC_KEY}
+    spec: {}

--- a/e2e/data/infrastructure-aws/cluster-template-ignition-fedora/aws-machine-template-patch.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition-fedora/aws-machine-template-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-aws-test-mt
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      ami:
+        id: ami-00288eb1655108c26 # Fedora CoreOS
+      instanceType: x2gd.8xlarge

--- a/e2e/data/infrastructure-aws/cluster-template-ignition-fedora/k0scontrolplane-patch.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition-fedora/k0scontrolplane-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: K0sControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-aws-test
+  namespace: ${NAMESPACE}
+spec:
+  k0sConfigSpec:
+    ignition:
+      variant: fcos
+      version: 1.4.0
+      additionalConfig: |
+        variant: fcos
+        version: 1.4.0
+        passwd:
+          users:
+            - name: core
+              ssh_authorized_keys:
+                - ssh-rsa ${SSH_PUBLIC_KEY}

--- a/e2e/data/infrastructure-aws/cluster-template-ignition-fedora/k0sworkerconfigtemplate-patch.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition-fedora/k0sworkerconfigtemplate-patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: K0sWorkerConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-machine-config
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      version: v1.30.2+k0s.0
+      ignition:
+        variant: fcos
+        version: 1.4.0
+        additionalConfig: |
+          variant: fcos
+          version: 1.4.0
+          passwd:
+            users:
+              - name: core
+                ssh_authorized_keys:
+                  - ssh-rsa ${SSH_PUBLIC_KEY}

--- a/e2e/data/infrastructure-aws/cluster-template-ignition-fedora/kustomization.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition-fedora/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- ../bases/cluster-with-ignition-provisioner.yaml
+
+patches:
+- path: k0scontrolplane-patch.yaml
+- path: k0sworkerconfigtemplate-patch.yaml
+- path: aws-machine-template-patch.yaml

--- a/e2e/data/infrastructure-aws/cluster-template-ignition-flatcar/aws-machine-template-patch.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition-flatcar/aws-machine-template-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-aws-test-mt
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      ami:
+        id: ami-00d12617b68dbc62f
+      instanceType: t3.large

--- a/e2e/data/infrastructure-aws/cluster-template-ignition-flatcar/k0scontrolplane-patch.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition-flatcar/k0scontrolplane-patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: K0sControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-aws-test
+  namespace: ${NAMESPACE}
+spec:
+  k0sConfigSpec:
+    k0sInstallDir: /opt/bin # Flatcar, as inmutable OS, needs k0s in /opt/bin. It cannot write k0s binary in the default /usr/local/bin.
+    ignition:
+      variant: flatcar
+      version: 1.1.0
+      additionalConfig: |
+        variant: flatcar
+        version: 1.1.0
+        passwd:
+          users:
+            - name: core
+              ssh_authorized_keys:
+                - ssh-rsa ${SSH_PUBLIC_KEY}

--- a/e2e/data/infrastructure-aws/cluster-template-ignition-flatcar/k0sworkerconfigtemplate-patch.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition-flatcar/k0sworkerconfigtemplate-patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: K0sWorkerConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-machine-config
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      version: v1.30.2+k0s.0
+      k0sInstallDir: /opt/bin # Flatcar, as inmutable OS, needs k0s in /opt/bin. It cannot write k0s binary in the default /usr/local/bin.
+      ignition:
+        variant: flatcar
+        version: 1.1.0
+        additionalConfig: |
+          variant: flatcar
+          version: 1.1.0
+          passwd:
+            users:
+              - name: core
+                ssh_authorized_keys:
+                  - ssh-rsa ${SSH_PUBLIC_KEY}

--- a/e2e/data/infrastructure-aws/cluster-template-ignition-flatcar/kustomization.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition-flatcar/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- ../bases/cluster-with-ignition-provisioner.yaml
+
+patches:
+- path: k0scontrolplane-patch.yaml
+- path: k0sworkerconfigtemplate-patch.yaml
+- path: aws-machine-template-patch.yaml

--- a/e2e/ignition_provisioning_test.go
+++ b/e2e/ignition_provisioning_test.go
@@ -58,7 +58,7 @@ func ignitionProvisioningSpec(t *testing.T) {
 	workloadClusterTemplate := clusterctl.ConfigCluster(ctx, clusterctl.ConfigClusterInput{
 		ClusterctlConfigPath: clusterctlConfigPath,
 		KubeconfigPath:       bootstrapClusterProxy.GetKubeconfigPath(),
-		Flavor:               "ignition",
+		Flavor:               "ignition-flatcar",
 
 		Namespace:                namespace.Name,
 		ClusterName:              clusterName,
@@ -75,8 +75,6 @@ func ignitionProvisioningSpec(t *testing.T) {
 		},
 	})
 	require.NotNil(t, workloadClusterTemplate)
-
-	fmt.Println(string(workloadClusterTemplate))
 
 	require.Eventually(t, func() bool {
 		return bootstrapClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate) == nil

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.2
 	k8s.io/apiextensions-apiserver v0.34.2
@@ -88,6 +87,7 @@ require (
 	github.com/bodgit/ntlmssp v0.0.0-20240506230425-31973bb52d9b // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/clarketm/json v1.17.1 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -199,6 +199,7 @@ require (
 	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/cluster-bootstrap v0.34.2 // indirect
 	k8s.io/component-base v0.34.2 // indirect
 	k8s.io/component-helpers v0.34.2 // indirect

--- a/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
@@ -19,8 +19,9 @@ limitations under the License.
 package bootstrap
 
 import (
-	"github.com/k0sproject/version"
 	"testing"
+
+	"github.com/k0sproject/version"
 
 	bootstrapv1 "github.com/k0sproject/k0smotron/api/bootstrap/v1beta1"
 	"github.com/stretchr/testify/require"
@@ -102,9 +103,9 @@ func TestController_genK0sCommands(t *testing.T) {
 			installCmd: "k0s install controller --force --enable-dynamic-config",
 			want: []string{
 				"curl -sSfL --retry 5 https://get.k0s.sh | K0S_INSTALL_PATH=/usr/local/bin K0S_VERSION=v1.31.0 sh",
-				"(command -v systemctl > /dev/null 2>&1 && (cp /k0s/k0sleave.service /etc/systemd/system/k0sleave.service && systemctl daemon-reload && systemctl enable k0sleave.service && systemctl start --no-block k0sleave.service) || true)",
-				"(command -v rc-service > /dev/null 2>&1 && (cp /k0s/k0sleave-openrc /etc/init.d/k0sleave && rc-update add k0sleave shutdown) || true)",
-				"(command -v service > /dev/null 2>&1 && (cp /k0s/k0sleave-sysv /etc/init.d/k0sleave && update-rc.d k0sleave defaults && service k0sleave start) || true)",
+				"(command -v systemctl > /dev/null 2>&1 && (cp /etc/k0s/k0sleave.service /etc/systemd/system/k0sleave.service && systemctl daemon-reload && systemctl enable k0sleave.service && systemctl start --no-block k0sleave.service) || true)",
+				"(command -v rc-service > /dev/null 2>&1 && (cp /etc/k0s/k0sleave-openrc /etc/init.d/k0sleave && rc-update add k0sleave shutdown) || true)",
+				"(command -v service > /dev/null 2>&1 && (cp /etc/k0s/k0sleave-sysv /etc/init.d/k0sleave && update-rc.d k0sleave defaults && service k0sleave start) || true)",
 				"k0s install controller --force --enable-dynamic-config",
 				"k0s start",
 			},

--- a/internal/provisioner/ignition_test.go
+++ b/internal/provisioner/ignition_test.go
@@ -35,39 +35,19 @@ func TestToProvisionData(t *testing.T) {
 					{Path: "/etc/test.conf", Content: "hello world", Permissions: "0644"},
 				},
 			},
-			wantJSON: `{
-  "ignition": {
-    "config": { 
-		"replace": { 
-			"verification": {} 
-		} 
-	},
-    "proxy": {},
-    "security": { 
-		"tls": {} 
-	},
-    "timeouts": {},
-    "version": "3.4.0"
-  },
-  "kernelArguments": {},
-  "passwd": {},
-  "storage": {
-    "files": [
+			wantJSON: `
       {
-        "contents": {
-          "compression": "",
-          "source": "data:,hello%20world",
-          "verification": {}
-        },
-        "group": {},
-        "mode": 420,
-        "path": "/etc/test.conf",
-        "user": {}
-      }
-    ]
-  },
-  "systemd": {}
-}`,
+        "ignition": {
+          "config": {
+            "merge": [
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL3Rlc3QuY29uZiIsCiAgICAgICAgImNvbnRlbnRzIjogewogICAgICAgICAgInNvdXJjZSI6ICJkYXRhOixoZWxsbyUyMHdvcmxkIgogICAgICAgIH0sCiAgICAgICAgIm1vZGUiOiA0MjAKICAgICAgfQogICAgXQogIH0KfQ=="
+              }
+            ]
+          },
+          "version": "3.0.0"
+        }
+      }`,
 		},
 		{
 			name: "with commands",
@@ -78,33 +58,19 @@ func TestToProvisionData(t *testing.T) {
 			input: &InputProvisionData{
 				Commands: []string{"echo hello"},
 			},
-			wantJSON: `{
-  "ignition": {
-    "config": { 
-		"replace": { 
-			"verification": {} 
-		} 
-	},
-    "proxy": {},
-    "security": { 
-		"tls": {} 
-	},
-    "timeouts": {},
-    "version": "3.4.0"
-  },
-  "kernelArguments": {},
-  "passwd": {},
-  "storage": {},
-  "systemd": {
-    "units": [
+			wantJSON: `
       {
-        "contents": "[Unit]\nDescription=K0s Bootstrap Commands\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c 'echo hello'\nRemainAfterExit=true\n\n[Install]\nWantedBy=multi-user.target",
-        "enabled": true,
-        "name": "k0s-bootstrap.service"
-      }
-    ]
-  }
-}`,
+        "ignition": {
+          "config": {
+            "merge": [
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN5c3RlbWQiOiB7CiAgICAidW5pdHMiOiBbCiAgICAgIHsKICAgICAgICAiY29udGVudHMiOiAiW1VuaXRdXG5EZXNjcmlwdGlvbj1LMHMgQm9vdHN0cmFwIENvbW1hbmRzXG5BZnRlcj1uZXR3b3JrLW9ubGluZS50YXJnZXRcblxuW1NlcnZpY2VdXG5UeXBlPW9uZXNob3RcbkV4ZWNTdGFydD0vYmluL3NoIC1jICdlY2hvIGhlbGxvJ1xuUmVtYWluQWZ0ZXJFeGl0PXRydWVcblxuW0luc3RhbGxdXG5XYW50ZWRCeT1tdWx0aS11c2VyLnRhcmdldCIsCiAgICAgICAgImVuYWJsZWQiOiB0cnVlLAogICAgICAgICJuYW1lIjogImswcy1ib290c3RyYXAuc2VydmljZSIKICAgICAgfQogICAgXQogIH0KfQ=="
+              }
+            ]
+          },
+          "version": "3.0.0"
+        }
+      }`,
 		},
 		{
 			name: "files + commands",
@@ -118,47 +84,19 @@ func TestToProvisionData(t *testing.T) {
 				},
 				Commands: []string{"echo combo"},
 			},
-			wantJSON: `{
-  "ignition": {
-    "config": { 
-		"replace": { 
-			"verification": {} 
-		} 
-	},
-    "proxy": {},
-    "security": { 
-		"tls": {} 
-	},
-    "timeouts": {},
-    "version": "3.4.0"
-  },
-  "kernelArguments": {},
-  "passwd": {},
-  "storage": {
-    "files": [
+			wantJSON: `
       {
-        "contents": {
-          "compression": "",
-          "source": "data:,combo",
-          "verification": {}
-        },
-        "group": {},
-        "mode": 420,
-        "path": "/etc/combined.conf",
-        "user": {}
-      }
-    ]
-  },
-  "systemd": {
-    "units": [
-      {
-        "contents": "[Unit]\nDescription=K0s Bootstrap Commands\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c 'echo combo'\nRemainAfterExit=true\n\n[Install]\nWantedBy=multi-user.target",
-        "enabled": true,
-        "name": "k0s-bootstrap.service"
-      }
-    ]
-  }
-}`,
+        "ignition": {
+          "config": {
+            "merge": [
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL2NvbWJpbmVkLmNvbmYiLAogICAgICAgICJjb250ZW50cyI6IHsKICAgICAgICAgICJzb3VyY2UiOiAiZGF0YTosY29tYm8iCiAgICAgICAgfSwKICAgICAgICAibW9kZSI6IDQyMAogICAgICB9CiAgICBdCiAgfSwKICAic3lzdGVtZCI6IHsKICAgICJ1bml0cyI6IFsKICAgICAgewogICAgICAgICJjb250ZW50cyI6ICJbVW5pdF1cbkRlc2NyaXB0aW9uPUswcyBCb290c3RyYXAgQ29tbWFuZHNcbkFmdGVyPW5ldHdvcmstb25saW5lLnRhcmdldFxuXG5bU2VydmljZV1cblR5cGU9b25lc2hvdFxuRXhlY1N0YXJ0PS9iaW4vc2ggLWMgJ2VjaG8gY29tYm8nXG5SZW1haW5BZnRlckV4aXQ9dHJ1ZVxuXG5bSW5zdGFsbF1cbldhbnRlZEJ5PW11bHRpLXVzZXIudGFyZ2V0IiwKICAgICAgICAiZW5hYmxlZCI6IHRydWUsCiAgICAgICAgIm5hbWUiOiAiazBzLWJvb3RzdHJhcC5zZXJ2aWNlIgogICAgICB9CiAgICBdCiAgfQp9"
+              }
+            ]
+          },
+          "version": "3.0.0"
+        }
+      }`,
 		},
 		{
 			name: "invalid permissions",
@@ -178,187 +116,161 @@ func TestToProvisionData(t *testing.T) {
 			provisioner: IgnitionProvisioner{
 				Variant: "fcos",
 				Version: "1.0.0",
-				AdditionalConfig: `variant: fcos
+				AdditionalConfig: `
+variant: fcos
 version: 1.0.0
 systemd:
   units:
-    - name: extra.service
-      enabled: true
-      contents: "echo extra"`,
+  - name: extra.service
+    enabled: true
+    contents: "echo extra"`,
 			},
 			input: &InputProvisionData{},
-			wantJSON: `{
-  "ignition": {
-    "config": { "replace": { "verification": {} } },
-    "proxy": {},
-    "security": { "tls": {} },
-    "timeouts": {},
-    "version": "3.4.0"
-  },
-  "kernelArguments": {},
-  "passwd": {},
-  "storage": {},
-  "systemd": {
-    "units": [
+			wantJSON: `
       {
-        "contents": "echo extra",
-        "enabled": true,
-        "name": "extra.service"
-      }
-    ]
-  }
-}`,
+        "ignition": {
+          "config": {
+            "merge": [
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0KfQ=="
+              },
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN5c3RlbWQiOiB7CiAgICAidW5pdHMiOiBbCiAgICAgIHsKICAgICAgICAiY29udGVudHMiOiAiZWNobyBleHRyYSIsCiAgICAgICAgImVuYWJsZWQiOiB0cnVlLAogICAgICAgICJuYW1lIjogImV4dHJhLnNlcnZpY2UiCiAgICAgIH0KICAgIF0KICB9Cn0="
+              }
+            ]
+          },
+          "version": "3.0.0"
+        }
+      }`,
+		},
+		{
+			name: "error: with additional config but different versions",
+			provisioner: IgnitionProvisioner{
+				Variant: "fcos",
+				Version: "1.2.0",
+				AdditionalConfig: `
+variant: fcos
+version: 1.1.0
+systemd:
+  units:
+  - name: extra.service
+    enabled: true
+    contents: "echo extra"`,
+			},
+			input:   &InputProvisionData{},
+			wantErr: true,
 		},
 		{
 			name: "additional config with file",
 			provisioner: IgnitionProvisioner{
 				Variant: "fcos",
 				Version: "1.0.0",
-				AdditionalConfig: `variant: fcos
+				AdditionalConfig: `
+variant: fcos
 version: 1.0.0
 storage:
   files:
-    - path: /etc/extra.conf
-      mode: 420
-      contents:
-        inline: "from additional config"`,
+  - path: /etc/extra.conf
+    mode: 420
+    contents:
+      inline: "from additional config"`,
 			},
 			input: &InputProvisionData{},
-			wantJSON: `{
-  "ignition": {
-    "config": { "replace": { "verification": {} } },
-    "proxy": {},
-    "security": { "tls": {} },
-    "timeouts": {},
-    "version": "3.4.0"
-  },
-  "kernelArguments": {},
-  "passwd": {},
-  "storage": {
-    "files": [
+			wantJSON: `
       {
-        "contents": {
-          "compression": "",
-          "source": "data:,from%20additional%20config",
-          "verification": {}
-        },
-        "group": {},
-        "mode": 420,
-        "path": "/etc/extra.conf",
-        "user": {}
-      }
-    ]
-  },
-  "systemd": {}
-}`,
+        "ignition": {
+          "config": {
+            "merge": [
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0KfQ=="
+              },
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL2V4dHJhLmNvbmYiLAogICAgICAgICJjb250ZW50cyI6IHsKICAgICAgICAgICJzb3VyY2UiOiAiZGF0YTosZnJvbSUyMGFkZGl0aW9uYWwlMjBjb25maWciCiAgICAgICAgfSwKICAgICAgICAibW9kZSI6IDQyMAogICAgICB9CiAgICBdCiAgfQp9"
+              }
+            ]
+          },
+          "version": "3.0.0"
+        }
+      }`,
 		},
 		{
 			name: "files + additional config",
 			provisioner: IgnitionProvisioner{
 				Variant: "fcos",
 				Version: "1.0.0",
-				AdditionalConfig: `variant: fcos
+				AdditionalConfig: `
+variant: fcos
 version: 1.0.0
 storage:
   files:
-    - path: /etc/extra.conf
-      mode: 420
-      contents:
-        inline: "from additional config"`,
+  - path: /etc/extra.conf
+    mode: 420
+    contents:
+    inline: "from additional config"`,
 			},
 			input: &InputProvisionData{
 				Files: []File{
 					{Path: "/etc/test.conf", Content: "hello world", Permissions: "0644"},
 				},
 			},
-			wantJSON: `{
-  "ignition": {
-    "config": { "replace": { "verification": {} } },
-    "proxy": {},
-    "security": { "tls": {} },
-    "timeouts": {},
-    "version": "3.4.0"
-  },
-  "kernelArguments": {},
-  "passwd": {},
-  "storage": {
-    "files": [
+			wantJSON: `
       {
-        "contents": {
-          "compression": "",
-          "source": "data:,hello%20world",
-          "verification": {}
-        },
-        "group": {},
-        "mode": 420,
-        "path": "/etc/test.conf",
-        "user": {}
-      },
-      {
-        "contents": {
-          "compression": "",
-          "source": "data:,from%20additional%20config",
-          "verification": {}
-        },
-        "group": {},
-        "mode": 420,
-        "path": "/etc/extra.conf",
-        "user": {}
-      }
-    ]
-  },
-  "systemd": {}
-}`,
+        "ignition": {
+          "config": {
+            "merge": [
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL3Rlc3QuY29uZiIsCiAgICAgICAgImNvbnRlbnRzIjogewogICAgICAgICAgInNvdXJjZSI6ICJkYXRhOixoZWxsbyUyMHdvcmxkIgogICAgICAgIH0sCiAgICAgICAgIm1vZGUiOiA0MjAKICAgICAgfQogICAgXQogIH0KfQ=="
+              },
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL2V4dHJhLmNvbmYiLAogICAgICAgICJtb2RlIjogNDIwCiAgICAgIH0KICAgIF0KICB9Cn0="
+              }
+            ]
+          },
+          "version": "3.0.0"
+        }
+      }`,
 		},
 		{
 			name: "commands + additional config unit",
 			provisioner: IgnitionProvisioner{
 				Variant: "fcos",
 				Version: "1.0.0",
-				AdditionalConfig: `variant: fcos
+				AdditionalConfig: `
+variant: fcos
 version: 1.0.0
 systemd:
   units:
-    - name: extra.service
-      enabled: true
-      contents: "echo extra"`,
+  - name: extra.service
+    enabled: true
+    contents: "echo extra"`,
 			},
 			input: &InputProvisionData{
 				Commands: []string{"echo hello"},
 			},
-			wantJSON: `{
-  "ignition": {
-    "config": { "replace": { "verification": {} } },
-    "proxy": {},
-    "security": { "tls": {} },
-    "timeouts": {},
-    "version": "3.4.0"
-  },
-  "kernelArguments": {},
-  "passwd": {},
-  "storage": {},
-  "systemd": {
-    "units": [
+			wantJSON: `
       {
-        "contents": "[Unit]\nDescription=K0s Bootstrap Commands\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c 'echo hello'\nRemainAfterExit=true\n\n[Install]\nWantedBy=multi-user.target",
-        "enabled": true,
-        "name": "k0s-bootstrap.service"
-      },
-      {
-        "contents": "echo extra",
-        "enabled": true,
-        "name": "extra.service"
-      }
-    ]
-  }
-}`,
+        "ignition": {
+          "config": {
+            "merge": [
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN5c3RlbWQiOiB7CiAgICAidW5pdHMiOiBbCiAgICAgIHsKICAgICAgICAiY29udGVudHMiOiAiW1VuaXRdXG5EZXNjcmlwdGlvbj1LMHMgQm9vdHN0cmFwIENvbW1hbmRzXG5BZnRlcj1uZXR3b3JrLW9ubGluZS50YXJnZXRcblxuW1NlcnZpY2VdXG5UeXBlPW9uZXNob3RcbkV4ZWNTdGFydD0vYmluL3NoIC1jICdlY2hvIGhlbGxvJ1xuUmVtYWluQWZ0ZXJFeGl0PXRydWVcblxuW0luc3RhbGxdXG5XYW50ZWRCeT1tdWx0aS11c2VyLnRhcmdldCIsCiAgICAgICAgImVuYWJsZWQiOiB0cnVlLAogICAgICAgICJuYW1lIjogImswcy1ib290c3RyYXAuc2VydmljZSIKICAgICAgfQogICAgXQogIH0KfQ=="
+              },
+              {
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN5c3RlbWQiOiB7CiAgICAidW5pdHMiOiBbCiAgICAgIHsKICAgICAgICAiY29udGVudHMiOiAiZWNobyBleHRyYSIsCiAgICAgICAgImVuYWJsZWQiOiB0cnVlLAogICAgICAgICJuYW1lIjogImV4dHJhLnNlcnZpY2UiCiAgICAgIH0KICAgIF0KICB9Cn0="
+              }
+            ]
+          },
+          "version": "3.0.0"
+        }
+      }`,
 		},
 		{
 			name: "invalid additional config YAML",
 			provisioner: IgnitionProvisioner{
 				Variant: "fcos",
 				Version: "1.0.0",
-				AdditionalConfig: `variant: fcos
+				AdditionalConfig: `
+variant: fcos
 version: 1.0.0
 systemd: [invalid_yaml_here`,
 			},


### PR DESCRIPTION
Ignition config was always generated for 3.4 version spec. Some variant versions for the butane config used to generate the ignition config may generate other ignition spec versions ([see map table](https://coreos.github.io/butane/specs/#butane-specifications-and-ignition-specifications)). 

With this change, we make use of [`ignition.config.merge`](https://coreos.github.io/ignition/configuration-v3_0/) feature to merge basic butane config generated for machine bootstrapping + the additional butane config the user can set and generate the proper ignition spec version. 

For additional context, merging butane configs [is not implemented](https://github.com/coreos/butane/issues/118) by butane package so we rely on the merge feature of the ignition config once basic and additional butane configs has been transpiled.

Also added an e2e example using Fedora CoreOS for machine nodes