### PR TITLE
Statefulset reconcile fix

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -711,7 +711,7 @@ func (scope *kmcScope) reconcileStatefulSet(ctx context.Context, kmc *km.Cluster
 	}
 
 	if !isStatefulSetsEqual(&statefulSetPreview, foundStatefulSet) {
-		return ctrl.Result{}, scope.client.Patch(ctx, &statefulSet, client.Apply, patchOpts...) //nolint:forbidigo
+		return ctrl.Result{}, scope.reconcileResource(ctx, kmc, &statefulSet)
 	}
 	needsScale := *foundStatefulSet.Spec.Replicas != *statefulSet.Spec.Replicas
 	if needsScale {


### PR DESCRIPTION
`scope.client.Patch` doesn't take patches into account