### PR TITLE
Fix RecreateDeleteFirst strategy to not exceed desired replicas

### DIFF
--- a/internal/controller/controlplane/k0s_controlplane_controller.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller.go
@@ -379,6 +379,13 @@ func (c *K0sController) reconcileMachines(ctx context.Context, cluster *clusterv
 		if len(errs) > 0 {
 			return kerrors.NewAggregate(errs)
 		}
+
+		if kcp.Spec.UpdateStrategy == cpv1beta2.UpdateRecreateDeleteFirst {
+			// Wait until there is no machine being deleted before creating
+			// new machines when the UpdateRecreateDeleteFirst strategy is used to
+			// prevent excessive number of machines.
+			return util.ErrNotReady
+		}
 	}
 
 	infraMachines, err := c.getInfraMachines(ctx, activeMachines)
@@ -497,6 +504,7 @@ func (c *K0sController) reconcileMachines(ctx context.Context, cluster *clusterv
 		}
 
 		logger.Info("Deleted machine", "machine", machineToDelete.Name)
+		return util.ErrNotReady
 	}
 
 	if len(desiredMachines) < int(kcp.Spec.Replicas) {


### PR DESCRIPTION
fix #1482 

After a machine was deleted, a new one is created during the same synchronization cycle, resulting in a situation where the old machine had not been completely deleted and a new one had already been provisioned. With this fix, new machines are no longer created until the old one has been completely removed.