### PR TITLE
Schedule requeue when updateStatus fails in K0sControlPlane defer

### DIFF
--- a/internal/controller/controlplane/k0s_controlplane_controller.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller.go
@@ -179,6 +179,10 @@ func (c *K0sController) Reconcile(ctx context.Context, req ctrl.Request) (res ct
 			if derr != nil {
 				if !errors.Is(derr, errUpgradeNotCompleted) {
 					log.Error(derr, "Failed to update status")
+					// Schedule a requeue so the controller retries status update
+					if res.IsZero() {
+						res = ctrl.Result{RequeueAfter: 10 * time.Second}
+					}
 					return
 				}
 


### PR DESCRIPTION
When updateStatus fails, the defer returns early with the zero value of res, so controller-runtime does not schedule a retry. This can cause the controller to stall until an external event triggers reconciliation.