### PR TITLE
Remove unused empty spec field from DockerCluster e2e templates

### DIFF
--- a/e2e/data/infrastructure-docker/main/bases/machinedeployment.yaml
+++ b/e2e/data/infrastructure-docker/main/bases/machinedeployment.yaml
@@ -38,7 +38,6 @@ kind: DockerCluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
-spec:
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/e2e/data/infrastructure-docker/main/cluster-template-ingress/cluster-with-ingress.yaml
+++ b/e2e/data/infrastructure-docker/main/cluster-template-ingress/cluster-with-ingress.yaml
@@ -51,7 +51,6 @@ kind: DockerCluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
-spec:
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
+++ b/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
@@ -99,4 +99,3 @@ kind: DockerCluster
 metadata:
   name: docker-test
   namespace: ${NAMESPACE}
-spec:


### PR DESCRIPTION
Remove unused empty spec: fields from DockerCluster resources in e2e templates.
