### PR TITLE
[Backport 1496] Fix bootstrap command to run shell logic with an interpreter

### DIFF
--- a/internal/controller/infrastructure/ssh_provisioner.go
+++ b/internal/controller/infrastructure/ssh_provisioner.go
@@ -27,6 +27,7 @@ import (
 	"regexp"
 	"strings"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/go-logr/logr"
 	"github.com/k0sproject/rig"
 	"github.com/k0sproject/rig/exec"
@@ -138,7 +139,8 @@ func (p *SSHProvisioner) Provision(ctx context.Context) error {
 		// Run commands
 		for _, cmd := range p.cloudInit.Commands {
 			p.log.Info("running command", "command", cmd)
-			output, err := connection.ExecOutput(cmd, execOpts...)
+			cmdWithShell := "sh -c " + shellescape.Quote(cmd)
+			output, err := connection.ExecOutput(cmdWithShell, execOpts...)
 			if err != nil {
 				p.log.Error(err, "failed to run command", "command", cmd, "output", output)
 				return fmt.Errorf("failed to run command: %w", err)


### PR DESCRIPTION
Probably this backport can be closed in favor of backporting https://github.com/k0sproject/k0smotron/pull/1503