### PR TITLE
Bump K8s version references in docs and tests to v1.34.3

### DIFF
--- a/api/controlplane/v1beta1/k0s_types.go
+++ b/api/controlplane/v1beta1/k0s_types.go
@@ -101,8 +101,8 @@ type K0sControlPlaneSpec struct {
 	//+kubebuilder:validation:Enum=InPlace;Recreate;RecreateDeleteFirst
 	//+kubebuilder:default=InPlace
 	UpdateStrategy UpdateStrategy `json:"updateStrategy,omitempty"`
-	// Version defines the k0s version to be deployed. You can use a specific k0s version (e.g. v1.27.1+k0s.0) or
-	// just the Kubernetes version (e.g. v1.27.1). If left empty, k0smotron will select one automatically.
+	// Version defines the k0s version to be deployed. You can use a specific k0s version (e.g. v1.34.3+k0s.0) or
+	// just the Kubernetes version (e.g. v1.34.3). If left empty, k0smotron will select one automatically.
 	//+kubebuilder:validation:Optional
 	Version string `json:"version,omitempty"`
 	// KubeconfigSecretMetadata specifies metadata (labels and annotations) to be propagated to the kubeconfig Secret

--- a/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -401,8 +401,8 @@ spec:
                 type: string
               version:
                 description: |-
-                  Version defines the k0s version to be deployed. You can use a specific k0s version (e.g. v1.27.1+k0s.0) or
-                  just the Kubernetes version (e.g. v1.27.1). If left empty, k0smotron will select one automatically.
+                  Version defines the k0s version to be deployed. You can use a specific k0s version (e.g. v1.34.3+k0s.0) or
+                  just the Kubernetes version (e.g. v1.34.3). If left empty, k0smotron will select one automatically.
                 type: string
             required:
             - k0sConfigSpec

--- a/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -401,8 +401,8 @@ spec:
                 type: string
               version:
                 description: |-
-                  Version defines the k0s version to be deployed. You can use a specific k0s version (e.g. v1.27.1+k0s.0) or
-                  just the Kubernetes version (e.g. v1.27.1). If left empty, k0smotron will select one automatically.
+                  Version defines the k0s version to be deployed. You can use a specific k0s version (e.g. v1.34.3+k0s.0) or
+                  just the Kubernetes version (e.g. v1.34.3). If left empty, k0smotron will select one automatically.
                 type: string
             required:
             - k0sConfigSpec

--- a/config/samples/capi/capi-controlplane-hetzner.yaml
+++ b/config/samples/capi/capi-controlplane-hetzner.yaml
@@ -24,7 +24,7 @@ kind: K0smotronControlPlane # This would somehow map to k0smotron
 metadata:
   name: cp-test
 spec:
-  version: v1.27.2-k0s.0
+  version: v1.34.3-k0s.0
   persistence:
     type: emptyDir
   service:

--- a/config/samples/capi/docker/cluster-with-machinedeployment.yaml
+++ b/config/samples/capi/docker/cluster-with-machinedeployment.yaml
@@ -26,7 +26,7 @@ kind: K0smotronControlPlane
 metadata:
   name: docker-md-test
 spec:
-  version: v1.27.2-k0s.0
+  version: v1.34.3-k0s.0
   persistence:
     type: emptyDir
   service:
@@ -57,7 +57,7 @@ spec:
         cluster.x-k8s.io/cluster-name: docker-md-test
         pool: worker-pool-1
     spec:
-      version: v1.27.2
+      version: v1.34.3
       clusterName: docker-md-test
       bootstrap:
         configRef:
@@ -77,7 +77,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.2+k0s.0
+      version: v1.34.3+k0s.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/config/samples/capi/docker/docker-cluster.yaml
+++ b/config/samples/capi/docker/docker-cluster.yaml
@@ -26,7 +26,7 @@ kind: K0smotronControlPlane
 metadata:
   name: docker-test
 spec:
-  version: v1.27.2-k0s.0
+  version: v1.34.3-k0s.0
   persistence:
     type: emptyDir
   service:
@@ -62,7 +62,7 @@ metadata:
   name: docker-test-0
   namespace: default
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachine

--- a/docs/capi-aws.md
+++ b/docs/capi-aws.md
@@ -50,7 +50,7 @@ kind: K0smotronControlPlane # This is the config for the controlplane
 metadata:
   name: k0s-aws-test-cp
 spec:
-  version: v1.27.2-k0s.0
+  version: v1.34.3-k0s.0
   persistence:
     type: emptyDir
   service:
@@ -136,7 +136,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.2+k0s.0
+      version: v1.34.3+k0s.0
       # More details of the worker configuration can be set here
 ---
 ```

--- a/docs/capi-bootstrap.md
+++ b/docs/capi-bootstrap.md
@@ -32,7 +32,7 @@ metadata:
   name: machine-test-config
   namespace: default
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
   # Details of the worker configuration can be set here
 ```
 
@@ -60,7 +60,7 @@ kind: K0sWorkerConfig
 metadata:
   name: worker-config
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
   preStartCommands:
     - "apt-get update && apt-get install -y curl jq"
     - "mkdir -p /etc/k0s/monitoring"
@@ -77,7 +77,7 @@ kind: K0sWorkerConfig
 metadata:
   name: worker-config
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
   postStartCommands:
     - "systemctl enable monitoring-agent"
     - "systemctl start monitoring-agent"
@@ -103,7 +103,7 @@ kind: K0sWorkerConfig
 metadata:
   name: worker-with-monitoring
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
   preStartCommands:
     - "curl -fsSL https://get.docker.com | sh"
     - "systemctl enable docker"
@@ -121,7 +121,7 @@ kind: K0sWorkerConfig
 metadata:
   name: worker-with-config
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
   preStartCommands:
     - "echo 'vm.max_map_count=262144' >> /etc/sysctl.conf"
     - "sysctl -p"
@@ -140,7 +140,7 @@ kind: K0sWorkerConfig
 metadata:
   name: worker-with-health-checks
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
   postStartCommands:
     - "kubectl get nodes --kubeconfig=/var/lib/k0s/pki/admin.conf"
     - "kubectl describe node $(hostname) --kubeconfig=/var/lib/k0s/pki/admin.conf"
@@ -210,7 +210,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.2+k0s.0
+      version: v1.34.3+k0s.0
       # More details of the worker configuration can be set here
 ```
 

--- a/docs/capi-clusterclass.md
+++ b/docs/capi-clusterclass.md
@@ -60,7 +60,7 @@ metadata:
 spec:
   topology:
     class: k0smotron-clusterclass
-    version: v1.27.2
+    version: v1.34.3
     workers:
       machineDeployments:
       - class: default-worker
@@ -163,7 +163,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.2+k0s.0
+      version: v1.34.3+k0s.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/docs/capi-controlplane.md
+++ b/docs/capi-controlplane.md
@@ -30,7 +30,7 @@ kind: K0smotronControlPlane
 metadata:
   name: cp-test
 spec:
-  version: v1.27.2-k0s.0
+  version: v1.34.3-k0s.0
   persistence:
     type: emptyDir
   service:

--- a/docs/capi-docker.md
+++ b/docs/capi-docker.md
@@ -54,7 +54,7 @@ metadata:
   name: docker-test-cp
   namespace: default
 spec:
-  version: v1.27.2-k0s.0
+  version: v1.34.3-k0s.0
   persistence:
     type: emptyDir
   service:
@@ -89,7 +89,7 @@ spec:
         pool: worker-pool-1
     spec:
       clusterName: docker-test
-      version: v1.27.2 # Docker Provider requires a version to be set (see https://hub.docker.com/r/kindest/node/tags)
+      version: v1.34.3 # Docker Provider requires a version to be set (see https://hub.docker.com/r/kindest/node/tags)
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -117,7 +117,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.2+k0s.0
+      version: v1.34.3+k0s.0
       # More details of the worker configuration can be set here
 ```
 

--- a/docs/capi-hetzner.md
+++ b/docs/capi-hetzner.md
@@ -51,7 +51,7 @@ kind: K0smotronControlPlane # This is the config for the controlplane
 metadata:
   name: hetzner-test-cp
 spec:
-  version: v1.27.2-k0s.0
+  version: v1.34.3-k0s.0
   persistence:
     type: emptyDir
   service:
@@ -129,7 +129,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.2+k0s.0
+      version: v1.34.3+k0s.0
       # More details of the worker configuration can be set here
 ---
 apiVersion: v1

--- a/docs/capi-kubevirt.md
+++ b/docs/capi-kubevirt.md
@@ -64,7 +64,7 @@ kind: K0smotronControlPlane # This is the config for the controlplane
 metadata:
   name: k0s-test-cp
 spec:
-  version: v1.27.4-k0s.0
+  version: v1.34.3-k0s.0
   persistence:
     type: emptyDir
   service:
@@ -106,7 +106,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: KubevirtMachineTemplate
         name: kubevirt-test-mt
-      version: v1.27.4
+      version: v1.34.3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtMachineTemplate
@@ -136,7 +136,7 @@ spec:
               evictionStrategy: External
               volumes:
               - containerDisk:
-                  image: quay.io/capk/ubuntu-2204-container-disk:v1.27.14
+                  image: quay.io/capk/ubuntu-2204-container-disk:v1.34.3
                 name: containervolume
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -146,7 +146,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.4+k0s.0
+      version: v1.34.3+k0s.0
       # More details of the worker configuration can be set here
 ```
 
@@ -158,7 +158,7 @@ NAME                                   PHASE         AGE     VERSION
 cluster.cluster.x-k8s.io/kubevirt-test Provisioned   22h
 
 NAME                                               CLUSTER         NODENAME                  PROVIDERID                           PHASE     AGE     VERSION
-machine.cluster.x-k8s.io/kubevirt-md-mdvns-l2rxb   kubevirt-test   kubevirt-md-mdvns-l2rxb   kubevirt://kubevirt-md-mdvns-l2rxb   Running   22h     v1.27.4
+machine.cluster.x-k8s.io/kubevirt-md-mdvns-l2rxb   kubevirt-test   kubevirt-md-mdvns-l2rxb   kubevirt://kubevirt-md-mdvns-l2rxb   Running   22h     v1.34.3
 ```
 
 You can also check the status of the cluster deployment with `clusterctl describe cluster`.

--- a/docs/capi-remote.md
+++ b/docs/capi-remote.md
@@ -41,7 +41,7 @@ metadata:
   name: remote-test
   namespace: default
 spec:
-  version: v1.27.2-k0s.0
+  version: v1.34.3-k0s.0
   persistence:
     type: emptyDir
   service:
@@ -85,7 +85,7 @@ metadata:
   name: remote-test-0
   namespace: default
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: RemoteMachine
@@ -159,7 +159,7 @@ metadata:
   name: remote-test
 spec:
   replicas: 1
-  version: v1.27.1+k0s.0
+  version: v1.34.3+k0s.0
   k0sConfigSpec:
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
@@ -210,7 +210,7 @@ When CAPI controller creates a `RemoteMachine` from template object for the `K0s
 
 ### Using Sudo for Commands
 
-When connecting to remote machines, you may need to execute commands with elevated privileges. 
+When connecting to remote machines, you may need to execute commands with elevated privileges.
 The `useSudo` field allows k0smotron to wrap all executed commands with `sudo`. This is particularly useful when the SSH user doesn't have root privileges but has sudo access:
 
 ```yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ metadata:
 spec:
   replicas: 1
   image: quay.io/k0sproject/k0s
-  version: v1.27.1-k0s.0
+  version: v1.34.3-k0s.0
   service:
     type: NodePort
     apiPort: 30443

--- a/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
+++ b/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
@@ -138,8 +138,8 @@ Note: This metadata will have precedence over default labels/annotations on the 
         <td><b>version</b></td>
         <td>string</td>
         <td>
-          Version defines the k0s version to be deployed. You can use a specific k0s version (e.g. v1.27.1+k0s.0) or
-just the Kubernetes version (e.g. v1.27.1). If left empty, k0smotron will select one automatically.<br/>
+          Version defines the k0s version to be deployed. You can use a specific k0s version (e.g. v1.34.3+k0s.0) or
+just the Kubernetes version (e.g. v1.34.3). If left empty, k0smotron will select one automatically.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/docs/update/update-capi-cluster.md
+++ b/docs/update/update-capi-cluster.md
@@ -91,7 +91,7 @@ where deploying the new control plane is followed by decommissioning of the old 
     spec:
       template:
         spec:
-          customImage: kindest/node:v1.31.0
+          customImage: kindest/node:v1.34.0
     ```
 
 2. Change the k0s version to [the target one](https://docs.k0sproject.io/stable/releases/#k0s-release-and-support-model). For example:
@@ -216,7 +216,7 @@ For the example below, k0smotron will create 3 new machines for the control plan
     spec:
       template:
         spec:
-          customImage: kindest/node:v1.31.0
+          customImage: kindest/node:v1.34.0
     ```
 
 2. Change the k0s version to [the target one](https://docs.k0sproject.io/stable/releases/#k0s-release-and-support-model). For example:

--- a/docs/update/update-cluster-pod.md
+++ b/docs/update/update-cluster-pod.md
@@ -34,7 +34,7 @@ the k0s version and machine names in the YAML configuration file:
     metadata:
       name: docker-test-cp
     spec:
-      version: v1.27.2-k0s.0
+      version: v1.34.2-k0s.0
     ```
 2. Make sure that the [persistence](../resource-reference/k0smotron.io-v1beta1.md#clusterspecpersistence) is configured
 to prevent data loss. For example:
@@ -46,7 +46,7 @@ to prevent data loss. For example:
     metadata:
       name: docker-test-cp
     spec:
-      version: v1.27.2-k0s.0
+      version: v1.34.2-k0s.0
       persistence:
         type: hostPath
         hostPath: "/tmp/kmc-test" # k0smotron will mount a basic hostPath volume to avoid data loss.
@@ -64,7 +64,7 @@ to prevent data loss. For example:
    metadata:
      name: cp-test
    spec:
-     version: v1.28.7-k0s.0 # new k0s version
+     version: v1.34.3-k0s.0 # new k0s version
    ```
 
 4. In the same configuration, replace the names of machines running the old k0smotron version
@@ -78,7 +78,7 @@ with the new names to create machines for the target k0smotron version. For exam
      name:  docker-test-1 # new machine
      namespace: default
    spec:
-     version: v1.28.7 # new version
+     version: v1.34.3 # new version
      clusterName: docker-test
      bootstrap:
        configRef:
@@ -96,7 +96,7 @@ with the new names to create machines for the target k0smotron version. For exam
      name: docker-test-1 # new machine
      namespace: default
    spec:
-     version: v1.28.7+k0s.0 # new version
+     version: v1.34.3+k0s.0 # new version
    ```
 
 5. Update the resources:

--- a/docs/update/update-standalone.md
+++ b/docs/update/update-standalone.md
@@ -13,7 +13,7 @@ in the YAML configuration file:
     spec:
       replicas: 1
       k0sImage: quay.io/k0sproject/k0s
-      version: v1.27.1-k0s.0
+      version: v1.34.2-k0s.0
     ```
 
 2. Change all the k0s versions to the target one. For example:
@@ -26,7 +26,7 @@ in the YAML configuration file:
     spec:
       replicas: 1
       k0sImage: quay.io/k0sproject/k0s
-      version: v1.28.7-k0s.0 # new k0s version
+      version: v1.34.3-k0s.0 # new k0s version
     ```
 
 3. Update the resources:

--- a/e2e/data/infrastructure-docker/main/bases/cluster-with-kcp.yaml
+++ b/e2e/data/infrastructure-docker/main/bases/cluster-with-kcp.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane

--- a/e2e/data/infrastructure-docker/main/bases/machine.yaml
+++ b/e2e/data/infrastructure-docker/main/bases/machine.yaml
@@ -45,7 +45,7 @@ metadata:
   name: ${CLUSTER_NAME}-docker-test-worker-0
   namespace: ${NAMESPACE}
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 ---
 apiVersion: v1
 kind: Secret

--- a/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
+++ b/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane

--- a/e2e/data/infrastructure-docker/main/cluster-template-remote-hcp/machine-with-hostname-override.yaml
+++ b/e2e/data/infrastructure-docker/main/cluster-template-remote-hcp/machine-with-hostname-override.yaml
@@ -49,7 +49,7 @@ metadata:
   name: ${CLUSTER_NAME}-docker-test-worker-0
   namespace: ${NAMESPACE}
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 ---
 apiVersion: v1
 kind: Secret

--- a/internal/controller/bootstrap/worker_bootstrap_webhook_test.go
+++ b/internal/controller/bootstrap/worker_bootstrap_webhook_test.go
@@ -37,7 +37,7 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			name: "valid config passes validation",
 			in: &bootstrapv1.K0sWorkerConfig{
 				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					Version: "v1.27.4+k0s.0",
+					Version: "v1.34.3+k0s.0",
 					Files: []bootstrapv1.File{
 						{
 							ContentFrom: &bootstrapv1.ContentSource{
@@ -69,7 +69,7 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			name: "err for unsupported k0s version",
 			in: &bootstrapv1.K0sWorkerConfig{
 				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					Version: "v1.27.4-k0s.0",
+					Version: "v1.34.3-k0s.0",
 				},
 			},
 			expectedWarnings: nil,
@@ -79,7 +79,7 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			name: "err for invalid files declared in config: content and contentFrom conflict",
 			in: &bootstrapv1.K0sWorkerConfig{
 				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					Version: "v1.27.4+k0s.0",
+					Version: "v1.34.3+k0s.0",
 					Files: []bootstrapv1.File{
 						{
 							File: provisioner.File{
@@ -102,7 +102,7 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			name: "err for invalid files declared in config: not content",
 			in: &bootstrapv1.K0sWorkerConfig{
 				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					Version: "v1.27.4+k0s.0",
+					Version: "v1.34.3+k0s.0",
 					Files: []bootstrapv1.File{
 						{
 							File: provisioner.File{
@@ -119,7 +119,7 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			name: "err for invalid files declared in config: contentFrom configmap and secret conflict",
 			in: &bootstrapv1.K0sWorkerConfig{
 				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					Version: "v1.27.4+k0s.0",
+					Version: "v1.34.3+k0s.0",
 					Files: []bootstrapv1.File{
 						{
 							ContentFrom: &bootstrapv1.ContentSource{
@@ -143,7 +143,7 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			name: "err for invalid files declared in config: contentFrom configmap name missing",
 			in: &bootstrapv1.K0sWorkerConfig{
 				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					Version: "v1.27.4+k0s.0",
+					Version: "v1.34.3+k0s.0",
 					Files: []bootstrapv1.File{
 						{
 							ContentFrom: &bootstrapv1.ContentSource{
@@ -163,7 +163,7 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			name: "err for invalid files declared in config: contentFrom secret name missing",
 			in: &bootstrapv1.K0sWorkerConfig{
 				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					Version: "v1.27.4+k0s.0",
+					Version: "v1.34.3+k0s.0",
 					Files: []bootstrapv1.File{
 						{
 							ContentFrom: &bootstrapv1.ContentSource{
@@ -183,7 +183,7 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			name: "err for invalid files declared in config: contentFrom secret name missing",
 			in: &bootstrapv1.K0sWorkerConfig{
 				Spec: bootstrapv1.K0sWorkerConfigSpec{
-					Version: "v1.27.4+k0s.0",
+					Version: "v1.34.3+k0s.0",
 					Files: []bootstrapv1.File{
 						{
 							File: provisioner.File{

--- a/inttest/capi-config-update-vm/capi_config_update_vm_test.go
+++ b/inttest/capi-config-update-vm/capi_config_update_vm_test.go
@@ -213,7 +213,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -221,7 +221,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 1
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
   k0sConfigSpec:
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
@@ -287,7 +287,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -295,7 +295,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 1
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
   k0sConfigSpec:
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1

--- a/inttest/capi-controlplane-docker-rm/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker-rm/capi_controlplane_docker_test.go
@@ -236,7 +236,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -244,7 +244,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 3
-  k0sVersion: v1.27.2+k0s.0
+  k0sVersion: v1.34.3-k0s.0
   k0sConfigSpec:
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
@@ -277,7 +277,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.27.1
+  version: v1.34.3
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -296,7 +296,7 @@ metadata:
   namespace: default
 spec:
   # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
+  version: v1.34.3+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:
@@ -313,5 +313,5 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 `

--- a/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
+++ b/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
@@ -244,7 +244,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -252,7 +252,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 1
-  version: v1.27.1+k0s.0
+  version: v1.34.3+k0s.0
   k0sConfigSpec:
     tunneling:
       enabled: true
@@ -288,7 +288,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.27.1
+  version: v1.34.3
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -307,7 +307,7 @@ metadata:
   namespace: default
 spec:
   # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
+  version: v1.34.3+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:
@@ -324,5 +324,5 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 `

--- a/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
+++ b/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
@@ -229,7 +229,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -237,7 +237,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 1
-  version: v1.27.1+k0s.0
+  version: v1.34.3+k0s.0
   k0sConfigSpec:
     tunneling:
       enabled: true
@@ -272,7 +272,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.27.1
+  version: v1.34.3
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -291,7 +291,7 @@ metadata:
   namespace: default
 spec:
   # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
+  version: v1.34.3+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:
@@ -308,5 +308,5 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 `

--- a/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
+++ b/inttest/capi-controlplane-docker-worker/capi_controlplane_docker_worker_test.go
@@ -191,7 +191,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -199,7 +199,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 1
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
   k0sConfigSpec:
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1

--- a/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
@@ -304,7 +304,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -415,7 +415,7 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 ---
 apiVersion: v1
 kind: Secret

--- a/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
+++ b/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
@@ -113,7 +113,7 @@ func (s *CAPIDockerClusterClassK0smotronSuite) TestCAPIDocker() {
 			kcp.Status.UnavailableReplicas == 0 &&
 			kcp.Status.Ready &&
 			kcp.Status.UpdatedReplicas == 2 &&
-			kcp.Status.Version == "v1.27.2+k0s.0"
+			kcp.Status.Version == "v1.34.3+k0s.0"
 
 		return ready, nil
 	})
@@ -146,7 +146,7 @@ metadata:
 spec:
   topology:
     class: k0smotron-cluster-class
-    version: v1.27.2
+    version: v1.34.3
     controlPlane:
       replicas: 2
     workers:
@@ -183,7 +183,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.2
+      version: v1.34.3
       persistence:
         type: emptyDir
       service:
@@ -197,7 +197,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.2
+      version: v1.34.3
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass

--- a/inttest/capi-docker-clusterclass-recreate-upgrade/capi_docker_clusterclass_test.go
+++ b/inttest/capi-docker-clusterclass-recreate-upgrade/capi_docker_clusterclass_test.go
@@ -408,7 +408,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlaneTemplate

--- a/inttest/capi-docker-clusterclass/capi_docker_clusterclass_test.go
+++ b/inttest/capi-docker-clusterclass/capi_docker_clusterclass_test.go
@@ -293,7 +293,7 @@ spec:
     port: 6443
   topology:
     class: k0smotron-clusterclass
-    version: v1.27.2+k0s.0
+    version: v1.34.3+k0s.0
     workers:
       machineDeployments:
       - class: remotemachine-test-default-worker
@@ -343,7 +343,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.27.2+k0s.0
+      version: v1.34.3+k0s.0
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass

--- a/inttest/capi-docker-machine-change-args/capi_docker_machine_change_args_test.go
+++ b/inttest/capi-docker-machine-change-args/capi_docker_machine_change_args_test.go
@@ -245,7 +245,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -317,7 +317,7 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 `
 
 var controlPlaneUpdate = `

--- a/inttest/capi-docker-machine-change-template/capi_docker_machine_change_template_test.go
+++ b/inttest/capi-docker-machine-change-template/capi_docker_machine_change_template_test.go
@@ -282,7 +282,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -354,7 +354,7 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 `
 
 var controlPlaneUpdate = `
@@ -367,7 +367,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -407,7 +407,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane

--- a/inttest/capi-docker-machine-template-update-recreate-kine/capi_docker_machine_template_update_recreate_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate-kine/capi_docker_machine_template_update_recreate_test.go
@@ -189,7 +189,7 @@ func (s *CAPIDockerMachineTemplateUpdateRecreateKine) TestCAPIControlPlaneDocker
 			if err != nil {
 				return false, nil
 			}
-			if v != "v1.28.7+k0s.0" {
+			if v != "v1.34.3+k0s.0" {
 				return false, nil
 			}
 		}
@@ -276,7 +276,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -284,7 +284,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 3
-  version: v1.27.1+k0s.0
+  version: v1.34.2+k0s.0
   updateStrategy: Recreate
   k0sConfigSpec:
     k0s:
@@ -322,7 +322,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.27.1
+  version: v1.34.2
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -341,7 +341,7 @@ metadata:
   namespace: default
 spec:
   # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
+  version: v1.34.2+k0s.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachine
@@ -349,7 +349,7 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 `
 
 var controlPlaneUpdate = `
@@ -359,7 +359,7 @@ metadata:
   name: docker-test
 spec:
   replicas: 3
-  version: v1.28.7+k0s.0
+  version: v1.34.3+k0s.0
   updateStrategy: Recreate
   k0sConfigSpec:
     k0s:

--- a/inttest/capi-docker-machine-template-update-recreate-single/capi_docker_machine_template_update_recreate_single_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate-single/capi_docker_machine_template_update_recreate_single_test.go
@@ -249,7 +249,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -323,7 +323,7 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 ---
 apiVersion: v1
 data:

--- a/inttest/capi-docker-machine-template-update-recreate/capi_docker_machine_template_update_recreate_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate/capi_docker_machine_template_update_recreate_test.go
@@ -262,7 +262,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -331,7 +331,7 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 `
 
 var controlPlaneUpdate = `

--- a/inttest/capi-docker-machine-template-update/capi_docker_machine_template_update_test.go
+++ b/inttest/capi-docker-machine-template-update/capi_docker_machine_template_update_test.go
@@ -296,7 +296,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.31.0
+      customImage: kindest/node:v1.34.0
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
@@ -370,7 +370,7 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 `
 
 var controlPlaneUpdate = `

--- a/inttest/capi-docker/capi_docker_test.go
+++ b/inttest/capi-docker/capi_docker_test.go
@@ -334,5 +334,5 @@ metadata:
   name: docker-test-0
   namespace: default
 spec:
-  customImage: kindest/node:v1.31.0
+  customImage: kindest/node:v1.34.0
 `

--- a/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
+++ b/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
@@ -274,7 +274,7 @@ metadata:
   name: remote-test
   namespace: default
 spec:
-  version: v1.27.2-k0s.0
+  version: v1.34.3-k0s.0
   persistence:
     type: emptyDir
   service:
@@ -310,7 +310,7 @@ metadata:
   name: remote-test-0
   namespace: default
 spec:
-  version: v1.27.2+k0s.0
+  version: v1.34.3+k0s.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: RemoteMachine


### PR DESCRIPTION
The k0s versions referenced in documentation and tests were significantly outdated (v1.27.x).
Updated them to v1.34.3 to better reflect current usage.
