### PR TITLE
Add convert tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,3 +164,60 @@ jobs:
           asset_path: ./templates/cluster-template-hcp.yaml
           asset_name: cluster-template-hcp.yaml
           asset_content_type: application/octet-stream
+
+  build-convert:
+    needs:
+      - release
+    name: Build convert binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run git checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: '1.25'
+
+      - name: Build convert binaries for all platforms
+        run: make build-convert-all
+
+      - name: Upload convert binary - linux/amd64
+        uses: shogo82148/actions-upload-release-asset@v1.8.1
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./bin/convert-v1beta1-to-v1beta2-linux-amd64
+          asset_name: convert-v1beta1-to-v1beta2-linux-amd64
+          asset_content_type: application/octet-stream
+
+      - name: Upload convert binary - linux/arm64
+        uses: shogo82148/actions-upload-release-asset@v1.8.1
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./bin/convert-v1beta1-to-v1beta2-linux-arm64
+          asset_name: convert-v1beta1-to-v1beta2-linux-arm64
+          asset_content_type: application/octet-stream
+
+      - name: Upload convert binary - darwin/amd64
+        uses: shogo82148/actions-upload-release-asset@v1.8.1
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./bin/convert-v1beta1-to-v1beta2-darwin-amd64
+          asset_name: convert-v1beta1-to-v1beta2-darwin-amd64
+          asset_content_type: application/octet-stream
+
+      - name: Upload convert binary - darwin/arm64
+        uses: shogo82148/actions-upload-release-asset@v1.8.1
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./bin/convert-v1beta1-to-v1beta2-darwin-arm64
+          asset_name: convert-v1beta1-to-v1beta2-darwin-arm64
+          asset_content_type: application/octet-stream
+
+      - name: Upload convert binary - windows/amd64
+        uses: shogo82148/actions-upload-release-asset@v1.8.1
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./bin/convert-v1beta1-to-v1beta2-windows-amd64.exe
+          asset_name: convert-v1beta1-to-v1beta2-windows-amd64.exe
+          asset_content_type: application/octet-stream

--- a/Makefile
+++ b/Makefile
@@ -443,3 +443,25 @@ sign-pub-key:
 	  gcr.io/projectsigstore/cosign:v2.2.0 \
 	  public-key \
 	  --key /k0s/cosign.key --output-file /out/cosign.pub
+
+.PHONY: convert
+convert: ## Run the v1beta1→v1beta2 conversion tool (pass ARGS="[flags] [files]")
+	go run ./hack/convert $(ARGS)
+
+.PHONY: build-convert
+build-convert: ## Build the convert binary for the current platform to bin/convert-v1beta1-to-v1beta2
+	go build -o bin/convert-v1beta1-to-v1beta2 ./hack/convert
+
+CONVERT_PLATFORMS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
+
+.PHONY: build-convert-all
+build-convert-all: ## Build the convert binary for all release platforms to bin/convert-v1beta1-to-v1beta2-<os>-<arch>
+	@mkdir -p bin
+	@for platform in $(CONVERT_PLATFORMS); do \
+		os=$$(echo $$platform | cut -d/ -f1); \
+		arch=$$(echo $$platform | cut -d/ -f2); \
+		ext=""; \
+		[ "$$os" = "windows" ] && ext=".exe"; \
+		echo "Building convert for $$os/$$arch..."; \
+		GOOS=$$os GOARCH=$$arch go build -o bin/convert-v1beta1-to-v1beta2-$${os}-$${arch}$${ext} ./hack/convert; \
+	done

--- a/docs/update/migrate-v1beta2-api.md
+++ b/docs/update/migrate-v1beta2-api.md
@@ -2,6 +2,59 @@
 
 This guide explains changes introduced in new `v1beta2` and how to migrate manifests from current `v1beta1` to the new k0smotron API. For more details about each Api Group, please check current custom resource references.
 
