### PR TITLE
Fix install files release when backporting

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -92,15 +92,17 @@ jobs:
           github.event.action == 'published' &&
           !github.event.release.draft &&
           !github.event.release.prerelease
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
         run: |
-          STABLE=${{ steps.set_versions.outputs.STABLE }}
-          make release IMG=quay.io/k0sproject/k0smotron:${STABLE}
-          make release-standalone IMG=quay.io/k0sproject/k0smotron:${STABLE}
+          make release IMG=quay.io/k0sproject/k0smotron:${VERSION}
+          make release-standalone IMG=quay.io/k0sproject/k0smotron:${VERSION}
           cp install.yaml /tmp/install.yaml
           cp install-standalone.yaml /tmp/install-standalone.yaml
           git checkout gh-pages
-          cp /tmp/install.yaml ${STABLE}/install.yaml
-          cp /tmp/install-standalone.yaml ${STABLE}/install-standalone.yaml
-          git add ${STABLE}/install.yaml ${STABLE}/install-standalone.yaml && git update-index --refresh
-          git diff-index --quiet HEAD -- || git commit -m "Update install.yaml and install-standalone.yaml to ${STABLE}"
+          mkdir -p ${VERSION}
+          cp /tmp/install.yaml ${VERSION}/install.yaml
+          cp /tmp/install-standalone.yaml ${VERSION}/install-standalone.yaml
+          git add ${VERSION}/install.yaml ${VERSION}/install-standalone.yaml && git update-index --refresh
+          git diff-index --quiet HEAD -- || git commit -m "Update install.yaml and install-standalone.yaml to ${VERSION}"
           git push origin gh-pages


### PR DESCRIPTION
Currently, the step uses the stable version instead of the published release version, so backport releases (e.g. `v1.10.6` when `v2.0.0` is already out) never get their `install.yaml` and `install-standalone.yaml` published to `gh-pages`.

After merge, workflow for publish docs should be re-run for `v1.10.8` and `v1.10.9` release as they where release after `v2.0.0` and the install manifests were not uploaded due to the bug