### PR TITLE
[Backport 1462 to release-1.10] fix: don't set service metadata labels as selector (#1462)

### DIFF
--- a/internal/controller/k0smotron.io/k0smotroncluster_service.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_service.go
@@ -90,7 +90,6 @@ func generateService(kmc *km.Cluster) v1.Service {
 	// Selector must match pods (same as main); ObjectMeta gets app.kubernetes.io/component.
 	selectorLabels := map[string]string{}
 	maps.Copy(selectorLabels, util.LabelsForK0smotronCluster(kmc))
-	maps.Copy(selectorLabels, kmc.Spec.Service.Labels)
 	metadataLabels := map[string]string{}
 	maps.Copy(metadataLabels, util.LabelsForK0smotronComponent(kmc, util.ComponentControlPlane))
 	maps.Copy(metadataLabels, kmc.Spec.Service.Labels)


### PR DESCRIPTION
The change prevents that metadata labels for k0smotron cluster service are used as selector. Previously, custom labels set in .spec.service.labels were incorrectly applied to both the Service's metadata and its selector. Since the target pods do not carry those extra labels, this resulted in an empty EndpointSlice. Now, the labels are only applied to the Service metadata, while the selector remains unchanged.