+## Migration tool
+
+k0smotron ships an experimental CLI tool that automates the manifest conversion described in this guide.
+
+### Download pre-built binary
+
+Pre-built binaries are published with every release for the following platforms:
+
+| Platform | Binary |
+|---|---|
+| Linux x86-64 | `convert-v1beta1-to-v1beta2-linux-amd64` |
+| Linux ARM 64-bit | `convert-v1beta1-to-v1beta2-linux-arm64` |
+| macOS x86-64 | `convert-v1beta1-to-v1beta2-darwin-amd64` |
+| macOS Apple Silicon | `convert-v1beta1-to-v1beta2-darwin-arm64` |
+| Windows x86-64 | `convert-v1beta1-to-v1beta2-windows-amd64.exe` |
+
+Download the binary for your platform from the [GitHub releases page](https://github.com/k0sproject/k0smotron/releases), make it executable, and run it:
+
+```shell
+# Example for Linux x86-64
+curl -L https://github.com/k0sproject/k0smotron/releases/latest/download/convert-v1beta1-to-v1beta2-linux-amd64 -o convert
+chmod +x convert
+
+# Convert a file
+./convert my-cluster.yaml > my-cluster-v1beta2.yaml
+
+# Read from stdin
+cat my-cluster.yaml | ./convert
+```
+
+### Build from source
+
+If you have the repository cloned, you can build or run the tool directly with `make`:
+
+```shell
+# Run without building (uses go run)
+make convert ARGS="my-cluster.yaml"
+make convert ARGS="my-cluster.yaml" > my-cluster-v1beta2.yaml
+cat my-cluster.yaml | make convert
+
+# Build a binary for the current platform
+make build-convert    # output: bin/convert-v1beta1-to-v1beta2
+
+# Build binaries for all release platforms
+make build-convert-all  # output: bin/convert-v1beta1-to-v1beta2-<os>-<arch>[.exe]
+```
+
+The tool processes multi-document YAML files and applies all the field renames listed below. Resources from other API groups are passed through unchanged.
+
+!!! warning
+    `convert` is a best-effort staging tool. Always review the output before applying it to a cluster, and keep a backup of the originals. This feature may be removed in future releases.
+
+
 ## Deprecation Policy
 
 Starting from `v1.11.0`, k0smotron uses new `v1beta2` API version as [storage version](https://kubernetes.io/docs/concepts/overview/working-with-objects/storage-version/) and deprecate `v1beta1`, which still served for compatibility. K0smotron follows the [Kubernetes API deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/) for beta APIs:

--- a/hack/convert/v1beta2.go
+++ b/hack/convert/v1beta2.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	bootstrapv1beta1 "github.com/k0sproject/k0smotron/api/bootstrap/v1beta1"
+	bootstrapv1beta2 "github.com/k0sproject/k0smotron/api/bootstrap/v1beta2"
+	cpv1beta1 "github.com/k0sproject/k0smotron/api/controlplane/v1beta1"
+	cpv1beta2 "github.com/k0sproject/k0smotron/api/controlplane/v1beta2"
+	infrav1beta1 "github.com/k0sproject/k0smotron/api/infrastructure/v1beta1"
+	infrav1beta2 "github.com/k0sproject/k0smotron/api/infrastructure/v1beta2"
+	k0smotronv1beta1 "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta1"
+	k0smotronv1beta2 "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta2"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	for _, add := range []func(*runtime.Scheme) error{
+		k0smotronv1beta1.AddToScheme,
+		k0smotronv1beta2.AddToScheme,
+		bootstrapv1beta1.AddToScheme,
+		bootstrapv1beta2.AddToScheme,
+		cpv1beta1.AddToScheme,
+		cpv1beta2.AddToScheme,
+		infrav1beta1.AddToScheme,
+		infrav1beta2.AddToScheme,
+	} {
+		if err := add(scheme); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func main() {
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convert [file]",
+		Short: "Convert k0smotron manifests from v1beta1 to v1beta2",
+		Long: `Convert k0smotron manifests from v1beta1 to v1beta2.
+
+Reads from stdin when no file is given. Output always goes to stdout.
+
+WARNING: This is an experimental staging tool. Output should be reviewed before use.`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return processStream(os.Stdin, os.Stdout)
+			}
+			f, err := os.Open(args[0])
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			return processStream(f, os.Stdout)
+		},
+	}
+	return cmd
+}
+
+func processStream(r io.Reader, w io.Writer) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	decoder := k8syaml.NewDocumentDecoder(io.NopCloser(bytes.NewReader(data)))
+	buf := make([]byte, len(data)+1)
+	first := true
+	for {
+		n, err := decoder.Read(buf)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading document: %w", err)
+		}
+		doc := bytes.TrimSpace(buf[:n])
+		if len(doc) == 0 {
+			continue
+		}
+
+		converted, err := convertDocument(doc)
+		if err != nil {
+			return err
+		}
+
+		if !first {
+			fmt.Fprint(w, "---\n")
+		}
+		first = false
+		fmt.Fprintf(w, "%s\n", converted)
+	}
+	return nil
+}
+
+func convertDocument(raw []byte) ([]byte, error) {
+	var u unstructured.Unstructured
+	if err := sigsyaml.Unmarshal(raw, &u.Object); err != nil {
+		return raw, nil // not a Kubernetes object; pass through unchanged
+	}
+
+	apiVersion := u.GetAPIVersion()
+	if !strings.HasSuffix(apiVersion, "/v1beta1") {
+		return raw, nil
+	}
+
+	group := strings.TrimSuffix(apiVersion, "/v1beta1")
+	kind := u.GetKind()
+
+	out, err := convert(group, kind, raw)
+	if err != nil {
+		ref := kind + " " + u.GetName()
+		if ns := u.GetNamespace(); ns != "" {
+			ref = kind + " " + ns + "/" + u.GetName()
+		}
+		return nil, fmt.Errorf("converting %s: %w", ref, err)
+	}
+	return out, nil
+}
+
+// convert uses the scheme to instantiate the v1beta1 object, type-asserts it to
+// conversion.Convertible, and calls ConvertTo on a scheme-created v1beta2 hub.
+// If the kind is not registered in the scheme or does not implement the conversion
+// interfaces, it falls back to a plain version bump.
+func convert(group, kind string, raw []byte) ([]byte, error) {
+	srcGVK := schema.GroupVersionKind{Group: group, Version: "v1beta1", Kind: kind}
+	srcObj, err := scheme.New(srcGVK)
+	if err != nil {
+		// Kind not registered — not a k0smotron resource, pass through.
+		return raw, nil
+	}
+
+	src, ok := srcObj.(conversion.Convertible)
+	if !ok {
+		// Registered but no field-level conversion needed; only bump the version.
+		return bumpAPIVersion(group, raw)
+	}
+
+	dstGVK := schema.GroupVersionKind{Group: group, Version: "v1beta2", Kind: kind}
+	dstObj, err := scheme.New(dstGVK)
+	if err != nil {
+		return nil, fmt.Errorf("creating v1beta2 object for %s: %w", kind, err)
+	}
+
+	dst, ok := dstObj.(conversion.Hub)
+	if !ok {
+		return nil, fmt.Errorf("%s/v1beta2 %s does not implement conversion.Hub", group, kind)
+	}
+
+	// Build a zero-value v1beta2 baseline so we can prune fields that were
+	// never set in the original and carry no conversion-derived meaning.
+	zeroObj, err := scheme.New(dstGVK)
+	if err != nil {
+		return nil, fmt.Errorf("creating zero v1beta2 object for %s: %w", kind, err)
+	}
+	zeroU := &unstructured.Unstructured{}
+	if err := scheme.Convert(zeroObj, zeroU, nil); err != nil {
+		return nil, fmt.Errorf("converting zero object to unstructured: %w", err)
+	}
+
+	if err := sigsyaml.Unmarshal(raw, src); err != nil {
+		return nil, err
+	}
+	if err := src.ConvertTo(dst); err != nil {
+		return nil, err
+	}
+	dst.GetObjectKind().SetGroupVersionKind(dstGVK)
+
+	u := &unstructured.Unstructured{}
+	if err := scheme.Convert(dst, u, nil); err != nil {
+		return nil, fmt.Errorf("converting to unstructured: %w", err)
+	}
+	pruneBaselineFields(u.Object, zeroU.Object)
+	pruneEmptyMaps(u.Object)
+	delete(u.Object, "status")
+	// Restore TypeMeta after pruning — scheme.Convert may not carry it.
+	u.Object["apiVersion"] = group + "/v1beta2"
+	u.Object["kind"] = kind
+	return sigsyaml.Marshal(u.Object)
+}
+
+// pruneBaselineFields removes from result any field whose value matches the
+// corresponding zero-value baseline — i.e. fields that were never set in the
+// original and that the conversion did not touch.
+func pruneBaselineFields(result, baseline map[string]any) {
+	for k, bv := range baseline {
+		rv, exists := result[k]
+		if !exists {
+			continue
+		}
+		bMap, bIsMap := bv.(map[string]any)
+		rMap, rIsMap := rv.(map[string]any)
+		if bIsMap && rIsMap {
+			pruneBaselineFields(rMap, bMap)
+			if len(rMap) == 0 {
+				delete(result, k)
+			}
+			continue
+		}
+		if deepEqual(rv, bv) {
+			delete(result, k)
+		}
+	}
+}
+
+func deepEqual(a, b any) bool {
+	switch av := a.(type) {
+	case map[string]any:
+		bm, ok := b.(map[string]any)
+		if !ok || len(av) != len(bm) {
+			return false
+		}
+		for k, v := range av {
+			if !deepEqual(v, bm[k]) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		bl, ok := b.([]any)
+		if !ok || len(av) != len(bl) {
+			return false
+		}
+		for i := range av {
+			if !deepEqual(av[i], bl[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return a == b
+	}
+}
+
+// pruneEmptyMaps removes map entries whose value is an empty map, recursively.
+func pruneEmptyMaps(m map[string]any) {
+	for k, v := range m {
+		if child, ok := v.(map[string]any); ok {
+			pruneEmptyMaps(child)
+			if len(child) == 0 {
+				delete(m, k)
+			}
+		}
+	}
+}
+
+// bumpAPIVersion replaces the apiVersion field with group/v1beta2.
+func bumpAPIVersion(group string, raw []byte) ([]byte, error) {
+	var obj map[string]any
+	if err := sigsyaml.Unmarshal(raw, &obj); err != nil {
+		return nil, err
+	}
+	obj["apiVersion"] = group + "/v1beta2"
+	return sigsyaml.Marshal(obj)
+}


### PR DESCRIPTION
Best-effort tool for convert manifests with k0smotron resources from v1beta1 to v1beta2 by using implemented `Convetible` inferface. Removed after v1beta1 support is gone