### PR TITLE
fix: make namespace for remote cluster kubeconfig required

### DIFF
--- a/api/k0smotron.io/v1beta1/k0smotroncluster_types.go
+++ b/api/k0smotron.io/v1beta1/k0smotroncluster_types.go
@@ -408,7 +408,7 @@ type KubeconfigRef struct {
 	//+kubebuilder:validation:Required
 	Name string `json:"name"`
 	// Namespace is the namespace of the secret containing the kubeconfig of the hosting cluster.
-	//+kubebuilder:validation:Optional
+	//+kubebuilder:validation:Required
 	Namespace string `json:"namespace,omitempty"`
 	// Key is the key in the secret containing the kubeconfig of the hosting cluster.
 	//+kubebuilder:validation:Optional

--- a/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -315,6 +315,7 @@ spec:
                     type: string
                 required:
                 - name
+                - namespace
                 type: object
               kubeconfigSecretMetadata:
                 description: |-

--- a/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanetemplates.yaml
+++ b/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanetemplates.yaml
@@ -303,6 +303,7 @@ spec:
                             type: string
                         required:
                         - name
+                        - namespace
                         type: object
                       kubeconfigSecretMetadata:
                         description: |-

--- a/config/crd/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/crd/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -315,6 +315,7 @@ spec:
                     type: string
                 required:
                 - name
+                - namespace
                 type: object
               kubeconfigSecretMetadata:
                 description: |-

--- a/config/crd/controlplane.cluster.x-k8s.io_k0smotroncontrolplanetemplates.yaml
+++ b/config/crd/controlplane.cluster.x-k8s.io_k0smotroncontrolplanetemplates.yaml
@@ -303,6 +303,7 @@ spec:
                             type: string
                         required:
                         - name
+                        - namespace
                         type: object
                       kubeconfigSecretMetadata:
                         description: |-

--- a/config/crd/k0smotron.io_clusters.yaml
+++ b/config/crd/k0smotron.io_clusters.yaml
@@ -277,6 +277,7 @@ spec:
                     type: string
                 required:
                 - name
+                - namespace
                 type: object
               kubeconfigSecretMetadata:
                 description: |-

--- a/config/standalone/crd/bases/k0smotron.io_clusters.yaml
+++ b/config/standalone/crd/bases/k0smotron.io_clusters.yaml
@@ -277,6 +277,7 @@ spec:
                     type: string
                 required:
                 - name
+                - namespace
                 type: object
               kubeconfigSecretMetadata:
                 description: |-

--- a/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
+++ b/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
@@ -2513,19 +2513,19 @@ This kubeconfig will be used to deploy the k0s control plane.
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>namespace</b></td>
+        <td>string</td>
+        <td>
+          Namespace is the namespace of the secret containing the kubeconfig of the hosting cluster.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>key</b></td>
         <td>string</td>
         <td>
           Key is the key in the secret containing the kubeconfig of the hosting cluster.<br/>
           <br/>
             <i>Default</i>: value<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>namespace</b></td>
-        <td>string</td>
-        <td>
-          Namespace is the namespace of the secret containing the kubeconfig of the hosting cluster.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12659,19 +12659,19 @@ This kubeconfig will be used to deploy the k0s control plane.
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>namespace</b></td>
+        <td>string</td>
+        <td>
+          Namespace is the namespace of the secret containing the kubeconfig of the hosting cluster.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>key</b></td>
         <td>string</td>
         <td>
           Key is the key in the secret containing the kubeconfig of the hosting cluster.<br/>
           <br/>
             <i>Default</i>: value<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>namespace</b></td>
-        <td>string</td>
-        <td>
-          Namespace is the namespace of the secret containing the kubeconfig of the hosting cluster.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/docs/resource-reference/k0smotron.io-v1beta1.md
+++ b/docs/resource-reference/k0smotron.io-v1beta1.md
@@ -647,19 +647,19 @@ This kubeconfig will be used to deploy the k0s control plane.
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>namespace</b></td>
+        <td>string</td>
+        <td>
+          Namespace is the namespace of the secret containing the kubeconfig of the hosting cluster.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>key</b></td>
         <td>string</td>
         <td>
           Key is the key in the secret containing the kubeconfig of the hosting cluster.<br/>
           <br/>
             <i>Default</i>: value<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>namespace</b></td>
-        <td>string</td>
-        <td>
-          Namespace is the namespace of the secret containing the kubeconfig of the hosting cluster.<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
fix #1348