### PR TITLE
fix(golangci-lint): remove `new-from-merge-base: HEAD~` config and fix all the existing linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,3 @@ formatters:
     generated: strict
     paths:
       - zz_generated.*\.go$
-# Warn only about new issues, not existing ones.
-# TODO: Remove this filter at some point and ensure all old issues are fixed.
-issues:
-  new-from-merge-base: HEAD~

--- a/api/bootstrap/v1beta1/k0s_template_types.go
+++ b/api/bootstrap/v1beta1/k0s_template_types.go
@@ -34,6 +34,7 @@ func init() {
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=bootstrap-k0smotron"
 
+// K0sWorkerConfigTemplate is the Schema for the k0sworkerconfigtemplates API
 type K0sWorkerConfigTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -41,10 +42,12 @@ type K0sWorkerConfigTemplate struct {
 	Spec K0sWorkerConfigTemplateSpec `json:"spec,omitempty"`
 }
 
+// K0sWorkerConfigTemplateSpec defines the desired state of K0sWorkerConfigTemplate
 type K0sWorkerConfigTemplateSpec struct {
 	Template K0sWorkerConfigTemplateResource `json:"template,omitempty"`
 }
 
+// K0sWorkerConfigTemplateResource defines the template for the worker config resource
 type K0sWorkerConfigTemplateResource struct {
 	// +kubebuilder:validation:Optional
 	ObjectMeta metav1.ObjectMeta   `json:"metadata,omitempty"`
@@ -53,6 +56,7 @@ type K0sWorkerConfigTemplateResource struct {
 
 // +kubebuilder:object:root=true
 
+// K0sWorkerConfigTemplateList contains a list of K0sWorkerConfigTemplate
 type K0sWorkerConfigTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/bootstrap/v1beta1/k0s_types.go
+++ b/api/bootstrap/v1beta1/k0s_types.go
@@ -56,6 +56,7 @@ const (
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=bootstrap-k0smotron"
 
+// K0sWorkerConfig is the Schema for the k0sworkerconfigs API
 type K0sWorkerConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -76,12 +77,14 @@ func (c *K0sWorkerConfig) SetConditions(conditions []metav1.Condition) {
 
 // +kubebuilder:object:root=true
 
+// K0sWorkerConfigList contains a list of K0sWorkerConfig
 type K0sWorkerConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []K0sWorkerConfig `json:"items"`
 }
 
+// K0sWorkerConfigSpec defines the desired state of K0sWorkerConfig
 type K0sWorkerConfigSpec struct {
 	// Ignition defines the ignition configuration. If empty, k0smotron will use cloud-init.
 	// +kubebuilder:validation:Optional
@@ -155,6 +158,7 @@ type SecretMetadata struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
+// JoinTokenSecretRef is a reference to a secret that contains the join token for k0s worker nodes.
 type JoinTokenSecretRef struct {
 	// Name is the name of the secret
 	// +kubebuilder:validation:Required
@@ -164,6 +168,7 @@ type JoinTokenSecretRef struct {
 	Key string `json:"key"`
 }
 
+// K0sWorkerConfigStatus defines the observed state of K0sWorkerConfig
 type K0sWorkerConfigStatus struct {
 	// Ready indicates the Bootstrapdata field is ready to be consumed
 	Ready bool `json:"ready,omitempty"`
@@ -182,6 +187,7 @@ type K0sWorkerConfigStatus struct {
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=bootstrap-k0smotron"
 
+// K0sControllerConfig is the Schema for the k0scontrollerconfigs API
 type K0sControllerConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -190,6 +196,7 @@ type K0sControllerConfig struct {
 	Status K0sControllerConfigStatus `json:"status,omitempty"`
 }
 
+// K0sControllerConfigStatus defines the observed state of K0sControllerConfig
 type K0sControllerConfigStatus struct {
 	// Ready indicates the Bootstrapdata field is ready to be consumed
 	Ready bool `json:"ready,omitempty"`
@@ -215,12 +222,14 @@ func (c *K0sControllerConfig) SetConditions(conditions []metav1.Condition) {
 
 // +kubebuilder:object:root=true
 
+// K0sControllerConfigList contains a list of K0sControllerConfig
 type K0sControllerConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []K0sControllerConfig `json:"items"`
 }
 
+// K0sControllerConfigSpec defines the desired state of K0sControllerConfig
 type K0sControllerConfigSpec struct {
 	// Version is the version of k0s to use. In case this is not set, k0smotron will use
 	// a version field of the Machine object. If it's empty, the latest version is used.
@@ -260,6 +269,7 @@ type ContentSourceRef struct {
 	Key string `json:"key"`
 }
 
+// K0sConfigSpec defines the common configuration for both K0sControllerConfig and K0sWorkerConfig.
 type K0sConfigSpec struct {
 	// Ignition defines the ignition configuration. If empty, k0smotron will use cloud-init.
 	// +kubebuilder:validation:Optional
@@ -325,6 +335,7 @@ type K0sConfigSpec struct {
 	WorkingDir string `json:"workingDir,omitempty"`
 }
 
+// TunnelingSpec defines the tunneling configuration for the cluster.
 type TunnelingSpec struct {
 	// Enabled specifies whether tunneling is enabled.
 	//+kubebuilder:validation:Optional
@@ -387,19 +398,19 @@ func (kcs *K0sConfigSpec) GetJoinTokenPath() string {
 }
 
 // GetK0sConfigPath returns the full path to the k0s.yaml file in the working directory.
-func (k *K0sWorkerConfig) GetK0sConfigPath() string {
-	if k.Spec.WorkingDir == "" {
+func (c *K0sWorkerConfig) GetK0sConfigPath() string {
+	if c.Spec.WorkingDir == "" {
 		return "/etc/k0s.yaml"
 	}
-	return filepath.Join(k.Spec.WorkingDir, "k0s.yaml")
+	return filepath.Join(c.Spec.WorkingDir, "k0s.yaml")
 }
 
 // GetJoinTokenPath returns the full path to the k0s token file in the working directory.
-func (k *K0sWorkerConfig) GetJoinTokenPath() string {
-	if k.Spec.WorkingDir == "" {
+func (c *K0sWorkerConfig) GetJoinTokenPath() string {
+	if c.Spec.WorkingDir == "" {
 		return "/etc/k0s.token"
 	}
-	return filepath.Join(k.Spec.WorkingDir, "k0s.token")
+	return filepath.Join(c.Spec.WorkingDir, "k0s.token")
 }
 
 // Validate validates the K0sWorkerConfigSpec.

--- a/api/controlplane/v1beta1/groupversion_info.go
+++ b/api/controlplane/v1beta1/groupversion_info.go
@@ -35,4 +35,5 @@ var (
 	AddToScheme = SchemeBuilder.AddToScheme
 )
 
+// K0sClusterIDAnnotation is the k0s cluster ID annotation
 const K0sClusterIDAnnotation = "k0sproject.io/cluster-id"

--- a/api/controlplane/v1beta1/k0s_template_types.go
+++ b/api/controlplane/v1beta1/k0s_template_types.go
@@ -14,6 +14,7 @@ func init() {
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
 
+// K0sControlPlaneTemplate is the template for creating K0s control planes.
 type K0sControlPlaneTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -21,16 +22,19 @@ type K0sControlPlaneTemplate struct {
 	Spec K0sControlPlaneTemplateSpec `json:"spec,omitempty"`
 }
 
+// K0sControlPlaneTemplateSpec defines the desired state of K0sControlPlaneTemplate.
 type K0sControlPlaneTemplateSpec struct {
 	Template K0sControlPlaneTemplateResource `json:"template,omitempty"`
 }
 
+// K0sControlPlaneTemplateResource describes the data needed to create a K0sControlPlane from a template.
 type K0sControlPlaneTemplateResource struct {
 	// +kubebuilder:validation:Optional
 	ObjectMeta metav1.ObjectMeta                   `json:"metadata,omitempty"`
 	Spec       K0sControlPlaneTemplateResourceSpec `json:"spec,omitempty"`
 }
 
+// K0sControlPlaneTemplateResourceSpec defines the desired state of K0sControlPlaneTemplateResource.
 type K0sControlPlaneTemplateResourceSpec struct {
 	K0sConfigSpec   bootstrapv1.K0sConfigSpec               `json:"k0sConfigSpec"`
 	MachineTemplate *K0sControlPlaneTemplateMachineTemplate `json:"machineTemplate,omitempty"`
@@ -74,6 +78,7 @@ type K0sControlPlaneTemplateMachineTemplate struct {
 
 // +kubebuilder:object:root=true
 
+// K0sControlPlaneTemplateList contains a list of K0sControlPlaneTemplate.
 type K0sControlPlaneTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/controlplane/v1beta1/k0s_types.go
+++ b/api/controlplane/v1beta1/k0s_types.go
@@ -29,6 +29,7 @@ func init() {
 	SchemeBuilder.Register(&K0sControlPlane{}, &K0sControlPlaneList{})
 }
 
+// UpdateStrategy defines the strategy to use when updating the control plane.
 type UpdateStrategy string
 
 const (
@@ -80,6 +81,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of K0sControlPlane"
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=".spec.version",description="Kubernetes version associated with this control plane"
 
+// K0sControlPlane is the Schema for the K0sControlPlanes API.
 type K0sControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -90,6 +92,7 @@ type K0sControlPlane struct {
 	Status K0sControlPlaneStatus `json:"status,omitempty"`
 }
 
+// K0sControlPlaneSpec defines the desired state of K0sControlPlane.
 type K0sControlPlaneSpec struct {
 	K0sConfigSpec   bootstrapv1.K0sConfigSpec       `json:"k0sConfigSpec"`
 	MachineTemplate *K0sControlPlaneMachineTemplate `json:"machineTemplate"`
@@ -112,6 +115,7 @@ type K0sControlPlaneSpec struct {
 	KubeconfigSecretMetadata bootstrapv1.SecretMetadata `json:"kubeconfigSecretMetadata,omitempty,omitzero"`
 }
 
+// K0sControlPlaneMachineTemplate defines the template for Machines in a K0sControlPlane object.
 type K0sControlPlaneMachineTemplate struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -125,12 +129,14 @@ type K0sControlPlaneMachineTemplate struct {
 
 // +kubebuilder:object:root=true
 
+// K0sControlPlaneList contains a list of K0sControlPlane.
 type K0sControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []K0sControlPlane `json:"items"`
 }
 
+// K0sControlPlaneStatus defines the observed state of K0sControlPlane.
 type K0sControlPlaneStatus struct {
 	// Ready denotes that the control plane is ready
 	// +optional
@@ -202,6 +208,8 @@ func (k *K0sControlPlane) SetConditions(conditions []metav1.Condition) {
 	k.Status.Conditions = conditions
 }
 
+// WorkerEnabled returns true if the control plane is configured to run worker nodes as well
+// (i.e. if the --enable-worker argument is set in the K0sConfigSpec).
 func (k *K0sControlPlane) WorkerEnabled() bool {
 	return slices.Contains(k.Spec.K0sConfigSpec.Args, "--enable-worker")
 }

--- a/api/controlplane/v1beta1/k0smotron_template_types.go
+++ b/api/controlplane/v1beta1/k0smotron_template_types.go
@@ -13,6 +13,7 @@ func init() {
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
 
+// K0smotronControlPlaneTemplate is the Schema for the k0smotroncontrolplanetemplates API
 type K0smotronControlPlaneTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -20,10 +21,12 @@ type K0smotronControlPlaneTemplate struct {
 	Spec K0smotronControlPlaneTemplateSpec `json:"spec,omitempty"`
 }
 
+// K0smotronControlPlaneTemplateSpec defines the desired state of K0smotronControlPlaneTemplate
 type K0smotronControlPlaneTemplateSpec struct {
 	Template K0smotronControlPlaneTemplateResource `json:"template,omitempty"`
 }
 
+// K0smotronControlPlaneTemplateResource defines the template for the control plane resource
 type K0smotronControlPlaneTemplateResource struct {
 	// +kubebuilder:validation:Optional
 	ObjectMeta metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -32,6 +35,7 @@ type K0smotronControlPlaneTemplateResource struct {
 
 // +kubebuilder:object:root=true
 
+// K0smotronControlPlaneTemplateList contains a list of K0smotronControlPlaneTemplate
 type K0smotronControlPlaneTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/controlplane/v1beta1/k0smotron_types.go
+++ b/api/controlplane/v1beta1/k0smotron_types.go
@@ -21,6 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// K0smotronControlPlaneFinalizer is the finalizer used by K0smotronControlPlane to clean up
+// resources associated with the control plane before deletion.
 const K0smotronControlPlaneFinalizer = "k0smotron.controlplane.cluster.x-k8s.io"
 
 func init() {
@@ -42,6 +44,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of K0sControlPlane"
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=".spec.version",description="Kubernetes version associated with this control plane"
 
+// K0smotronControlPlane is the Schema for the k0smotroncontrolplanes API
 type K0smotronControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,6 +56,7 @@ type K0smotronControlPlane struct {
 
 // +kubebuilder:object:root=true
 
+// K0smotronControlPlaneList contains a list of K0smotronControlPlane
 type K0smotronControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -66,6 +70,7 @@ type Initialization struct {
 	ControlPlaneInitialized bool `json:"controlPlaneInitialized"`
 }
 
+// K0smotronControlPlaneStatus defines the observed state of K0smotronControlPlane
 type K0smotronControlPlaneStatus struct {
 	// Ready denotes that the control plane is ready
 	// +optional

--- a/api/infrastructure/v1beta1/remote_machine_template_types.go
+++ b/api/infrastructure/v1beta1/remote_machine_template_types.go
@@ -32,6 +32,7 @@ func init() {
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=infrastructure-k0smotron"
 
+// RemoteMachineTemplate is the Schema for the remotemachinetemplates API
 type RemoteMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -39,16 +40,19 @@ type RemoteMachineTemplate struct {
 	Spec RemoteMachineTemplateSpec `json:"spec,omitempty"`
 }
 
+// RemoteMachineTemplateSpec defines the desired state of RemoteMachineTemplate
 type RemoteMachineTemplateSpec struct {
 	Template RemoteMachineTemplateResource `json:"template"`
 }
 
+// RemoteMachineTemplateResource describes the data needed to create a RemoteMachine from a template
 type RemoteMachineTemplateResource struct {
 	// +kubebuilder:validation:Optional
 	ObjectMeta metav1.ObjectMeta                 `json:"metadata,omitempty"`
 	Spec       RemoteMachineTemplateResourceSpec `json:"spec,omitempty"`
 }
 
+// RemoteMachineTemplateResourceSpec defines the desired state of RemoteMachineTemplateResource
 type RemoteMachineTemplateResourceSpec struct {
 	Pool string `json:"pool"`
 	// ProvisionJob describes the kubernetes Job to use to provision the machine.
@@ -57,6 +61,7 @@ type RemoteMachineTemplateResourceSpec struct {
 
 // +kubebuilder:object:root=true
 
+// RemoteMachineTemplateList contains a list of RemoteMachineTemplate
 type RemoteMachineTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/infrastructure/v1beta1/remote_machine_types.go
+++ b/api/infrastructure/v1beta1/remote_machine_types.go
@@ -34,6 +34,7 @@ func init() {
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=infrastructure-k0smotron"
 
+// RemoteMachine is the Schema for the remotemachines API
 type RemoteMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -97,6 +98,7 @@ type RemoteMachineSpec struct {
 	ProvisionJob *ProvisionJob `json:"provisionJob,omitempty"`
 }
 
+// ProvisionJob describes the kubernetes Job to use to provision the machine.
 type ProvisionJob struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="ssh"
@@ -122,6 +124,7 @@ type RemoteMachineStatus struct {
 	FailureMessage string `json:"failureMessage,omitempty"`
 }
 
+// SecretRef is a reference to a secret that contains a value.
 type SecretRef struct {
 	// Name is the name of the secret.
 	// +kubebuilder:validation:Required
@@ -130,6 +133,7 @@ type SecretRef struct {
 
 // +kubebuilder:object:root=true
 
+// RemoteMachineList contains a list of RemoteMachine
 type RemoteMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -144,6 +148,7 @@ type RemoteMachineList struct {
 // +kubebuilder:printcolumn:name="Reserved",type=string,JSONPath=".status.reserved",description="Indicates if the machine is reserved"
 // +kubebuilder:printcolumn:name="Remote Machine",type=string,JSONPath=".status.machineRef.name",description="Reference to the RemoteMachine"
 
+// PooledRemoteMachine represents a RemoteMachine that is part of a pool and can be reserved for use.
 type PooledRemoteMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -152,11 +157,13 @@ type PooledRemoteMachine struct {
 	Status PooledRemoteMachineStatus `json:"status,omitempty"`
 }
 
+// PooledRemoteMachineSpec defines the desired state of PooledRemoteMachine
 type PooledRemoteMachineSpec struct {
 	Pool    string            `json:"pool"`
 	Machine PooledMachineSpec `json:"machine"`
 }
 
+// PooledMachineSpec defines the connection details and provisioning information for a machine in a pool.
 type PooledMachineSpec struct {
 	// Address is the IP address or DNS name of the remote machine.
 	// +kubebuilder:validation:Required
@@ -194,11 +201,13 @@ type PooledMachineSpec struct {
 	SSHKeyRef SecretRef `json:"sshKeyRef"`
 }
 
+// PooledRemoteMachineStatus defines the observed state of PooledRemoteMachine
 type PooledRemoteMachineStatus struct {
 	Reserved   bool             `json:"reserved"`
 	MachineRef RemoteMachineRef `json:"machineRef"`
 }
 
+// RemoteMachineRef is a reference to a RemoteMachine that has been reserved for use.
 type RemoteMachineRef struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
@@ -206,6 +215,7 @@ type RemoteMachineRef struct {
 
 // +kubebuilder:object:root=true
 
+// PooledRemoteMachineList contains a list of PooledRemoteMachine
 type PooledRemoteMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/infrastructure/v1beta1/remotecluster_types.go
+++ b/api/infrastructure/v1beta1/remotecluster_types.go
@@ -14,6 +14,7 @@ func init() {
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1beta1"
 // +kubebuilder:metadata:labels="cluster.x-k8s.io/provider=infrastructure-k0smotron"
 
+// RemoteCluster is the Schema for the remoteclusters API
 type RemoteCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -39,6 +40,7 @@ type RemoteClusterStatus struct {
 
 // +kubebuilder:object:root=true
 
+// RemoteClusterList contains a list of RemoteCluster
 type RemoteClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/infrastructure/v1beta1/remoteclustertemplate_types.go
+++ b/api/infrastructure/v1beta1/remoteclustertemplate_types.go
@@ -23,7 +23,6 @@ type RemoteClusterTemplate struct {
 }
 
 // RemoteClusterTemplateSpec defines the desired state of RemoteClusterTemplate.
-
 type RemoteClusterTemplateSpec struct {
 	Template RemoteClusterTemplateResource `json:"template"`
 }

--- a/api/k0smotron.io/v1beta1/jointoken_types.go
+++ b/api/k0smotron.io/v1beta1/jointoken_types.go
@@ -38,6 +38,7 @@ type JoinTokenRequestSpec struct {
 	Role string `json:"role,omitempty"`
 }
 
+// ClusterRef is a reference to a cluster for which a join token is requested.
 type ClusterRef struct {
 	// Name of the cluster.
 	Name string `json:"name"`

--- a/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -20,6 +20,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0sControllerConfig is the Schema for the k0scontrollerconfigs
+          API
         properties:
           apiVersion:
             description: |-
@@ -39,6 +41,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: K0sControllerConfigSpec defines the desired state of K0sControllerConfig
             properties:
               args:
                 description: |-
@@ -259,6 +262,7 @@ spec:
                 type: string
             type: object
           status:
+            description: K0sControllerConfigStatus defines the observed state of K0sControllerConfig
             properties:
               conditions:
                 description: Conditions defines current service state of the K0sControllerConfig.

--- a/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -20,6 +20,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0sWorkerConfig is the Schema for the k0sworkerconfigs API
         properties:
           apiVersion:
             description: |-
@@ -39,6 +40,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: K0sWorkerConfigSpec defines the desired state of K0sWorkerConfig
             properties:
               args:
                 description: |-
@@ -226,6 +228,7 @@ spec:
                 type: string
             type: object
           status:
+            description: K0sWorkerConfigStatus defines the observed state of K0sWorkerConfig
             properties:
               conditions:
                 description: Conditions defines current service state of the K0sWorkerConfig.

--- a/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -20,6 +20,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0sWorkerConfigTemplate is the Schema for the k0sworkerconfigtemplates
+          API
         properties:
           apiVersion:
             description: |-
@@ -39,8 +41,12 @@ spec:
           metadata:
             type: object
           spec:
+            description: K0sWorkerConfigTemplateSpec defines the desired state of
+              K0sWorkerConfigTemplate
             properties:
               template:
+                description: K0sWorkerConfigTemplateResource defines the template
+                  for the worker config resource
                 properties:
                   metadata:
                     properties:
@@ -62,6 +68,8 @@ spec:
                         type: string
                     type: object
                   spec:
+                    description: K0sWorkerConfigSpec defines the desired state of
+                      K0sWorkerConfig
                     properties:
                       args:
                         description: |-

--- a/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -61,6 +61,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0sControlPlane is the Schema for the K0sControlPlanes API.
         properties:
           apiVersion:
             description: |-
@@ -80,8 +81,11 @@ spec:
           metadata:
             type: object
           spec:
+            description: K0sControlPlaneSpec defines the desired state of K0sControlPlane.
             properties:
               k0sConfigSpec:
+                description: K0sConfigSpec defines the common configuration for both
+                  K0sControllerConfig and K0sWorkerConfig.
                 properties:
                   args:
                     description: |-
@@ -312,6 +316,8 @@ spec:
                     type: object
                 type: object
               machineTemplate:
+                description: K0sControlPlaneMachineTemplate defines the template for
+                  Machines in a K0sControlPlane object.
                 properties:
                   infrastructureRef:
                     description: |-
@@ -415,6 +421,7 @@ spec:
               initialized: false
               ready: false
               version: ""
+            description: K0sControlPlaneStatus defines the observed state of K0sControlPlane.
             properties:
               conditions:
                 description: Conditions defines current service state of the K0sControlPlane.

--- a/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
+++ b/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
@@ -19,6 +19,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0sControlPlaneTemplate is the template for creating K0s control
+          planes.
         properties:
           apiVersion:
             description: |-
@@ -38,8 +40,12 @@ spec:
           metadata:
             type: object
           spec:
+            description: K0sControlPlaneTemplateSpec defines the desired state of
+              K0sControlPlaneTemplate.
             properties:
               template:
+                description: K0sControlPlaneTemplateResource describes the data needed
+                  to create a K0sControlPlane from a template.
                 properties:
                   metadata:
                     properties:
@@ -61,8 +67,12 @@ spec:
                         type: string
                     type: object
                   spec:
+                    description: K0sControlPlaneTemplateResourceSpec defines the desired
+                      state of K0sControlPlaneTemplateResource.
                     properties:
                       k0sConfigSpec:
+                        description: K0sConfigSpec defines the common configuration
+                          for both K0sControllerConfig and K0sWorkerConfig.
                         properties:
                           args:
                             description: |-

--- a/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -61,6 +61,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0smotronControlPlane is the Schema for the k0smotroncontrolplanes
+          API
         properties:
           apiVersion:
             description: |-
@@ -85,6 +87,8 @@ spec:
               certificateRefs:
                 description: CertificateRefs defines the certificate references.
                 items:
+                  description: CertificateRef defines a reference to a certificate
+                    that should be included in the cluster configuration.
                   properties:
                     name:
                       type: string
@@ -2274,6 +2278,9 @@ spec:
                   For more information check:
                   https://kubernetes.io/docs/concepts/storage/volumes
                 items:
+                  description: |-
+                    Mount defines a volume to be mounted in the control plane pod,
+                    along with the mount path and read-only flag.
                   properties:
                     awsElasticBlockStore:
                       description: |-
@@ -4936,6 +4943,8 @@ spec:
               initialized: false
               ready: false
               version: ""
+            description: K0smotronControlPlaneStatus defines the observed state of
+              K0smotronControlPlane
             properties:
               conditions:
                 description: Conditions defines current service state of the K0smotronControlPlane.

--- a/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanetemplates.yaml
+++ b/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0smotroncontrolplanetemplates.yaml
@@ -19,6 +19,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0smotronControlPlaneTemplate is the Schema for the k0smotroncontrolplanetemplates
+          API
         properties:
           apiVersion:
             description: |-
@@ -38,8 +40,12 @@ spec:
           metadata:
             type: object
           spec:
+            description: K0smotronControlPlaneTemplateSpec defines the desired state
+              of K0smotronControlPlaneTemplate
             properties:
               template:
+                description: K0smotronControlPlaneTemplateResource defines the template
+                  for the control plane resource
                 properties:
                   metadata:
                     properties:
@@ -66,6 +72,8 @@ spec:
                       certificateRefs:
                         description: CertificateRefs defines the certificate references.
                         items:
+                          description: CertificateRef defines a reference to a certificate
+                            that should be included in the cluster configuration.
                           properties:
                             name:
                               type: string
@@ -2280,6 +2288,9 @@ spec:
                           For more information check:
                           https://kubernetes.io/docs/concepts/storage/volumes
                         items:
+                          description: |-
+                            Mount defines a volume to be mounted in the control plane pod,
+                            along with the mount path and read-only flag.
                           properties:
                             awsElasticBlockStore:
                               description: |-

--- a/config/clusterapi/infrastructure/crd/bases/infrastructure.cluster.x-k8s.io_pooledremotemachines.yaml
+++ b/config/clusterapi/infrastructure/crd/bases/infrastructure.cluster.x-k8s.io_pooledremotemachines.yaml
@@ -33,6 +33,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
+        description: PooledRemoteMachine represents a RemoteMachine that is part of
+          a pool and can be reserved for use.
         properties:
           apiVersion:
             description: |-
@@ -52,8 +54,11 @@ spec:
           metadata:
             type: object
           spec:
+            description: PooledRemoteMachineSpec defines the desired state of PooledRemoteMachine
             properties:
               machine:
+                description: PooledMachineSpec defines the connection details and
+                  provisioning information for a machine in a pool.
                 properties:
                   address:
                     description: Address is the IP address or DNS name of the remote
@@ -110,8 +115,11 @@ spec:
             - pool
             type: object
           status:
+            description: PooledRemoteMachineStatus defines the observed state of PooledRemoteMachine
             properties:
               machineRef:
+                description: RemoteMachineRef is a reference to a RemoteMachine that
+                  has been reserved for use.
                 properties:
                   name:
                     type: string

--- a/config/clusterapi/infrastructure/crd/bases/infrastructure.cluster.x-k8s.io_remoteclusters.yaml
+++ b/config/clusterapi/infrastructure/crd/bases/infrastructure.cluster.x-k8s.io_remoteclusters.yaml
@@ -20,6 +20,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: RemoteCluster is the Schema for the remoteclusters API
         properties:
           apiVersion:
             description: |-

--- a/config/clusterapi/infrastructure/crd/bases/infrastructure.cluster.x-k8s.io_remoteclustertemplates.yaml
+++ b/config/clusterapi/infrastructure/crd/bases/infrastructure.cluster.x-k8s.io_remoteclustertemplates.yaml
@@ -43,6 +43,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: RemoteClusterTemplateSpec defines the desired state of RemoteClusterTemplate.
             properties:
               template:
                 description: RemoteClusterTemplateResource describes the data needed

--- a/config/clusterapi/infrastructure/crd/bases/infrastructure.cluster.x-k8s.io_remotemachines.yaml
+++ b/config/clusterapi/infrastructure/crd/bases/infrastructure.cluster.x-k8s.io_remotemachines.yaml
@@ -20,6 +20,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: RemoteMachine is the Schema for the remotemachines API
         properties:
           apiVersion:
             description: |-

--- a/config/clusterapi/infrastructure/crd/bases/infrastructure.cluster.x-k8s.io_remotemachinetemplates.yaml
+++ b/config/clusterapi/infrastructure/crd/bases/infrastructure.cluster.x-k8s.io_remotemachinetemplates.yaml
@@ -20,6 +20,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: RemoteMachineTemplate is the Schema for the remotemachinetemplates
+          API
         properties:
           apiVersion:
             description: |-
@@ -39,8 +41,11 @@ spec:
           metadata:
             type: object
           spec:
+            description: RemoteMachineTemplateSpec defines the desired state of RemoteMachineTemplate
             properties:
               template:
+                description: RemoteMachineTemplateResource describes the data needed
+                  to create a RemoteMachine from a template
                 properties:
                   metadata:
                     properties:
@@ -62,6 +67,8 @@ spec:
                         type: string
                     type: object
                   spec:
+                    description: RemoteMachineTemplateResourceSpec defines the desired
+                      state of RemoteMachineTemplateResource
                     properties:
                       pool:
                         type: string

--- a/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -61,6 +61,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0sControlPlane is the Schema for the K0sControlPlanes API.
         properties:
           apiVersion:
             description: |-
@@ -80,8 +81,11 @@ spec:
           metadata:
             type: object
           spec:
+            description: K0sControlPlaneSpec defines the desired state of K0sControlPlane.
             properties:
               k0sConfigSpec:
+                description: K0sConfigSpec defines the common configuration for both
+                  K0sControllerConfig and K0sWorkerConfig.
                 properties:
                   args:
                     description: |-
@@ -312,6 +316,8 @@ spec:
                     type: object
                 type: object
               machineTemplate:
+                description: K0sControlPlaneMachineTemplate defines the template for
+                  Machines in a K0sControlPlane object.
                 properties:
                   infrastructureRef:
                     description: |-
@@ -415,6 +421,7 @@ spec:
               initialized: false
               ready: false
               version: ""
+            description: K0sControlPlaneStatus defines the observed state of K0sControlPlane.
             properties:
               conditions:
                 description: Conditions defines current service state of the K0sControlPlane.

--- a/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
+++ b/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
@@ -19,6 +19,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0sControlPlaneTemplate is the template for creating K0s control
+          planes.
         properties:
           apiVersion:
             description: |-
@@ -38,8 +40,12 @@ spec:
           metadata:
             type: object
           spec:
+            description: K0sControlPlaneTemplateSpec defines the desired state of
+              K0sControlPlaneTemplate.
             properties:
               template:
+                description: K0sControlPlaneTemplateResource describes the data needed
+                  to create a K0sControlPlane from a template.
                 properties:
                   metadata:
                     properties:
@@ -61,8 +67,12 @@ spec:
                         type: string
                     type: object
                   spec:
+                    description: K0sControlPlaneTemplateResourceSpec defines the desired
+                      state of K0sControlPlaneTemplateResource.
                     properties:
                       k0sConfigSpec:
+                        description: K0sConfigSpec defines the common configuration
+                          for both K0sControllerConfig and K0sWorkerConfig.
                         properties:
                           args:
                             description: |-

--- a/config/crd/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
+++ b/config/crd/controlplane.cluster.x-k8s.io_k0smotroncontrolplanes.yaml
@@ -61,6 +61,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0smotronControlPlane is the Schema for the k0smotroncontrolplanes
+          API
         properties:
           apiVersion:
             description: |-
@@ -85,6 +87,8 @@ spec:
               certificateRefs:
                 description: CertificateRefs defines the certificate references.
                 items:
+                  description: CertificateRef defines a reference to a certificate
+                    that should be included in the cluster configuration.
                   properties:
                     name:
                       type: string
@@ -2274,6 +2278,9 @@ spec:
                   For more information check:
                   https://kubernetes.io/docs/concepts/storage/volumes
                 items:
+                  description: |-
+                    Mount defines a volume to be mounted in the control plane pod,
+                    along with the mount path and read-only flag.
                   properties:
                     awsElasticBlockStore:
                       description: |-
@@ -4936,6 +4943,8 @@ spec:
               initialized: false
               ready: false
               version: ""
+            description: K0smotronControlPlaneStatus defines the observed state of
+              K0smotronControlPlane
             properties:
               conditions:
                 description: Conditions defines current service state of the K0smotronControlPlane.

--- a/config/crd/controlplane.cluster.x-k8s.io_k0smotroncontrolplanetemplates.yaml
+++ b/config/crd/controlplane.cluster.x-k8s.io_k0smotroncontrolplanetemplates.yaml
@@ -19,6 +19,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: K0smotronControlPlaneTemplate is the Schema for the k0smotroncontrolplanetemplates
+          API
         properties:
           apiVersion:
             description: |-
@@ -38,8 +40,12 @@ spec:
           metadata:
             type: object
           spec:
+            description: K0smotronControlPlaneTemplateSpec defines the desired state
+              of K0smotronControlPlaneTemplate
             properties:
               template:
+                description: K0smotronControlPlaneTemplateResource defines the template
+                  for the control plane resource
                 properties:
                   metadata:
                     properties:
@@ -66,6 +72,8 @@ spec:
                       certificateRefs:
                         description: CertificateRefs defines the certificate references.
                         items:
+                          description: CertificateRef defines a reference to a certificate
+                            that should be included in the cluster configuration.
                           properties:
                             name:
                               type: string
@@ -2280,6 +2288,9 @@ spec:
                           For more information check:
                           https://kubernetes.io/docs/concepts/storage/volumes
                         items:
+                          description: |-
+                            Mount defines a volume to be mounted in the control plane pod,
+                            along with the mount path and read-only flag.
                           properties:
                             awsElasticBlockStore:
                               description: |-

--- a/config/crd/k0smotron.io_clusters.yaml
+++ b/config/crd/k0smotron.io_clusters.yaml
@@ -47,6 +47,8 @@ spec:
               certificateRefs:
                 description: CertificateRefs defines the certificate references.
                 items:
+                  description: CertificateRef defines a reference to a certificate
+                    that should be included in the cluster configuration.
                   properties:
                     name:
                       type: string
@@ -2236,6 +2238,9 @@ spec:
                   For more information check:
                   https://kubernetes.io/docs/concepts/storage/volumes
                 items:
+                  description: |-
+                    Mount defines a volume to be mounted in the control plane pod,
+                    along with the mount path and read-only flag.
                   properties:
                     awsElasticBlockStore:
                       description: |-

--- a/config/standalone/crd/bases/k0smotron.io_clusters.yaml
+++ b/config/standalone/crd/bases/k0smotron.io_clusters.yaml
@@ -47,6 +47,8 @@ spec:
               certificateRefs:
                 description: CertificateRefs defines the certificate references.
                 items:
+                  description: CertificateRef defines a reference to a certificate
+                    that should be included in the cluster configuration.
                   properties:
                     name:
                       type: string
@@ -2236,6 +2238,9 @@ spec:
                   For more information check:
                   https://kubernetes.io/docs/concepts/storage/volumes
                 items:
+                  description: |-
+                    Mount defines a volume to be mounted in the control plane pod,
+                    along with the mount path and read-only flag.
                   properties:
                     awsElasticBlockStore:
                       description: |-

--- a/docs/resource-reference/bootstrap.cluster.x-k8s.io-v1beta1.md
+++ b/docs/resource-reference/bootstrap.cluster.x-k8s.io-v1beta1.md
@@ -25,7 +25,7 @@ Resource Types:
 
 
 
-
+K0sControllerConfig is the Schema for the k0scontrollerconfigs API
 
 <table>
     <thead>
@@ -57,14 +57,14 @@ Resource Types:
         <td><b><a href="#k0scontrollerconfigspec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sControllerConfigSpec defines the desired state of K0sControllerConfig<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#k0scontrollerconfigstatus">status</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sControllerConfigStatus defines the observed state of K0sControllerConfig<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -76,7 +76,7 @@ Resource Types:
 
 
 
-
+K0sControllerConfigSpec defines the desired state of K0sControllerConfig
 
 <table>
     <thead>
@@ -586,7 +586,7 @@ If empty, k0smotron will use the default one.<br/>
 
 
 
-
+K0sControllerConfigStatus defines the observed state of K0sControllerConfig
 
 <table>
     <thead>
@@ -706,7 +706,7 @@ with respect to the current state of the instance.<br/>
 
 
 
-
+K0sWorkerConfig is the Schema for the k0sworkerconfigs API
 
 <table>
     <thead>
@@ -738,14 +738,14 @@ with respect to the current state of the instance.<br/>
         <td><b><a href="#k0sworkerconfigspec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sWorkerConfigSpec defines the desired state of K0sWorkerConfig<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#k0sworkerconfigstatus">status</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sWorkerConfigStatus defines the observed state of K0sWorkerConfig<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -757,7 +757,7 @@ with respect to the current state of the instance.<br/>
 
 
 
-
+K0sWorkerConfigSpec defines the desired state of K0sWorkerConfig
 
 <table>
     <thead>
@@ -1218,7 +1218,7 @@ SecretMetadata specifies metadata (labels and annotations) to be propagated to t
 
 
 
-
+K0sWorkerConfigStatus defines the observed state of K0sWorkerConfig
 
 <table>
     <thead>
@@ -1338,7 +1338,7 @@ with respect to the current state of the instance.<br/>
 
 
 
-
+K0sWorkerConfigTemplate is the Schema for the k0sworkerconfigtemplates API
 
 <table>
     <thead>
@@ -1370,7 +1370,7 @@ with respect to the current state of the instance.<br/>
         <td><b><a href="#k0sworkerconfigtemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sWorkerConfigTemplateSpec defines the desired state of K0sWorkerConfigTemplate<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1382,7 +1382,7 @@ with respect to the current state of the instance.<br/>
 
 
 
-
+K0sWorkerConfigTemplateSpec defines the desired state of K0sWorkerConfigTemplate
 
 <table>
     <thead>
@@ -1397,7 +1397,7 @@ with respect to the current state of the instance.<br/>
         <td><b><a href="#k0sworkerconfigtemplatespectemplate">template</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sWorkerConfigTemplateResource defines the template for the worker config resource<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1409,7 +1409,7 @@ with respect to the current state of the instance.<br/>
 
 
 
-
+K0sWorkerConfigTemplateResource defines the template for the worker config resource
 
 <table>
     <thead>
@@ -1431,7 +1431,7 @@ with respect to the current state of the instance.<br/>
         <td><b><a href="#k0sworkerconfigtemplatespectemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sWorkerConfigSpec defines the desired state of K0sWorkerConfig<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1498,7 +1498,7 @@ with respect to the current state of the instance.<br/>
 
 
 
-
+K0sWorkerConfigSpec defines the desired state of K0sWorkerConfig
 
 <table>
     <thead>

--- a/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
+++ b/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
@@ -27,7 +27,7 @@ Resource Types:
 
 
 
-
+K0sControlPlane is the Schema for the K0sControlPlanes API.
 
 <table>
     <thead>
@@ -59,14 +59,14 @@ Resource Types:
         <td><b><a href="#k0scontrolplanespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sControlPlaneSpec defines the desired state of K0sControlPlane.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#k0scontrolplanestatus">status</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sControlPlaneStatus defines the observed state of K0sControlPlane.<br/>
           <br/>
             <i>Default</i>: map[initialization:map[controlPlaneInitialized:false] initialized:false ready:false version:]<br/>
         </td>
@@ -80,7 +80,7 @@ Resource Types:
 
 
 
-
+K0sControlPlaneSpec defines the desired state of K0sControlPlane.
 
 <table>
     <thead>
@@ -95,14 +95,14 @@ Resource Types:
         <td><b><a href="#k0scontrolplanespeck0sconfigspec">k0sConfigSpec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sConfigSpec defines the common configuration for both K0sControllerConfig and K0sWorkerConfig.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#k0scontrolplanespecmachinetemplate">machineTemplate</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sControlPlaneMachineTemplate defines the template for Machines in a K0sControlPlane object.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -151,7 +151,7 @@ just the Kubernetes version (e.g. v1.27.1). If left empty, k0smotron will select
 
 
 
-
+K0sConfigSpec defines the common configuration for both K0sControllerConfig and K0sWorkerConfig.
 
 <table>
     <thead>
@@ -651,7 +651,7 @@ If empty, k0smotron will use the default one.<br/>
 
 
 
-
+K0sControlPlaneMachineTemplate defines the template for Machines in a K0sControlPlane object.
 
 <table>
     <thead>
@@ -845,7 +845,7 @@ Note: This metadata will have precedence over default labels/annotations on the 
 
 
 
-
+K0sControlPlaneStatus defines the observed state of K0sControlPlane.
 
 <table>
     <thead>
@@ -1071,7 +1071,7 @@ initialization represents the initialization status of the control plane
 
 
 
-
+K0sControlPlaneTemplate is the template for creating K0s control planes.
 
 <table>
     <thead>
@@ -1103,7 +1103,7 @@ initialization represents the initialization status of the control plane
         <td><b><a href="#k0scontrolplanetemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sControlPlaneTemplateSpec defines the desired state of K0sControlPlaneTemplate.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1115,7 +1115,7 @@ initialization represents the initialization status of the control plane
 
 
 
-
+K0sControlPlaneTemplateSpec defines the desired state of K0sControlPlaneTemplate.
 
 <table>
     <thead>
@@ -1130,7 +1130,7 @@ initialization represents the initialization status of the control plane
         <td><b><a href="#k0scontrolplanetemplatespectemplate">template</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sControlPlaneTemplateResource describes the data needed to create a K0sControlPlane from a template.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1142,7 +1142,7 @@ initialization represents the initialization status of the control plane
 
 
 
-
+K0sControlPlaneTemplateResource describes the data needed to create a K0sControlPlane from a template.
 
 <table>
     <thead>
@@ -1164,7 +1164,7 @@ initialization represents the initialization status of the control plane
         <td><b><a href="#k0scontrolplanetemplatespectemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sControlPlaneTemplateResourceSpec defines the desired state of K0sControlPlaneTemplateResource.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1231,7 +1231,7 @@ initialization represents the initialization status of the control plane
 
 
 
-
+K0sControlPlaneTemplateResourceSpec defines the desired state of K0sControlPlaneTemplateResource.
 
 <table>
     <thead>
@@ -1246,7 +1246,7 @@ initialization represents the initialization status of the control plane
         <td><b><a href="#k0scontrolplanetemplatespectemplatespeck0sconfigspec">k0sConfigSpec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0sConfigSpec defines the common configuration for both K0sControllerConfig and K0sWorkerConfig.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -1287,7 +1287,7 @@ be configured on the K0sControlPlaneTemplate.<br/>
 
 
 
-
+K0sConfigSpec defines the common configuration for both K0sControllerConfig and K0sWorkerConfig.
 
 <table>
     <thead>
@@ -1889,7 +1889,7 @@ More info: http://kubernetes.io/docs/user-guide/labels<br/>
 
 
 
-
+K0smotronControlPlane is the Schema for the k0smotroncontrolplanes API
 
 <table>
     <thead>
@@ -1928,7 +1928,7 @@ More info: http://kubernetes.io/docs/user-guide/labels<br/>
         <td><b><a href="#k0smotroncontrolplanestatus">status</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0smotronControlPlaneStatus defines the observed state of K0smotronControlPlane<br/>
           <br/>
             <i>Default</i>: map[conditions:[map[lastTransitionTime:1970-01-01T00:00:00Z message:Waiting for cluster topology to be reconciled reason:ControlPlaneDoesNotExist status:Unknown type:ControlPlaneReady]] initialization:map[controlPlaneInitialized:false] initialized:false ready:false version:]<br/>
         </td>
@@ -2143,7 +2143,7 @@ will pick it automatically.<br/>
 
 
 
-
+CertificateRef defines a reference to a certificate that should be included in the cluster configuration.
 
 <table>
     <thead>
@@ -6552,7 +6552,8 @@ them as usual kubernetes pod metrics.<br/>
 
 
 
-
+Mount defines a volume to be mounted in the control plane pod,
+along with the mount path and read-only flag.
 
 <table>
     <thead>
@@ -11709,7 +11710,7 @@ merge patch.<br/>
 
 
 
-
+K0smotronControlPlaneStatus defines the observed state of K0smotronControlPlane
 
 <table>
     <thead>
@@ -11928,7 +11929,7 @@ initialization represents the initialization status of the control plane
 
 
 
-
+K0smotronControlPlaneTemplate is the Schema for the k0smotroncontrolplanetemplates API
 
 <table>
     <thead>
@@ -11960,7 +11961,7 @@ initialization represents the initialization status of the control plane
         <td><b><a href="#k0smotroncontrolplanetemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0smotronControlPlaneTemplateSpec defines the desired state of K0smotronControlPlaneTemplate<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11972,7 +11973,7 @@ initialization represents the initialization status of the control plane
 
 
 
-
+K0smotronControlPlaneTemplateSpec defines the desired state of K0smotronControlPlaneTemplate
 
 <table>
     <thead>
@@ -11987,7 +11988,7 @@ initialization represents the initialization status of the control plane
         <td><b><a href="#k0smotroncontrolplanetemplatespectemplate">template</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          K0smotronControlPlaneTemplateResource defines the template for the control plane resource<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11999,7 +12000,7 @@ initialization represents the initialization status of the control plane
 
 
 
-
+K0smotronControlPlaneTemplateResource defines the template for the control plane resource
 
 <table>
     <thead>
@@ -12289,7 +12290,7 @@ will pick it automatically.<br/>
 
 
 
-
+CertificateRef defines a reference to a certificate that should be included in the cluster configuration.
 
 <table>
     <thead>
@@ -16698,7 +16699,8 @@ them as usual kubernetes pod metrics.<br/>
 
 
 
-
+Mount defines a volume to be mounted in the control plane pod,
+along with the mount path and read-only flag.
 
 <table>
     <thead>

--- a/docs/resource-reference/infrastructure.cluster.x-k8s.io-v1beta1.md
+++ b/docs/resource-reference/infrastructure.cluster.x-k8s.io-v1beta1.md
@@ -29,7 +29,7 @@ Resource Types:
 
 
 
-
+PooledRemoteMachine represents a RemoteMachine that is part of a pool and can be reserved for use.
 
 <table>
     <thead>
@@ -61,14 +61,14 @@ Resource Types:
         <td><b><a href="#pooledremotemachinespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          PooledRemoteMachineSpec defines the desired state of PooledRemoteMachine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#pooledremotemachinestatus">status</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          PooledRemoteMachineStatus defines the observed state of PooledRemoteMachine<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -80,7 +80,7 @@ Resource Types:
 
 
 
-
+PooledRemoteMachineSpec defines the desired state of PooledRemoteMachine
 
 <table>
     <thead>
@@ -95,7 +95,7 @@ Resource Types:
         <td><b><a href="#pooledremotemachinespecmachine">machine</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          PooledMachineSpec defines the connection details and provisioning information for a machine in a pool.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -114,7 +114,7 @@ Resource Types:
 
 
 
-
+PooledMachineSpec defines the connection details and provisioning information for a machine in a pool.
 
 <table>
     <thead>
@@ -229,7 +229,7 @@ The key must be placed on the secret using the key "value".
 
 
 
-
+PooledRemoteMachineStatus defines the observed state of PooledRemoteMachine
 
 <table>
     <thead>
@@ -244,7 +244,7 @@ The key must be placed on the secret using the key "value".
         <td><b><a href="#pooledremotemachinestatusmachineref">machineRef</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          RemoteMachineRef is a reference to a RemoteMachine that has been reserved for use.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -263,7 +263,7 @@ The key must be placed on the secret using the key "value".
 
 
 
-
+RemoteMachineRef is a reference to a RemoteMachine that has been reserved for use.
 
 <table>
     <thead>
@@ -299,7 +299,7 @@ The key must be placed on the secret using the key "value".
 
 
 
-
+RemoteCluster is the Schema for the remoteclusters API
 
 <table>
     <thead>
@@ -478,7 +478,7 @@ RemoteClusterTemplate is the Schema for the remoteclustertemplates API.
         <td><b><a href="#remoteclustertemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          RemoteClusterTemplateSpec defines the desired state of RemoteClusterTemplate.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -490,7 +490,7 @@ RemoteClusterTemplate is the Schema for the remoteclustertemplates API.
 
 
 
-
+RemoteClusterTemplateSpec defines the desired state of RemoteClusterTemplate.
 
 <table>
     <thead>
@@ -698,7 +698,7 @@ More info: http://kubernetes.io/docs/user-guide/labels<br/>
 
 
 
-
+RemoteMachine is the Schema for the remotemachines API
 
 <table>
     <thead>
@@ -18170,7 +18170,7 @@ MachineAddress contains information for the node's address.
 
 
 
-
+RemoteMachineTemplate is the Schema for the remotemachinetemplates API
 
 <table>
     <thead>
@@ -18202,7 +18202,7 @@ MachineAddress contains information for the node's address.
         <td><b><a href="#remotemachinetemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          RemoteMachineTemplateSpec defines the desired state of RemoteMachineTemplate<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -18214,7 +18214,7 @@ MachineAddress contains information for the node's address.
 
 
 
-
+RemoteMachineTemplateSpec defines the desired state of RemoteMachineTemplate
 
 <table>
     <thead>
@@ -18229,7 +18229,7 @@ MachineAddress contains information for the node's address.
         <td><b><a href="#remotemachinetemplatespectemplate">template</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          RemoteMachineTemplateResource describes the data needed to create a RemoteMachine from a template<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -18241,7 +18241,7 @@ MachineAddress contains information for the node's address.
 
 
 
-
+RemoteMachineTemplateResource describes the data needed to create a RemoteMachine from a template
 
 <table>
     <thead>
@@ -18263,7 +18263,7 @@ MachineAddress contains information for the node's address.
         <td><b><a href="#remotemachinetemplatespectemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          <br/>
+          RemoteMachineTemplateResourceSpec defines the desired state of RemoteMachineTemplateResource<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -18330,7 +18330,7 @@ MachineAddress contains information for the node's address.
 
 
 
-
+RemoteMachineTemplateResourceSpec defines the desired state of RemoteMachineTemplateResource
 
 <table>
     <thead>

--- a/docs/resource-reference/k0smotron.io-v1beta1.md
+++ b/docs/resource-reference/k0smotron.io-v1beta1.md
@@ -277,7 +277,7 @@ will pick it automatically.<br/>
 
 
 
-
+CertificateRef defines a reference to a certificate that should be included in the cluster configuration.
 
 <table>
     <thead>
@@ -4686,7 +4686,8 @@ them as usual kubernetes pod metrics.<br/>
 
 
 
-
+Mount defines a volume to be mounted in the control plane pod,
+along with the mount path and read-only flag.
 
 <table>
     <thead>

--- a/internal/controller/bootstrap/controlplane_bootstrap_controller.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller.go
@@ -62,6 +62,7 @@ import (
 	"github.com/k0sproject/version"
 )
 
+// ControlPlaneController is responsible for reconciling the K0sControllerConfig resource.
 type ControlPlaneController struct {
 	client.Client
 	SecretCachingClient client.Client
@@ -70,10 +71,11 @@ type ControlPlaneController struct {
 	RESTConfig          *rest.Config
 }
 
-var minVersionForETCDName = version.MustParse("v1.31.1")
 var minVersionForETCDMemberCRD = version.MustParse("v1.31.6")
 var errInitialControllerMachineNotInitialize = errors.New("initial controller machine has not completed its initialization")
 
+// ControllerScope contains the information required to generate the bootstrap data
+// for a control plane machine.
 type ControllerScope struct {
 	Config            *bootstrapv1.K0sControllerConfig
 	ConfigOwner       *bsutil.ConfigOwner
@@ -95,6 +97,8 @@ type ControllerScope struct {
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 
+// Reconcile reconciles the K0sControllerConfig resource, which is responsible for generating the
+// bootstrap data for control plane machines.
 func (c *ControlPlaneController) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := log.FromContext(ctx).WithValues("K0sControllerConfig", req.NamespacedName)
 	log.Info("Reconciling K0sControllerConfig")

--- a/internal/controller/bootstrap/providerid_controller.go
+++ b/internal/controller/bootstrap/providerid_controller.go
@@ -23,12 +23,15 @@ import (
 	k0smoutil "github.com/k0sproject/k0smotron/internal/controller/util"
 )
 
+// ProviderIDController is responsible for reconciling the ProviderID field of the Machine resource.
 type ProviderIDController struct {
 	client.Client
 	Scheme    *runtime.Scheme
 	ClientSet *kubernetes.Clientset
 }
 
+// Reconcile reconciles the ProviderID field of the Machine resource and
+// ensures it is set on the corresponding Node in the workload cluster.
 func (p *ProviderIDController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx).WithValues("providerID", req.NamespacedName)
 	log.Info("Reconciling machine's ProviderID")
@@ -112,7 +115,7 @@ func (p *ProviderIDController) Reconcile(ctx context.Context, req ctrl.Request) 
 	if node.Spec.ProviderID == "" {
 		node.Spec.ProviderID = machine.Spec.ProviderID
 		node.Labels[machineNameNodeLabel] = machine.GetName()
-		err = retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		err = retry.OnError(retry.DefaultBackoff, func(_ error) bool {
 			return true
 		}, func() error {
 			_, upErr := childClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})

--- a/internal/controller/bootstrap/worker_bootstrap_controller.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller.go
@@ -60,6 +60,8 @@ const (
 	machineNameNodeLabel = "k0smotron.io/machine-name"
 )
 
+// Controller is responsible for reconciling the K0sWorkerConfig resource, which is responsible
+// for generating the bootstrap data for worker machines.
 type Controller struct {
 	client.Client
 	SecretCachingClient client.Client
@@ -70,6 +72,7 @@ type Controller struct {
 	workloadClusterClient client.Client
 }
 
+// Scope contains the information required to generate the bootstrap data for a worker machine.
 type Scope struct {
 	Config              *bootstrapv1.K0sWorkerConfig
 	ConfigOwner         *bsutil.ConfigOwner
@@ -91,6 +94,7 @@ type Scope struct {
 // +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=k0scontrolplanes/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=k0scontrolplanes,verbs=get;list;watch;create;update;patch;delete
 
+// Reconcile reconciles the k0sconfig resource.
 func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := log.FromContext(ctx).WithValues("k0sconfig", req.NamespacedName)
 	log.Info("Reconciling K0sConfig")

--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -68,6 +68,7 @@ const (
 	AnnotationValueManagedByK0smotron = "k0smotron"
 )
 
+// K0smotronController is the controller for K0smotronControlPlane objects.
 type K0smotronController struct {
 	client.Client
 	SecretCachingClient client.Client
@@ -76,6 +77,7 @@ type K0smotronController struct {
 	RESTConfig          *rest.Config
 }
 
+// Scope defines the basic context for the reconciliation of a K0smotronControlPlane object.
 type Scope struct {
 	Config *cpv1beta1.K0smotronControlPlane
 	// ConfigOwner *bsutil.ConfigOwner
@@ -101,6 +103,7 @@ type kmcScope struct {
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 
+// Reconcile reconciles the K0smotronControlPlane to the desired state.
 func (c *K0smotronController) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := log.FromContext(ctx).WithValues("controlplane", req.NamespacedName)
 	log.Info("Reconciling K0smotronControlPlane")

--- a/internal/controller/controlplane/remediation.go
+++ b/internal/controller/controlplane/remediation.go
@@ -124,7 +124,7 @@ func (c *K0sController) reconcileUnhealthyMachines(ctx context.Context, cluster 
 
 	// After checks, remediation can be carried out.
 
-	if err := c.runMachineDeletionSequence(ctx, cluster, kcp, machineToBeRemediated); err != nil {
+	if err := c.runMachineDeletionSequence(ctx, kcp, machineToBeRemediated); err != nil {
 		conditions.Set(machineToBeRemediated, metav1.Condition{
 			Type:    string(clusterv1.MachineOwnerRemediatedCondition),
 			Status:  metav1.ConditionFalse,

--- a/internal/controller/infrastructure/cluster_controller.go
+++ b/internal/controller/infrastructure/cluster_controller.go
@@ -29,6 +29,8 @@ import (
 	infrastructure "github.com/k0sproject/k0smotron/api/infrastructure/v1beta1"
 )
 
+// ClusterController is responsible for reconciling the RemoteCluster resource,
+// which represents a remote cluster that is being managed by k0smotron.
 type ClusterController struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -37,6 +39,7 @@ type ClusterController struct {
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=remoteclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=remoteclusters/status,verbs=get;list;watch;create;update;patch;delete
 
+// Reconcile reconciles the RemoteCluster resource and ensures it is in a ready state.
 func (r *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := log.FromContext(ctx).WithValues("remotecluster", req.NamespacedName)
 	log.Info("Reconciling RemoteCluster")

--- a/internal/controller/infrastructure/job_provisioner.go
+++ b/internal/controller/infrastructure/job_provisioner.go
@@ -26,6 +26,9 @@ var patchOpts []client.PatchOption = []client.PatchOption{
 	client.ForceOwnership,
 }
 
+// JobProvisioner is responsible for provisioning a remote machine using a Kubernetes Job.
+// It creates a Job that runs a container with the necessary tools to SSH into the
+// remote machine and execute the bootstrap commands.
 type JobProvisioner struct {
 	client    client.Client
 	clientSet *kubernetes.Clientset
@@ -38,6 +41,8 @@ type JobProvisioner struct {
 	log           logr.Logger
 }
 
+// Provision provisions the remote machine by creating a Kubernetes Job that executes the
+// bootstrap commands on the remote machine.
 func (p *JobProvisioner) Provision(ctx context.Context) error {
 	// Parse the bootstrap data
 
@@ -190,6 +195,7 @@ func (p *JobProvisioner) machineDSN() (dsn string) {
 	return dsn
 }
 
+// Cleanup cleans up the resources created for provisioning the remote machine.
 func (p *JobProvisioner) Cleanup(_ context.Context, mode RemoteMachineMode) error {
 	if mode == ModeNonK0s {
 		return nil

--- a/internal/controller/infrastructure/ssh_provisioner.go
+++ b/internal/controller/infrastructure/ssh_provisioner.go
@@ -38,6 +38,7 @@ import (
 
 var regex = regexp.MustCompile(`--kubelet-root-dir[ =](/[/a-zA-Z0-9_-]+)+`)
 
+// SSHProvisioner is responsible for provisioning a remote machine using SSH.
 type SSHProvisioner struct {
 	cloudInit *provisioner.InputProvisionData
 	machine   *api.RemoteMachine

--- a/internal/controller/k0smotron.io/jointokenrequest_controller.go
+++ b/internal/controller/k0smotron.io/jointokenrequest_controller.go
@@ -57,6 +57,8 @@ type JoinTokenRequestReconciler struct {
 //+kubebuilder:rbac:groups=k0smotron.io,resources=jointokenrequests/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
+// Reconcile reconciles a JoinTokenRequest object by creating a join token for the referenced
+// cluster and storing it in a secret.
 func (r *JoinTokenRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 

--- a/internal/controller/k0smotron.io/k0smotroncluster_webhook.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_webhook.go
@@ -84,6 +84,7 @@ func (c ClusterValidator) validateVersionSuffix(version string) admission.Warnin
 	return warnings
 }
 
+// Default sets default values for the Cluster resource.
 func (c *ClusterDefaulter) Default(_ context.Context, obj runtime.Object) error {
 	kmc, ok := obj.(*km.Cluster)
 	if !ok {

--- a/internal/controller/util/kubeclient.go
+++ b/internal/controller/util/kubeclient.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// GetKubeClient returns a Kubernetes clientset for the given cluster.
 func GetKubeClient(ctx context.Context, client client.Client, cluster *clusterv1.Cluster) (*kubernetes.Clientset, error) {
 	data, err := kubeconfig.FromSecret(ctx, client, capiutil.ObjectKey(cluster))
 	if err != nil {

--- a/internal/controller/util/util.go
+++ b/internal/controller/util/util.go
@@ -72,6 +72,8 @@ func LabelsForEtcdK0smotronCluster(kmc *km.Cluster) map[string]string {
 	return labels
 }
 
+// AnnotationsForK0smotronCluster returns annotations for K0smotron cluster resources,
+// including user-defined annotations from the cluster spec.
 func AnnotationsForK0smotronCluster(kmc *km.Cluster) map[string]string {
 	if kmc.Annotations == nil {
 		kmc.Annotations = make(map[string]string)
@@ -83,12 +85,12 @@ func AnnotationsForK0smotronCluster(kmc *km.Cluster) map[string]string {
 }
 
 // AddToExistingSans merges original sans list with a new sans slice avoiding duplicated values.
-func AddToExistingSans(existing []string, new []string) []string {
+func AddToExistingSans(existing []string, newSan []string) []string {
 	uniques := make(map[string]struct{})
 	for _, val := range existing {
 		uniques[val] = struct{}{}
 	}
-	for _, val := range new {
+	for _, val := range newSan {
 		uniques[val] = struct{}{}
 	}
 	finalSans := make([]string, 0, len(uniques))

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:revive
 package exec
 
 import (

--- a/internal/provisioner/cloudinit.go
+++ b/internal/provisioner/cloudinit.go
@@ -94,6 +94,8 @@ func (c *CloudInitProvisioner) GetFormat() string {
 	return cloudInitProvisioningFormat
 }
 
+// PermissionsAsInt converts the Permissions string to an int64.
+// If Permissions is empty, it defaults to "0644".
 func (f File) PermissionsAsInt() (int64, error) {
 	if f.Permissions == "" {
 		f.Permissions = "0644"

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -175,6 +175,7 @@ func newEnvironment(setupSecretCachingClient setupSecretCachingClientFn) *Enviro
 	}
 }
 
+// Build builds and starts the test environment, returning an instance of it.
 func Build(ctx context.Context, setupSecretCachingClient setupSecretCachingClientFn) *Environment {
 	testEnv := newEnvironment(setupSecretCachingClient)
 	go func() {
@@ -187,6 +188,7 @@ func Build(ctx context.Context, setupSecretCachingClient setupSecretCachingClien
 	return testEnv
 }
 
+// Teardown stops the test environment and performs necessary cleanup.
 func (e *Environment) Teardown() {
 	e.cancel()
 	if err := e.Stop(); err != nil {

--- a/internal/util/dynamic_config.go
+++ b/internal/util/dynamic_config.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package util
 
 import (
@@ -14,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ReconcileDynamicConfig updates the k0s ClusterConfig with the provided unstructured configuration.
 func ReconcileDynamicConfig(ctx context.Context, cluster metav1.Object, cli client.Client, u unstructured.Unstructured) error {
 	u.SetName("k0s")
 	u.SetNamespace("kube-system")
@@ -39,7 +41,7 @@ func ReconcileDynamicConfig(ctx context.Context, cluster metav1.Object, cli clie
 		Duration: 100 * time.Millisecond,
 		Factor:   5.0,
 		Jitter:   0.5,
-	}, func(err error) bool {
+	}, func(_ error) bool {
 		return true
 	}, func() error {
 		return chCS.Patch(ctx, &u, client.RawPatch(client.Merge.Type(), b), []client.PatchOption{}...)

--- a/internal/util/random.go
+++ b/internal/util/random.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:revive
 package util
 
 import "crypto/rand"

--- a/internal/util/token.go
+++ b/internal/util/token.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package util
 
 import (
@@ -30,6 +31,8 @@ func joinEncode(in io.Reader) (string, error) {
 	return base64.StdEncoding.EncodeToString(outBuf.Bytes()), nil
 }
 
+// CreateK0sJoinToken creates a join token for k0s using the provided CA certificate,
+// token, join URL, and username.
 func CreateK0sJoinToken(caCert []byte, token string, joinURL string, userName string) (string, error) {
 	const k0sContextName = "k0s"
 	kubeconfig, err := clientcmd.Write(clientcmdapi.Config{

--- a/inttest/basic/basic_test.go
+++ b/inttest/basic/basic_test.go
@@ -81,7 +81,7 @@ func (s *BasicSuite) TestK0sGetsUp() {
 	s.updateK0smotronCluster(s.Context(), rc)
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.Context(), 100*time.Millisecond, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.Context(), 100*time.Millisecond, func(_ context.Context) (bool, error) {
 		pod, err := kc.CoreV1().Pods("kmc-test").Get(s.Context(), "kmc-kmc-test-0", metav1.GetOptions{})
 		if err != nil {
 			return false, nil

--- a/inttest/capi-config-update-vm/capi_config_update_vm_test.go
+++ b/inttest/capi-config-update-vm/capi_config_update_vm_test.go
@@ -95,7 +95,7 @@ func (s *CAPIConfigUpdateVMSuite) TestCAPIConfigUpdateVMWorker() {
 
 	var localPort int
 	// nolint:staticcheck
-	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -129,7 +129,7 @@ func (s *CAPIConfigUpdateVMSuite) TestCAPIConfigUpdateVMWorker() {
 	s.Require().NoError(err)
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		output, err := exec.Command("docker", "exec", fmt.Sprintf("docker-test-cluster-%s", controlPlaneMachineName), "k0s", "kc", "--kubeconfig=/var/lib/k0s/pki/admin.conf", "get", "clusterconfig", "-A").Output()
 		if err != nil {
 			return false, nil
@@ -143,7 +143,7 @@ func (s *CAPIConfigUpdateVMSuite) TestCAPIConfigUpdateVMWorker() {
 	s.updateClusterObjects()
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		cm, err := kmcKC.CoreV1().ConfigMaps("kube-system").Get(s.ctx, "kube-router-cfg", metav1.GetOptions{})
 		if err != nil {
 			return false, nil

--- a/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
+++ b/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
@@ -96,7 +96,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
 	var localPort int
-	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -106,7 +106,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 	kmcKC, err := util.GetKMCClientSet(s.ctx, s.client, "docker-test-cluster", "default", localPort)
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -176,7 +176,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 	s.Require().NoError(err)
 
 	// wait for the controlplane nodes to be down to 1
-	err = wait.PollUntilContextCancel(scaleDownCtx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(scaleDownCtx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		ids, err := util.GetControlPlaneNodesIDs("docker-test-cluster")
 		if err != nil {
 			return false, nil

--- a/inttest/capi-controlplane-docker-rm/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker-rm/capi_controlplane_docker_test.go
@@ -93,7 +93,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 
 	var localPort int
 	// nolint:staticcheck
-	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -104,7 +104,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.Require().NoError(err)
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").

--- a/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
+++ b/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
@@ -94,7 +94,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
 	var localPort int
-	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -104,7 +104,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	kmcKC, err := util.GetKMCClientSet(s.ctx, s.client, "docker-test-cluster", "default", localPort)
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -150,7 +150,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.Require().NoError(err)
 
 	s.T().Log("check for node to be ready via tunnel")
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		resp, err := tunneledKmcKC.RESTClient().
 			Get().
 			AbsPath("/healthz").

--- a/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
+++ b/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
@@ -93,7 +93,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
 	var localPort int
-	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -103,7 +103,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	kmcKC, err := util.GetKMCClientSet(s.ctx, s.client, "docker-test-cluster", "default", localPort)
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -151,7 +151,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	}
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		resp, err := cl.Get("https://localhost:" + strconv.Itoa(forwardedPort) + "/healthz")
 		if err != nil {
 			return false, nil

--- a/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
+++ b/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
@@ -91,7 +91,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDockerWorker() {
 
 	var localPort int
 	// nolint:staticcheck
-	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -102,7 +102,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDockerWorker() {
 	s.Require().NoError(err)
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").

--- a/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
@@ -95,7 +95,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 
 	var localPort int
 	// nolint:staticcheck
-	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -105,7 +105,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	kmcKC, err := util.GetKMCClientSet(s.ctx, s.client, "docker-test-cluster", "default", localPort)
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -195,7 +195,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 		Do(s.ctx).
 		Error()
 
-	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(_ context.Context) (bool, error) {
 		var obj unstructured.UnstructuredList
 		err := s.client.RESTClient().
 			Get().
@@ -211,7 +211,7 @@ func (s *CAPIControlPlaneDockerSuite) TestCAPIControlPlaneDocker() {
 	})
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").

--- a/inttest/capi-docker-clusterclass-recreate-upgrade/capi_docker_clusterclass_test.go
+++ b/inttest/capi-docker-clusterclass-recreate-upgrade/capi_docker_clusterclass_test.go
@@ -146,7 +146,7 @@ func (s *CAPIDockerClusterClassSuite) TestCAPIDockerClusterClass() {
 
 	var localPort int
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -158,7 +158,7 @@ func (s *CAPIDockerClusterClassSuite) TestCAPIDockerClusterClass() {
 
 	s.T().Log("waiting for control-plane")
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -170,7 +170,7 @@ func (s *CAPIDockerClusterClassSuite) TestCAPIDockerClusterClass() {
 
 	s.T().Log("waiting for worker nodes")
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		nodes, _ := kmcKC.CoreV1().Nodes().List(s.ctx, metav1.ListOptions{})
 		return len(nodes.Items) == 2, nil
 	})
@@ -189,7 +189,7 @@ func (s *CAPIDockerClusterClassSuite) TestCAPIDockerClusterClass() {
 	kcpName := kcpList.Items[0].Name
 	// Wait to see the controlplane status is correct
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		kcp, err := util.GetK0sControlPlane(s.ctx, s.client, kcpName, "default")
 		if err != nil {
 			return true, err
@@ -211,7 +211,7 @@ func (s *CAPIDockerClusterClassSuite) TestCAPIDockerClusterClass() {
 
 	s.T().Log("waiting for control-plane nodes to be updated")
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		cp, err := util.GetK0sControlPlane(s.ctx, s.client, kcpName, "default")
 		if err != nil {
 			return false, err

--- a/inttest/capi-docker-clusterclass/capi_docker_clusterclass_test.go
+++ b/inttest/capi-docker-clusterclass/capi_docker_clusterclass_test.go
@@ -154,7 +154,7 @@ func (s *CAPIDockerClusterClassSuite) TestCAPIDockerClusterClass() {
 
 	var localPort int
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("TestCAPIDockerClusterClassSuite-k0smotron0")
 		return localPort > 0, nil
 	})
@@ -166,7 +166,7 @@ func (s *CAPIDockerClusterClassSuite) TestCAPIDockerClusterClass() {
 
 	s.T().Log("waiting for control-plane")
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -178,7 +178,7 @@ func (s *CAPIDockerClusterClassSuite) TestCAPIDockerClusterClass() {
 
 	s.T().Log("waiting for worker nodes")
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		nodes, _ := kmcKC.CoreV1().Nodes().List(s.ctx, metav1.ListOptions{})
 		return len(nodes.Items) == 2, nil
 	})

--- a/inttest/capi-docker-machine-change-args/capi_docker_machine_change_args_test.go
+++ b/inttest/capi-docker-machine-change-args/capi_docker_machine_change_args_test.go
@@ -96,7 +96,7 @@ func (s *CAPIDockerMachineChangeArgs) TestCAPIControlPlaneDockerDownScaling() {
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
 	var localPort int
-	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-lb")
 		return localPort > 0, nil
 	})
@@ -106,7 +106,7 @@ func (s *CAPIDockerMachineChangeArgs) TestCAPIControlPlaneDockerDownScaling() {
 	kmcKC, err := util.GetKMCClientSet(s.ctx, s.client, "docker-test", "default", localPort)
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -117,7 +117,7 @@ func (s *CAPIDockerMachineChangeArgs) TestCAPIControlPlaneDockerDownScaling() {
 	s.Require().NoError(err)
 
 	var nodeIDs []string
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		var err error
 		nodeIDs, err = util.GetControlPlaneNodesIDs("docker-test-")
 
@@ -133,7 +133,7 @@ func (s *CAPIDockerMachineChangeArgs) TestCAPIControlPlaneDockerDownScaling() {
 	s.Require().NoError(err)
 
 	for _, node := range nodes {
-		err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 			output, err := exec.Command("docker", "exec", node, "k0s", "status").Output()
 			if err != nil {
 				return false, nil
@@ -150,7 +150,7 @@ func (s *CAPIDockerMachineChangeArgs) TestCAPIControlPlaneDockerDownScaling() {
 	s.T().Log("updating cluster objects")
 	s.updateClusterObjects()
 
-	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(_ context.Context) (bool, error) {
 		var obj unstructured.UnstructuredList
 		err := s.client.RESTClient().
 			Get().
@@ -175,7 +175,7 @@ func (s *CAPIDockerMachineChangeArgs) TestCAPIControlPlaneDockerDownScaling() {
 	})
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").

--- a/inttest/capi-docker-machine-change-template/capi_docker_machine_change_template_test.go
+++ b/inttest/capi-docker-machine-change-template/capi_docker_machine_change_template_test.go
@@ -100,7 +100,7 @@ func (s *CAPIDockerMachineChangeTemplate) TestCAPIControlPlaneDockerDownScaling(
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
 	var localPort int
-	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-lb")
 		return localPort > 0, nil
 	})
@@ -110,7 +110,7 @@ func (s *CAPIDockerMachineChangeTemplate) TestCAPIControlPlaneDockerDownScaling(
 	kmcKC, err := util.GetKMCClientSet(s.ctx, s.client, "docker-test", "default", localPort)
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -121,7 +121,7 @@ func (s *CAPIDockerMachineChangeTemplate) TestCAPIControlPlaneDockerDownScaling(
 	s.Require().NoError(err)
 
 	var nodeIDs []string
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		var err error
 		nodeIDs, err = util.GetControlPlaneNodesIDs("docker-test-")
 
@@ -137,7 +137,7 @@ func (s *CAPIDockerMachineChangeTemplate) TestCAPIControlPlaneDockerDownScaling(
 	s.Require().NoError(err)
 
 	for _, node := range nodes {
-		err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 			output, err := exec.Command("docker", "exec", node, "k0s", "status").Output()
 			if err != nil {
 				return false, nil
@@ -154,7 +154,7 @@ func (s *CAPIDockerMachineChangeTemplate) TestCAPIControlPlaneDockerDownScaling(
 	s.T().Log("updating cluster objects")
 	s.updateClusterObjects()
 
-	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(_ context.Context) (bool, error) {
 		var obj unstructured.UnstructuredList
 		err := s.client.RESTClient().
 			Get().
@@ -181,7 +181,7 @@ func (s *CAPIDockerMachineChangeTemplate) TestCAPIControlPlaneDockerDownScaling(
 	s.T().Log("updating cluster objects again")
 	s.updateClusterObjectsAgain()
 
-	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(_ context.Context) (bool, error) {
 		var obj unstructured.UnstructuredList
 		err := s.client.RESTClient().
 			Get().
@@ -206,7 +206,7 @@ func (s *CAPIDockerMachineChangeTemplate) TestCAPIControlPlaneDockerDownScaling(
 	})
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").

--- a/inttest/capi-docker-machine-template-update-recreate-kine/capi_docker_machine_template_update_recreate_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate-kine/capi_docker_machine_template_update_recreate_test.go
@@ -104,7 +104,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateKine) TestCAPIControlPlaneDocker
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
 	var localPort int
-	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -114,7 +114,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateKine) TestCAPIControlPlaneDocker
 	kmcKC, err := util.GetKMCClientSet(s.ctx, s.client, "docker-test-cluster", "default", localPort)
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -125,7 +125,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateKine) TestCAPIControlPlaneDocker
 	s.Require().NoError(err)
 
 	var nodeIDs []string
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		var err error
 		nodeIDs, err = util.GetControlPlaneNodesIDs("docker-test-")
 
@@ -169,7 +169,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateKine) TestCAPIControlPlaneDocker
 	s.T().Log("updating cluster objects")
 	s.updateClusterObjects()
 
-	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(_ context.Context) (bool, error) {
 		var obj unstructured.UnstructuredList
 		err := s.client.RESTClient().
 			Get().

--- a/inttest/capi-docker-machine-template-update-recreate-single/capi_docker_machine_template_update_recreate_single_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate-single/capi_docker_machine_template_update_recreate_single_test.go
@@ -96,7 +96,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateSingle) TestCAPIControlPlaneDock
 
 	var localPort int
 	// nolint:staticcheck
-	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -107,7 +107,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateSingle) TestCAPIControlPlaneDock
 	s.Require().NoError(err)
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -144,7 +144,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateSingle) TestCAPIControlPlaneDock
 	s.updateClusterObjects()
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 100*time.Millisecond, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 100*time.Millisecond, func(_ context.Context) (bool, error) {
 		var err error
 		newNodeIDs, err := util.GetControlPlaneNodesIDs("docker-test-")
 
@@ -157,7 +157,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateSingle) TestCAPIControlPlaneDock
 	s.Require().NoError(err)
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		var err error
 		nodeIDs, err := util.GetControlPlaneNodesIDs("docker-test-")
 

--- a/inttest/capi-docker-machine-template-update-recreate/capi_docker_machine_template_update_recreate_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate/capi_docker_machine_template_update_recreate_test.go
@@ -98,7 +98,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreate) TestCAPIControlPlaneDockerDown
 
 	var localPort int
 	// nolint:staticcheck
-	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err := wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		var portErr error
 		localPort, portErr = getLBPort("docker-test-lb")
 		if portErr != nil {
@@ -114,7 +114,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreate) TestCAPIControlPlaneDockerDown
 	s.Require().NoError(err)
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").
@@ -125,7 +125,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreate) TestCAPIControlPlaneDockerDown
 	s.Require().NoError(err)
 
 	var nodeIDs []string
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		var err error
 		nodeIDs, err = util.GetControlPlaneNodesIDs("docker-test-")
 
@@ -168,7 +168,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreate) TestCAPIControlPlaneDockerDown
 	s.T().Log("updating cluster objects")
 	s.updateClusterObjects()
 
-	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 100*time.Millisecond, true, func(_ context.Context) (bool, error) {
 		var obj unstructured.UnstructuredList
 		err := s.client.RESTClient().
 			Get().

--- a/inttest/capi-docker-machine-template-update/capi_docker_machine_template_update_test.go
+++ b/inttest/capi-docker-machine-template-update/capi_docker_machine_template_update_test.go
@@ -98,7 +98,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 
 	var localPort int
-	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("docker-test-cluster-lb")
 		return localPort > 0, nil
 	})
@@ -108,7 +108,7 @@ func (s *CAPIControlPlaneDockerDownScalingSuite) TestCAPIControlPlaneDockerDownS
 	kmcKC, err := util.GetKMCClientSet(s.ctx, s.client, "docker-test-cluster", "default", localPort)
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.ctx, 1*time.Second, true, func(_ context.Context) (bool, error) {
 		b, _ := s.client.RESTClient().
 			Get().
 			AbsPath("/healthz").

--- a/inttest/capi-remote-machine-template-update/capi_remote_machine_template_update_test.go
+++ b/inttest/capi-remote-machine-template-update/capi_remote_machine_template_update_test.go
@@ -143,7 +143,7 @@ func (s *RemoteMachineTemplateUpdateSuite) TestCAPIRemoteMachine() {
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 	var localPort int
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("TestRemoteMachineSuite-k0smotron0")
 		return localPort > 0, nil
 	})
@@ -156,7 +156,7 @@ func (s *RemoteMachineTemplateUpdateSuite) TestCAPIRemoteMachine() {
 	s.T().Log("verify the RemoteMachine is at expected state")
 	var rmName string
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		rm, err := s.findRemoteMachines("default")
 		if err != nil {
 			return false, err
@@ -172,7 +172,7 @@ func (s *RemoteMachineTemplateUpdateSuite) TestCAPIRemoteMachine() {
 	s.Require().NoError(err)
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		rm, err := s.getRemoteMachine(rmName, "default")
 		if err != nil {
 			return false, err
@@ -194,7 +194,7 @@ func (s *RemoteMachineTemplateUpdateSuite) TestCAPIRemoteMachine() {
 	s.T().Log("update cluster")
 	s.updateCluster()
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		output, err := exec.Command("docker", "exec", "TestRemoteMachineSuite-k0smotron0", "k0s", "status").Output()
 		if err != nil {
 			return false, nil

--- a/inttest/capi-remote-machine-template/capi_remote_machine_template_test.go
+++ b/inttest/capi-remote-machine-template/capi_remote_machine_template_test.go
@@ -141,7 +141,7 @@ func (s *RemoteMachineTemplateSuite) TestCAPIRemoteMachine() {
 	s.T().Log("cluster objects applied, waiting for cluster to be ready")
 	var localPort int
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(_ context.Context) (bool, error) {
 		localPort, _ = getLBPort("TestRemoteMachineSuite-k0smotron0")
 		return localPort > 0, nil
 	})

--- a/inttest/config-update-hcp/config_update_test.go
+++ b/inttest/config-update-hcp/config_update_test.go
@@ -88,7 +88,7 @@ func (s *ConfigUpdateSuite) TestK0sGetsUp() {
 	s.updateK0smotronCluster(s.Context(), rc)
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.Context(), 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.Context(), 1*time.Second, func(_ context.Context) (bool, error) {
 		cm, err := kmcKC.CoreV1().ConfigMaps("kube-system").Get(s.Context(), "kube-router-cfg", metav1.GetOptions{})
 		if err != nil {
 			return false, nil

--- a/inttest/ha-controller-etcd/ha_controller_etcd_test.go
+++ b/inttest/ha-controller-etcd/ha_controller_etcd_test.go
@@ -89,7 +89,7 @@ func (s *HAControllerEtcdSuite) TestK0sGetsUp() {
 	s.T().Log("update cluster")
 	s.updateK0smotronCluster(s.Context(), rc)
 
-	err = wait.PollUntilContextCancel(s.Context(), 5*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.Context(), 5*time.Second, true, func(_ context.Context) (bool, error) {
 		sts, err := kc.AppsV1().StatefulSets("kmc-test").Get(s.Context(), "kmc-kmc-test", metav1.GetOptions{})
 		if err != nil {
 			return false, nil

--- a/inttest/jointoken/jointoken_test.go
+++ b/inttest/jointoken/jointoken_test.go
@@ -68,7 +68,7 @@ func (s *JoinTokenSuite) TestK0sGetsUp() {
 	s.deleteK0smotronCluster(s.Context(), kc)
 
 	s.T().Log("checking if JoinTokenRequest is deleted")
-	err = wait.PollUntilContextCancel(s.Context(), 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(s.Context(), 100*time.Millisecond, true, func(_ context.Context) (bool, error) {
 		res := kc.RESTClient().Get().AbsPath("/apis/k0smotron.io/v1beta1/namespaces/jtr-test/jointokenrequests/jtr-test").Do(s.Context())
 
 		var statusCode int

--- a/inttest/scaling-etcd/scaling_etcd_test.go
+++ b/inttest/scaling-etcd/scaling_etcd_test.go
@@ -76,7 +76,7 @@ func (s *ScalingSuite) TestK0sGetsUp() {
 	s.scaleK0smotronCluster(s.Context(), rc, 2)
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.Context(), 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.Context(), 1*time.Second, func(_ context.Context) (bool, error) {
 		cpSts, err := kc.AppsV1().StatefulSets("default").Get(s.Context(), "kmc-scaling", metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -86,7 +86,7 @@ func (s *ScalingSuite) TestK0sGetsUp() {
 	})
 	s.Require().NoError(err)
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.Context(), 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.Context(), 1*time.Second, func(_ context.Context) (bool, error) {
 		etcdSts, err := kc.AppsV1().StatefulSets("default").Get(s.Context(), "kmc-scaling-etcd", metav1.GetOptions{})
 		if err != nil {
 			return false, nil
@@ -108,7 +108,7 @@ func (s *ScalingSuite) TestK0sGetsUp() {
 	s.Require().NoError(common.WaitForStatefulSet(s.Context(), kc, "kmc-scaling-etcd", "default"))
 
 	// nolint:staticcheck
-	err = wait.PollImmediateUntilWithContext(s.Context(), 1*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollImmediateUntilWithContext(s.Context(), 1*time.Second, func(_ context.Context) (bool, error) {
 		sts, err := kc.AppsV1().StatefulSets("default").Get(s.Context(), "kmc-scaling", metav1.GetOptions{})
 		if err != nil {
 			return false, nil

--- a/inttest/upgrade/upgrade_test.go
+++ b/inttest/upgrade/upgrade_test.go
@@ -109,7 +109,7 @@ func (s *UpgradeSuite) TestK0smotronUpgrade() {
 	kmcKC, err := util.GetKMCClientSet(s.Context(), kc, "kmc-test", "kmc-test", localPort)
 	s.Require().NoError(err)
 
-	err = wait.PollUntilContextCancel(s.Context(), 100*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextCancel(s.Context(), 100*time.Millisecond, true, func(_ context.Context) (done bool, err error) {
 		_, err = kmcKC.CoreV1().Namespaces().Get(s.Context(), "test-ns-cm", metav1.GetOptions{})
 		if err != nil {
 			return false, nil

--- a/inttest/util/docker.go
+++ b/inttest/util/docker.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package util
 
 import (
@@ -6,6 +7,8 @@ import (
 	"strings"
 )
 
+// GetControlPlaneNodesIDs retrieves the IDs of the control plane nodes by executing a `docker ps`
+// command and filtering the output based on the given prefix.
 func GetControlPlaneNodesIDs(prefix string) ([]string, error) {
 	out, err := exec.Command("/bin/sh", "-c", fmt.Sprintf(`docker ps | grep %s | grep -v "\-lb" | grep -v worker | awk '{print $1}'`, prefix)).Output()
 	if err != nil {

--- a/inttest/util/k0sutil.go
+++ b/inttest/util/k0sutil.go
@@ -55,6 +55,7 @@ func logfFrom(ctx context.Context) LogfFn {
 	return logrus.Infof
 }
 
+// LineWriter is an io.Writer that buffers data until it encounters a newline character,
 type LineWriter struct {
 	WriteLine func([]byte)
 	buf       []byte
@@ -87,6 +88,7 @@ func (s *LineWriter) logLines() {
 	}
 }
 
+// Flush should be called before stopping the writer to ensure all data is logged.
 // Logs any remaining data in the buffer that doesn't end with a newline.
 func (s *LineWriter) Flush() {
 	if len(s.buf) > 0 {
@@ -96,6 +98,7 @@ func (s *LineWriter) Flush() {
 	}
 }
 
+// WaitForNodeReadyStatus waits until the node with the given name has the specified Ready condition status.
 func WaitForNodeReadyStatus(ctx context.Context, clients kubernetes.Interface, nodeName string, status corev1.ConditionStatus) error {
 	return watch.Nodes(clients.CoreV1().Nodes()).
 		WithObjectName(nodeName).
@@ -115,6 +118,8 @@ func WaitForNodeReadyStatus(ctx context.Context, clients kubernetes.Interface, n
 		})
 }
 
+// RetryWatchErrors returns a watch.ErrorCallback that retries on transient errors and logs them
+// using the provided LogfFn.
 func RetryWatchErrors(logf LogfFn) watch.ErrorCallback {
 	return func(err error) (time.Duration, error) {
 		if retryDelay, e := watch.IsRetryable(err); e == nil {
@@ -142,6 +147,7 @@ func RetryWatchErrors(logf LogfFn) watch.ErrorCallback {
 	}
 }
 
+// WaitForPod waits until the pod with the given name and namespace has the Ready condition set to True.
 func WaitForPod(ctx context.Context, kc *kubernetes.Clientset, name, namespace string) error {
 	return watch.Pods(kc.CoreV1().Pods(namespace)).
 		WithObjectName(name).

--- a/inttest/util/k0sutil_test.go
+++ b/inttest/util/k0sutil_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:revive
 package util
 
 import (

--- a/inttest/util/portforward.go
+++ b/inttest/util/portforward.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:revive
 package util
 
 import (
@@ -28,13 +29,18 @@ import (
 	"k8s.io/client-go/transport/spdy"
 )
 
+// PortForwarder is a utility for managing port forwarding to a Kubernetes pod.
 type PortForwarder struct {
 	stopChan  chan struct{}
 	ReadyChan chan struct{}
 	fw        *portforward.PortForwarder
 }
-type ErrorHandler func(err error, msgAndArgs ...interface{})
 
+// ErrorHandler is a function type for handling errors,
+// typically used in the Start method of PortForwarder.
+type ErrorHandler func(err error, msgAndArgs ...any)
+
+// GetPortForwarder creates a new PortForwarder for the specified pod and port.
 func GetPortForwarder(cfg *rest.Config, name string, namespace string, port int) (*PortForwarder, error) {
 	transport, upgrader, err := spdy.RoundTripperFor(cfg)
 	if err != nil {
@@ -77,7 +83,7 @@ func (pf *PortForwarder) Close() {
 	pf.fw.Close()
 }
 
-// Get the local port that is forwarded to the remote port
+// LocalPort returns the local port that is being forwarded to the pod.
 func (pf *PortForwarder) LocalPort() (int, error) {
 	ports, err := pf.fw.GetPorts()
 	if err != nil {

--- a/inttest/util/portforward_test.go
+++ b/inttest/util/portforward_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:revive
 package util
 
 import (

--- a/inttest/util/suite_ctx.go
+++ b/inttest/util/suite_ctx.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:revive
 package util
 
 import (
@@ -27,6 +28,7 @@ import (
 	"time"
 )
 
+// NewSuiteContext creates a context for the test suite that is aware of OS signals and test deadlines.
 func NewSuiteContext(t *testing.T) (context.Context, context.CancelCauseFunc) {
 	signalCtx, cancel := signalAwareCtx(context.Background())
 

--- a/inttest/util/watch/apps.go
+++ b/inttest/util/watch/apps.go
@@ -20,14 +20,17 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
+// DaemonSets returns a Watcher for DaemonSets.
 func DaemonSets(client Provider[*appsv1.DaemonSetList]) *Watcher[appsv1.DaemonSet] {
 	return FromClient[*appsv1.DaemonSetList, appsv1.DaemonSet](client)
 }
 
+// Deployments returns a Watcher for Deployments.
 func Deployments(client Provider[*appsv1.DeploymentList]) *Watcher[appsv1.Deployment] {
 	return FromClient[*appsv1.DeploymentList, appsv1.Deployment](client)
 }
 
+// StatefulSets returns a Watcher for StatefulSets.
 func StatefulSets(client Provider[*appsv1.StatefulSetList]) *Watcher[appsv1.StatefulSet] {
 	return FromClient[*appsv1.StatefulSetList, appsv1.StatefulSet](client)
 }

--- a/inttest/util/watch/core.go
+++ b/inttest/util/watch/core.go
@@ -20,10 +20,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// Nodes returns a Watcher for Nodes.
 func Nodes(client Provider[*corev1.NodeList]) *Watcher[corev1.Node] {
 	return FromClient[*corev1.NodeList, corev1.Node](client)
 }
 
+// Pods returns a Watcher for Pods.
 func Pods(client Provider[*corev1.PodList]) *Watcher[corev1.Pod] {
 	return FromClient[*corev1.PodList, corev1.Pod](client)
 }

--- a/inttest/util/watch/watcher.go
+++ b/inttest/util/watch/watcher.go
@@ -63,6 +63,7 @@ type Provider[L any] interface {
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
 }
 
+// VersionedResource is a Kubernetes resource that has a resource version.
 type VersionedResource interface {
 	GetResourceVersion() string
 }

--- a/inttest/util/watch/watcher_test.go
+++ b/inttest/util/watch/watcher_test.go
@@ -121,7 +121,7 @@ func TestWatcher(t *testing.T) {
 
 		err := underTest.
 			WithErrorCallback(forbiddenErrorCallback(t)).
-			Until(ctx, func(watched *corev1.ConfigMap) (bool, error) {
+			Until(ctx, func(_ *corev1.ConfigMap) (bool, error) {
 				assert.Zero(t, callsToCondition, "Condition called more than once")
 				callsToCondition++
 
@@ -194,7 +194,7 @@ func TestWatcher(t *testing.T) {
 				t.Parallel()
 				provider, underTest := newTestWatcher()
 				provider.nextList.ListMeta.ResourceVersion = t.Name()
-				provider.watch = func(opts metav1.ListOptions) error {
+				provider.watch = func(_ metav1.ListOptions) error {
 					provider.ch = openEventChanWith(apiwatch.Event{
 						Type:   test.eventType,
 						Object: &injectedErr.ErrStatus,
@@ -275,7 +275,7 @@ func TestWatcher(t *testing.T) {
 				Object: &apierrors.NewResourceExpired("injected resource version too old").ErrStatus,
 			})
 
-			provider.watch = func(opts metav1.ListOptions) error {
+			provider.watch = func(_ metav1.ListOptions) error {
 				provider.ch = openEventChanWith(apiwatch.Event{
 					Type:   apiwatch.Added,
 					Object: &someConfigMap,
@@ -311,7 +311,7 @@ func TestWatcher(t *testing.T) {
 		t.Parallel()
 		provider, underTest := newTestWatcher()
 		provider.nextList.ListMeta.ResourceVersion = t.Name()
-		provider.watch = func(opts metav1.ListOptions) error {
+		provider.watch = func(_ metav1.ListOptions) error {
 			provider.ch = openEventChanWith(apiwatch.Event{
 				Type:   apiwatch.Added,
 				Object: &someConfigMap,
@@ -351,7 +351,7 @@ func TestWatcher(t *testing.T) {
 
 		provider, underTest := newTestWatcher()
 		provider.nextList.ListMeta.ResourceVersion = t.Name()
-		provider.watch = func(opts metav1.ListOptions) error {
+		provider.watch = func(_ metav1.ListOptions) error {
 			provider.ch = openEventChanWith(apiwatch.Event{
 				Type:   apiwatch.Added,
 				Object: &bogusSecret,
@@ -429,7 +429,7 @@ func TestWatcher(t *testing.T) {
 
 			provider, underTest := newTestWatcher()
 			provider.nextList.ListMeta.ResourceVersion = t.Name()
-			provider.watch = func(opts metav1.ListOptions) error {
+			provider.watch = func(_ metav1.ListOptions) error {
 				provider.ch = openEventChanWith(apiwatch.Event{
 					Type:   apiwatch.Added,
 					Object: &invalidConfigMap,
@@ -479,7 +479,7 @@ func TestWatcher(t *testing.T) {
 		provider, underTest := newTestWatcher()
 		provider.nextList.ListMeta.ResourceVersion = t.Name()
 		var second, third func(opts metav1.ListOptions) error
-		provider.watch = func(opts metav1.ListOptions) error {
+		provider.watch = func(_ metav1.ListOptions) error {
 			bookmark := unstructured.Unstructured{
 				Object: map[string]any{
 					"metadata": map[string]any{


### PR DESCRIPTION
Most of the linting error was `exported: exported function X should have comment or be unexported (revive)`. Copilot inline completions are doing fine job. But some of them may feel a bit forced.

There were some unused parameter errors as well. In that case, I removed the unused parameters where possible, and used `_` where required.

This has become a rather large PR, but I was able to completely remove the `issues: new-from-merge-base: HEAD~` piece and moving forward all linting issues will be reported as normal.

Fixed 237 linting issues in total.