### PR TITLE
Cache cluster client

### DIFF
--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/controllers/external"
-	"sigs.k8s.io/cluster-api/controllers/remote"
 	crcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -635,7 +634,7 @@ func (c *K0smotronController) computeAvailability(ctx context.Context, cluster *
 	logger.Info("Pinging the workload cluster API")
 
 	// Get the CAPI cluster accessor
-	client, err := remote.NewClusterClient(ctx, "k0smotron", c.Client, capiutil.ObjectKey(cluster))
+	client, err := util.GetCachedWorkloadClusterClient(ctx, "k0smotron", c.Client, capiutil.ObjectKey(cluster))
 	if err != nil {
 		logger.Info("Failed to create cluster client", "error", err)
 		conditions.Set(kcp, metav1.Condition{

--- a/internal/controller/k0smotron.io/k0smotroncluster_status.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_status.go
@@ -28,9 +28,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kutil "github.com/k0sproject/k0smotron/internal/controller/util"
 )
 
 func (r *ClusterReconciler) updateStatus(ctx context.Context, kmc *k0smotroniov1beta2.Cluster, scope currentReconcileState) {
@@ -268,7 +269,7 @@ func setControlPlaneFunctionalCondition(ctx context.Context, c client.Client, km
 		return
 	}
 
-	workloadClusterClient, err := remote.NewClusterClient(ctx, "k0smotron", c, client.ObjectKeyFromObject(kmc))
+	workloadClusterClient, err := kutil.GetCachedWorkloadClusterClient(ctx, "k0smotron", c, client.ObjectKeyFromObject(kmc))
 	if err != nil {
 		conditions.Set(kmc, metav1.Condition{
 			Type:    k0smotroniov1beta2.ClusterControlPlaneFunctionalCondition,

--- a/internal/controller/util/hostingcluster.go
+++ b/internal/controller/util/hostingcluster.go
@@ -16,46 +16,125 @@ package util
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	capisecret "sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kapi "github.com/k0sproject/k0smotron/api/k0smotron.io/v1beta2"
 )
 
-// GetKmcClientFromClusterKubeconfigSecret retrieves a client for the K0smotron cluster using the kubeconfig stored in a secret.
+// Without per-cluster caching, every reconcile rebuilds an http.Transport, RESTMapper,
+// and discovery cache. Under a tight reconcile loop (PR #1353, v1.10.3) the operator
+// OOMs because hundreds of transports stay live until idle-conn timeout. Cache entries
+// are invalidated by the kubeconfig secret's resourceVersion: a kubeconfig rotation
+// bumps the RV, the next call observes the change and rebuilds the client.
+var (
+	remoteHostClientCache      sync.Map // map[client.ObjectKey]*cachedClient — host cluster (Spec.RemoteHostCluster.KubeconfigRef)
+	workloadClusterClientCache sync.Map // map[client.ObjectKey]*cachedClient — workload cluster (CAPI kubeconfig secret)
+)
+
+// cachedClient holds the cached clients for a given kubeconfig secret. Workload-cluster
+// entries leave clientSet/restConfig/httpClient nil — they only need the ctrl-runtime client.
+type cachedClient struct {
+	c          client.Client
+	clientSet  *kubernetes.Clientset
+	restConfig *rest.Config
+	httpClient *http.Client
+	rv         string
+}
+
+// GetKmcClientFromClusterKubeconfigSecret returns a client for the remote host cluster
+// referenced by kubeconfigRef. Clients are cached per kubeconfigRef and re-built only
+// when the kubeconfig secret's resourceVersion changes.
 func GetKmcClientFromClusterKubeconfigSecret(ctx context.Context, managementClusterClient client.Client, kubeconfigRef *kapi.KubeconfigRef) (client.Client, *kubernetes.Clientset, *rest.Config, error) {
 	kubeconfigSecret := &corev1.Secret{}
 	key := client.ObjectKey{
 		Namespace: kubeconfigRef.Namespace,
 		Name:      kubeconfigRef.Name,
 	}
-	err := managementClusterClient.Get(ctx, key, kubeconfigSecret)
-	if err != nil {
+	if err := managementClusterClient.Get(ctx, key, kubeconfigSecret); err != nil {
 		return nil, nil, nil, err
+	}
+
+	if entry, ok := remoteHostClientCache.Load(key); ok {
+		cached := entry.(*cachedClient)
+		if cached.rv == kubeconfigSecret.ResourceVersion {
+			return cached.c, cached.clientSet, cached.restConfig, nil
+		}
 	}
 
 	kubeconfigData, ok := kubeconfigSecret.Data[kubeconfigRef.Key]
 	if !ok {
 		return nil, nil, nil, fmt.Errorf("missing %s key in secret %s/%s", kubeconfigRef.Key, kubeconfigSecret.Namespace, kubeconfigSecret.Name)
 	}
+
 	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
-
-	clientSet, err := kubernetes.NewForConfig(restConfig)
+	httpClient, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create http client: %w", err)
+	}
+	clientSet, err := kubernetes.NewForConfigAndClient(restConfig, httpClient)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create clientset: %w", err)
 	}
-
-	c, err := client.New(restConfig, client.Options{Scheme: managementClusterClient.Scheme()})
+	c, err := client.New(restConfig, client.Options{
+		Scheme:     managementClusterClient.Scheme(),
+		HTTPClient: httpClient,
+	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
+	entry := &cachedClient{
+		c:          c,
+		clientSet:  clientSet,
+		restConfig: restConfig,
+		httpClient: httpClient,
+		rv:         kubeconfigSecret.ResourceVersion,
+	}
+	if old, loaded := remoteHostClientCache.Swap(key, entry); loaded && old != nil {
+		old.(*cachedClient).httpClient.CloseIdleConnections()
+	}
 	return c, clientSet, restConfig, nil
+}
+
+// GetCachedWorkloadClusterClient returns a controller-runtime client for the workload
+// cluster identified by the given ObjectKey. It is a caching wrapper over CAPI's
+// remote.NewClusterClient: that factory rebuilds an http.Transport, RESTMapper and
+// triggers fresh API discovery on every call. The cache is keyed on the workload
+// cluster ObjectKey and invalidated by the kubeconfig secret's resourceVersion.
+// Evicted entries' transports are released by GC once their idle-conn timeout elapses.
+func GetCachedWorkloadClusterClient(ctx context.Context, sourceName string, c client.Client, cluster client.ObjectKey) (client.Client, error) {
+	sec := &corev1.Secret{}
+	secretKey := client.ObjectKey{
+		Namespace: cluster.Namespace,
+		Name:      capisecret.Name(cluster.Name, capisecret.Kubeconfig),
+	}
+	if err := c.Get(ctx, secretKey, sec); err != nil {
+		return nil, fmt.Errorf("failed to retrieve kubeconfig secret for cluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
+	}
+
+	if entry, ok := workloadClusterClientCache.Load(cluster); ok {
+		cached := entry.(*cachedClient)
+		if cached.rv == sec.ResourceVersion {
+			return cached.c, nil
+		}
+	}
+
+	cli, err := remote.NewClusterClient(ctx, sourceName, c, cluster)
+	if err != nil {
+		return nil, err
+	}
+	workloadClusterClientCache.Store(cluster, &cachedClient{c: cli, rv: sec.ResourceVersion})
+	return cli, nil
 }


### PR DESCRIPTION
Cache cluster client to avoid creating a new one on each reconcile request. Saves memory and cpu during high reconcile loads