### PR TITLE
Propagate k0smotron Cluster reconciliation status to K0smotronControlPlane conditions

### DIFF
--- a/api/controlplane/v1beta1/conditions_consts.go
+++ b/api/controlplane/v1beta1/conditions_consts.go
@@ -19,4 +19,17 @@ package v1beta1
 const (
 	// ControlPlaneAvailableReason documents the fact that the control plane is reachable.
 	ControlPlaneAvailableReason = "Available"
+
+	// K0smotronClusterReconciledCondition documents the reconciliation status of the
+	// k0smotron.io/v1beta1 Cluster that manages the generated resources.
+	K0smotronClusterReconciledCondition = "K0smotronClusterReconciled"
+
+	// ReconciliationSucceededReason documents that the k0smotron Cluster reconciled successfully.
+	ReconciliationSucceededReason = "ReconciliationSucceeded"
+
+	// ReconciliationFailedReason documents that the k0smotron Cluster encountered a reconciliation error.
+	ReconciliationFailedReason = "ReconciliationFailed"
+
+	// ReconciliationInProgressReason documents that the k0smotron Cluster is not yet fully reconciled.
+	ReconciliationInProgressReason = "ReconciliationInProgress"
 )

--- a/api/k0smotron.io/v1beta1/reconciliation_status.go
+++ b/api/k0smotron.io/v1beta1/reconciliation_status.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+const (
+	// ReconciliationStatusSuccessful is the status set when the k0smotron Cluster
+	// has been reconciled successfully.
+	ReconciliationStatusSuccessful = "Reconciliation successful"
+
+	// ReconciliationStatusFailedPrefix is the prefix used for all failure statuses.
+	ReconciliationStatusFailedPrefix = "Failed"
+)

--- a/internal/controller/k0smotron.io/k0smotroncluster_controller.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_controller.go
@@ -223,28 +223,28 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	logger.Info("Reconciling services")
 	if err := kmcScope.reconcileServices(ctx, kmc); err != nil {
-		kmc.Status.ReconciliationStatus = "Failed reconciling services"
+		kmc.Status.ReconciliationStatus = km.ReconciliationStatusFailedPrefix + " reconciling services"
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}
 
 	if err := kmcScope.reconcileIngress(ctx, kmc); err != nil {
-		kmc.Status.ReconciliationStatus = "Failed reconciling ingress"
+		kmc.Status.ReconciliationStatus = km.ReconciliationStatusFailedPrefix + " reconciling ingress"
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}
 
 	if err := kmcScope.reconcileK0sConfig(ctx, kmc, r.Client); err != nil {
-		kmc.Status.ReconciliationStatus = "Failed reconciling configmap"
+		kmc.Status.ReconciliationStatus = km.ReconciliationStatusFailedPrefix + " reconciling configmap"
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}
 
 	if err := kmcScope.reconcileEntrypointCM(ctx, kmc); err != nil {
-		kmc.Status.ReconciliationStatus = "Failed reconciling entrypoint configmap"
+		kmc.Status.ReconciliationStatus = km.ReconciliationStatusFailedPrefix + " reconciling entrypoint configmap"
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}
 
 	if kmc.Spec.Monitoring.Enabled {
 		if err := kmcScope.reconcileMonitoringCM(ctx, kmc); err != nil {
-			kmc.Status.ReconciliationStatus = "Failed reconciling prometheus configmap"
+			kmc.Status.ReconciliationStatus = km.ReconciliationStatusFailedPrefix + " reconciling prometheus configmap"
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 		}
 	}
@@ -302,13 +302,13 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if err := kmcScope.reconcilePVC(ctx, kmc); err != nil {
-		kmc.Status.ReconciliationStatus = "Failed reconciling PVCs"
+		kmc.Status.ReconciliationStatus = km.ReconciliationStatusFailedPrefix + " reconciling PVCs"
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}
 
 	logger.Info("Reconciling etcd")
 	if err := kmcScope.reconcileEtcd(ctx, kmc); err != nil {
-		kmc.Status.ReconciliationStatus = fmt.Sprintf("Failed reconciling etcd, %+v", err)
+		kmc.Status.ReconciliationStatus = fmt.Sprintf("%s reconciling etcd, %+v", km.ReconciliationStatusFailedPrefix, err)
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}
 
@@ -319,16 +319,16 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 		}
 
-		kmc.Status.ReconciliationStatus = fmt.Sprintf("Failed reconciling statefulset, %+v", err)
+		kmc.Status.ReconciliationStatus = fmt.Sprintf("%s reconciling statefulset, %+v", km.ReconciliationStatusFailedPrefix, err)
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}
 
 	if err := kmcScope.reconcileKubeConfigSecret(ctx, r.Client, kmc); err != nil {
-		kmc.Status.ReconciliationStatus = "Failed reconciling secret"
+		kmc.Status.ReconciliationStatus = km.ReconciliationStatusFailedPrefix + " reconciling secret"
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, err
 	}
 
-	kmc.Status.ReconciliationStatus = "Reconciliation successful"
+	kmc.Status.ReconciliationStatus = km.ReconciliationStatusSuccessful
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
## Summary

- Propagate k0smotron Cluster's reconciliation status to K0smotronControlPlane as a K0smotronClusterReconciled condition

## Motivation

When K0smotronControlPlane was stuck and not becoming Ready, there was no way to tell from the K0smotronControlPlane alone whether the underlying k0smotron Cluster had a reconciliation error. Users had to dig into the k0smotron Cluster object to find the root cause. This change surfaces the reconciliation status directly on the K0smotronControlPlane conditions, making errors immediately visible.
