### PR TITLE
fix(controlplane): break hosted CP deadlock

### DIFF
--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -646,17 +646,42 @@ func (c *K0smotronController) computeAvailability(ctx context.Context, cluster *
 	// and checking if the control plane is initialized
 	logger.Info("Pinging the workload cluster API")
 
+	clusterKey := client.ObjectKeyFromObject(cluster)
+
 	// Get the CAPI cluster accessor
-	client, err := c.ClusterCache.GetClient(ctx, client.ObjectKeyFromObject(cluster))
+	client, err := c.ClusterCache.GetClient(ctx, clusterKey)
 	if err != nil {
-		logger.Info("Failed to get cluster client", "error", err)
-		conditions.Set(kcp, metav1.Condition{
-			Type:    string(cpv1beta2.ControlPlaneAvailableCondition),
-			Status:  metav1.ConditionFalse,
-			Reason:  "ClusterClientCreationFailed",
-			Message: err.Error(),
-		})
-		return
+		// ClusterCache refuses to connect until Cluster.status.initialization.infrastructureProvisioned=true.
+		// For K0smotronControlPlane the hosted CP runs in the mgmt cluster and its API is reachable via the
+		// CAPI kubeconfig secret regardless of infra state; when infra is externally managed by k0smotron
+		// itself with cluster.x-k8s.io/managed-by: k0smotron, that ClusterCache gate
+		// and the ControlPlaneInitialized->status.ready patch chain form a permanent deadlock, see k0rdent/kcm#2884.
+		// Fall back to a direct kubeconfig-secret client on ErrClusterNotConnected to break it
+		if errors.Is(err, clustercache.ErrClusterNotConnected) {
+			logger.Info("ClusterCache not connected yet, falling back to direct kubeconfig-secret client")
+			directClient, fbErr := util.GetWorkloadClusterClientFromKubeconfigSecret(ctx, c.Client, clusterKey)
+			if fbErr != nil {
+				logger.Error(fbErr, "Failed to build direct workload cluster client fallback")
+				conditions.Set(kcp, metav1.Condition{
+					Type:    cpv1beta2.ControlPlaneAvailableCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  "ClusterClientCreationFailed",
+					Message: fbErr.Error(),
+				})
+				return
+			}
+
+			client = directClient
+		} else {
+			logger.Error(err, "Failed to get cluster client")
+			conditions.Set(kcp, metav1.Condition{
+				Type:    cpv1beta2.ControlPlaneAvailableCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  "ClusterClientCreationFailed",
+				Message: err.Error(),
+			})
+			return
+		}
 	}
 
 	pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -752,7 +777,6 @@ func (c *K0smotronController) patchInfrastructureStatus(ctx context.Context, clu
 
 // reconcileDelete handles the deletion of the K0smotronControlPlane object when the controlplane replicas runs in a different cluster.
 func (c *K0smotronController) reconcileDelete(ctx context.Context, key types.NamespacedName, kcp *cpv1beta2.K0smotronControlPlane) (res ctrl.Result, err error) {
-
 	defer func() {
 		if err != nil && apierrors.IsNotFound(err) {
 			// The cluster is already deleted. Remove the finalizer from the K0smotronControlPlane object for complete cleanup.

--- a/internal/controller/controlplane/k0smotron_controlplane_controller_test.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	cpv1beta2 "github.com/k0sproject/k0smotron/v2/api/controlplane/v1beta2"
 	kapi "github.com/k0sproject/k0smotron/v2/api/k0smotron.io/v1beta2"
 	"github.com/k0sproject/version"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/controllers/clustercache"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/secret"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -328,7 +333,6 @@ func TestIsClusterSpecSynced(t *testing.T) {
 			})
 		}
 	}
-
 }
 
 func Test_alignToSpecVersionFormat(t *testing.T) {
@@ -362,6 +366,99 @@ func Test_alignToSpecVersionFormat(t *testing.T) {
 			got, err := alignToSpecVersionFormat(tt.specVersion, tt.currentVersion)
 			require.NoError(t, err)
 			require.True(t, tt.want.Equal(got), "alignToSpecVersionFormat() = %v, want %v", got, tt.want)
+		})
+	}
+}
+
+// Test_computeAvailability regression-guards k0rdent/kcm#2884
+func Test_computeAvailability(t *testing.T) {
+	const (
+		clusterName = "hosted"
+		clusterNs   = "default"
+	)
+
+	// syntactically valid kubeconfig pointing to an unroutable endpoint; the fallback only builds a client
+	// from this blob, the subsequent ping is expected to fail and that is exactly what distinguishes
+	// fallback success from a pre-ping ClusterClientCreationFailed
+	kubeconfigYAML := []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: https://127.0.0.1:1
+    insecure-skip-tls-verify: true
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user:
+    token: dummy
+`)
+
+	kubeconfigSecret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      secret.Name(clusterName, secret.Kubeconfig),
+			Namespace: clusterNs,
+		},
+		Data: map[string][]byte{
+			secret.KubeconfigDataName: kubeconfigYAML,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, cpv1beta2.AddToScheme(scheme))
+
+	tests := []struct {
+		name          string
+		hubObjects    []client.Object
+		wantCondition string
+	}{
+		{
+			name:          "fallback client used when ClusterCache is not connected and kubeconfig secret exists",
+			hubObjects:    []client.Object{kubeconfigSecret},
+			wantCondition: "KubeSystemNamespaceNotAccessible",
+		},
+		{
+			name:          "ClusterClientCreationFailed surfaced when kubeconfig secret is missing",
+			hubObjects:    nil,
+			wantCondition: "ClusterClientCreationFailed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: v1.ObjectMeta{Name: clusterName, Namespace: clusterNs},
+			}
+
+			hubClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.hubObjects...).Build()
+
+			// non-matching cluster key -> clustercache.ErrClusterNotConnected on GetClient (kcm#2884)
+			disconnectedCache := clustercache.NewFakeClusterCache(
+				fake.NewClientBuilder().Build(),
+				client.ObjectKey{Name: "unrelated", Namespace: "unrelated"},
+			)
+
+			c := &K0smotronController{
+				Client:       hubClient,
+				ClusterCache: disconnectedCache,
+				Scheme:       scheme,
+			}
+			kcp := &cpv1beta2.K0smotronControlPlane{
+				ObjectMeta: v1.ObjectMeta{Name: clusterName, Namespace: clusterNs},
+			}
+
+			c.computeAvailability(context.Background(), cluster, kcp)
+
+			cond := conditions.Get(kcp, string(cpv1beta2.ControlPlaneAvailableCondition))
+			require.NotNil(t, cond, "Available condition must be set")
+			require.Equal(t, tt.wantCondition, cond.Reason)
 		})
 	}
 }

--- a/internal/controller/util/wc_client.go
+++ b/internal/controller/util/wc_client.go
@@ -39,14 +39,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var (
-	// ErrNotReady is used to indicate that the control plane is not ready yet.
-	ErrNotReady = fmt.Errorf("waiting for the state")
-)
+// ErrNotReady is used to indicate that the control plane is not ready yet.
+var ErrNotReady = fmt.Errorf("waiting for the state")
 
 // GetWorkloadClusterClientset returns a Kubernetes clientset for the given cluster.
 func GetWorkloadClusterClientset(ctx context.Context, hubClient client.Client, cache clustercache.ClusterCache, cluster *clusterv1.Cluster) (*kubernetes.Clientset, error) {
-
 	k0sControlPlane, err := FindK0sControlPlane(ctx, hubClient, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find K0sControlPlane: %w", err)
@@ -90,6 +87,27 @@ func GetWorkloadClusterClientset(ctx context.Context, hubClient client.Client, c
 func GetControllerRuntimeClient(ctx context.Context, hubClient client.Client, clustercache clustercache.ClusterCache, kcp *cpv1beta2.K0sControlPlane, cluster client.ObjectKey) (client.Client, error) {
 	restConfig, err := getRESTConfig(ctx, hubClient, clustercache, kcp, cluster)
 	if err != nil {
+		return nil, err
+	}
+
+	return client.New(restConfig, client.Options{Scheme: hubClient.Scheme()})
+}
+
+// GetWorkloadClusterClientFromKubeconfigSecret returns a controller-runtime client for the given cluster built
+// directly from the CAPI-managed kubeconfig secret, bypassing ClusterCache. Intended as a fallback for callers whose
+// workload API is reachable independently of Cluster.status.initialization.infrastructureProvisioned, i.e.
+// K0smotronControlPlane, whose hosted CP runs as pods in the mgmt cluster. Wraps ErrNotReady when the kubeconfig
+// secret does not exist yet.
+func GetWorkloadClusterClientFromKubeconfigSecret(ctx context.Context, hubClient client.Client, cluster client.ObjectKey) (client.Client, error) {
+	restConfig, err := fromKubeconfigSecretToRestConfig(ctx, hubClient, client.ObjectKey{
+		Namespace: cluster.Namespace,
+		Name:      secret.Name(cluster.Name, secret.Kubeconfig),
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: %v", ErrNotReady, err)
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
K0smotronControlPlane's availability ping goes through ClusterCache, which won't connect until infrastructureProvisioned=true. When infra is externally managed (cluster.x-k8s.io/managed-by: k0smotron), k0smotron alone patches InfraCluster.status.ready and gates that patch on ControlPlaneInitialized: set only after a successful ping. Permanent deadlock.

Fall back to a direct CAPI kubeconfig-secret client on ErrClusterNotConnected; the hosted CP is reachable regardless of infra state.

Regressed by 211072e2.
Fixes k0rdent/kcm#2884