### PR TITLE
k0s native konnectivity ingress support

### DIFF
--- a/api/k0smotron.io/v1beta2/k0smotroncluster_types.go
+++ b/api/k0smotron.io/v1beta2/k0smotroncluster_types.go
@@ -346,6 +346,31 @@ func (c *ClusterSpec) GetImage() string {
 	return fmt.Sprintf("%s:%s", c.Image, k0sVersion)
 }
 
+// nativeKonnectivityMinVersion is the first k0s release whose konnectivity
+// agent honors spec.konnectivity.externalAddress (k0s commit c5b3a4ef, first
+// released in v1.35.1+k0s.0). Below this, the field is accepted but silently
+// ignored, so k0smotron must ship its own konnectivity agent manifest for the
+// ingress topology. Compared on Core() (major.minor.patch) since the
+// "+k0s.N"/"-k0s.N" build suffix is not meaningful for this decision.
+var nativeKonnectivityMinVersion = version.MustParse("v1.35.1")
+
+// HasNativeIngressKonnectivity reports whether the target k0s version deploys
+// the ingress konnectivity agent itself (pointed at externalAddress). When
+// false, k0smotron ships its own konnectivity agent manifest instead (see
+// generateKonnectivityIngressConfigMap). An unparseable version falls back to
+// false so we keep shipping the manifest rather than silently lose konnectivity.
+func (c *ClusterSpec) HasNativeIngressKonnectivity() bool {
+	k0sVersion := c.Version
+	if k0sVersion == "" {
+		k0sVersion = DefaultK0SVersion
+	}
+	v, err := version.NewVersion(k0sVersion)
+	if err != nil {
+		return false
+	}
+	return !v.Core().LessThan(nativeKonnectivityMinVersion.Core())
+}
+
 // GetConditions returns the conditions of the Cluster status.
 func (kmc *Cluster) GetConditions() []metav1.Condition {
 	return kmc.Status.Conditions

--- a/e2e/data/infrastructure-docker/main/cluster-template-ingress/cluster-with-ingress.yaml
+++ b/e2e/data/infrastructure-docker/main/cluster-template-ingress/cluster-with-ingress.yaml
@@ -27,7 +27,7 @@ kind: K0smotronControlPlane
 metadata:
   name: ${CLUSTER_NAME}-cp
 spec:
-  version: v1.34.1-k0s.0
+  version: v1.36.2-k0s.0
   service:
     type: NodePort
   ingress:
@@ -45,10 +45,6 @@ spec:
           anonymous-auth: "true"
       telemetry:
         enabled: false
-      images:
-        konnectivity:
-          image: quay.io/k0sproject/apiserver-network-proxy-agent
-          version: v0.33.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DevCluster
@@ -77,7 +73,7 @@ spec:
         cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
         pool: worker-pool-1
     spec:
-      version: v1.34.1
+      version: v1.36.2
       clusterName: ${CLUSTER_NAME}
       bootstrap:
         configRef:
@@ -97,7 +93,7 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.34.1+k0s.0
+      version: v1.36.2+k0s.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DevMachineTemplate

--- a/e2e/ingress_test.go
+++ b/e2e/ingress_test.go
@@ -182,7 +182,7 @@ func ingressSupportSpec(flavor string) func(t *testing.T) {
 		out, err := podexec.PodExecCmdOutput(ctx, bootstrapClusterProxy.GetClientSet(), bootstrapClusterProxy.GetRESTConfig(), podList.Items[0].Name, testNamespace.Name, "k0s kc logs -n kube-system ds/konnectivity-agent")
 		require.NoError(t, err)
 		t.Logf("Konnectivity agent logs:\n%s", out)
-		require.Contains(t, out, "change detected in proxy")
+		require.Contains(t, out, "successfully connected to new proxy server")
 
 		for _, m := range machineList.Items {
 			var (

--- a/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_configmap.go
@@ -268,10 +268,19 @@ func getV1Beta1Spec(kmc *km.Cluster, sans []string) map[string]any {
 		v1beta1Spec["api"].(map[string]any)["extraArgs"] = map[string]any{
 			"endpoint-reconciler-type": "none",
 		}
-		v1beta1Spec["konnectivity"] = map[string]any{
-			"externalAddress": kmc.Spec.Ingress.KonnectivityHost,
-			"agentPort":       int64(kmc.Spec.Service.KonnectivityPort),
+		konnectivity := map[string]any{
+			"agentPort": int64(kmc.Spec.Service.KonnectivityPort),
 		}
+		if kmc.Spec.HasNativeIngressKonnectivity() {
+			// k0s deploys the konnectivity agent itself; point it at the ingress
+			// endpoint (host:ingressPort), reached via SNI routing.
+			konnectivity["externalAddress"] = net.JoinHostPort(kmc.Spec.Ingress.KonnectivityHost, strconv.FormatInt(kmc.Spec.Ingress.Port, 10))
+		} else {
+			// Older k0s ignores externalAddress; k0smotron ships its own agent
+			// manifest instead. Keep the host-only value for parity.
+			konnectivity["externalAddress"] = kmc.Spec.Ingress.KonnectivityHost
+		}
+		v1beta1Spec["konnectivity"] = konnectivity
 	}
 
 	return v1beta1Spec

--- a/internal/controller/k0smotron.io/k0smotroncluster_ingress.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_ingress.go
@@ -45,44 +45,70 @@ func (scope *kmcScope) reconcileIngress(ctx context.Context, kmc *km.Cluster) er
 		return fmt.Errorf("failed to patch haproxy configmap for ingress: %w", err)
 	}
 
-	configMap, err = scope.generateKonnectivityIngressConfigMap(kmc)
-	if err != nil {
-		return fmt.Errorf("failed to generate ingress manifests configmap: %w", err)
-	}
-	_ = kcontrollerutil.SetExternalOwnerReference(kmc, &configMap, scope.client.Scheme(), scope.externalOwner)
-
-	err = scope.reconcileResource(ctx, kmc, &configMap)
-	if err != nil {
-		return fmt.Errorf("failed to patch haproxy configmap for ingress: %w", err)
-	}
-
-	var foundManifest bool
-	for _, manifest := range kmc.Spec.Manifests {
-		if manifest.Name == kmc.GetIngressManifestsConfigMapName() {
-			foundManifest = true
-			break
+	// On k0s versions that honor spec.konnectivity.externalAddress the
+	// konnectivity agent is deployed by k0s itself; on older versions the field
+	// is accepted but ignored, so we ship our own konnectivity agent manifest
+	// pointed at the ingress endpoint.
+	native := kmc.Spec.HasNativeIngressKonnectivity()
+	if !native {
+		configMap, err = scope.generateKonnectivityIngressConfigMap(kmc)
+		if err != nil {
+			return fmt.Errorf("failed to generate konnectivity ingress configmap: %w", err)
+		}
+		_ = kcontrollerutil.SetExternalOwnerReference(kmc, &configMap, scope.client.Scheme(), scope.externalOwner)
+		if err = scope.reconcileResource(ctx, kmc, &configMap); err != nil {
+			return fmt.Errorf("failed to reconcile konnectivity configmap for ingress: %w", err)
 		}
 	}
+
+	ingressVolume := corev1.Volume{
+		Name: kmc.GetIngressManifestsConfigMapName(),
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: kmc.GetIngressManifestsConfigMapName(),
+				},
+			},
+		},
+	}
+	konnectivityVolume := corev1.Volume{
+		Name: "konnectivity",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: kmc.GetIngressManifestsConfigMapName() + "-konnectivity",
+				},
+			},
+		},
+	}
+
+	// Ensure the ingress bundle volume is present, and the konnectivity volume
+	// only on non-native k0s. On native k0s a stale konnectivity volume is
+	// dropped so the control-plane pod doesn't mount a ConfigMap we no longer
+	// ship.
+	var foundManifest, foundKonnectivity bool
+	filtered := kmc.Spec.Manifests[:0]
+	for _, m := range kmc.Spec.Manifests {
+		switch m.Name {
+		case ingressVolume.Name:
+			foundManifest = true
+			filtered = append(filtered, m)
+		case konnectivityVolume.Name:
+			if native {
+				continue
+			}
+			foundKonnectivity = true
+			filtered = append(filtered, m)
+		default:
+			filtered = append(filtered, m)
+		}
+	}
+	kmc.Spec.Manifests = filtered
 	if !foundManifest {
-		kmc.Spec.Manifests = append(kmc.Spec.Manifests, corev1.Volume{
-			Name: kmc.GetIngressManifestsConfigMapName(),
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: kmc.GetIngressManifestsConfigMapName(),
-					},
-				},
-			},
-		}, corev1.Volume{
-			Name: "konnectivity",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: kmc.GetIngressManifestsConfigMapName() + "-konnectivity",
-					},
-				},
-			},
-		})
+		kmc.Spec.Manifests = append(kmc.Spec.Manifests, ingressVolume)
+	}
+	if !native && !foundKonnectivity {
+		kmc.Spec.Manifests = append(kmc.Spec.Manifests, konnectivityVolume)
 	}
 
 	if *kmc.Spec.Ingress.Deploy {

--- a/internal/controller/k0smotron.io/k0smotroncluster_ingress_test.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_ingress_test.go
@@ -214,3 +214,24 @@ func TestGetKonnectivityAgentPullPolicy(t *testing.T) {
 		assert.Equal(t, "Always", scope.getKonnectivityAgentPullPolicy(kmc))
 	})
 }
+
+func TestHasNativeIngressKonnectivity(t *testing.T) {
+	cases := []struct {
+		version string
+		native  bool
+	}{
+		{"v1.35.1+k0s.0", true},
+		{"v1.35.1-k0s.0", true},
+		{"v1.35.2+k0s.0", true},
+		{"v1.36.0+k0s.0", true},
+		{"v1.34.1+k0s.0", false},
+		{"v1.34.5+k0s.0", false},
+		{"v1.27.9-k0s.0", false},
+		{"", false}, // defaults to DefaultK0SVersion (old)
+		{"not-a-version", false},
+	}
+	for _, tc := range cases {
+		spec := km.ClusterSpec{Version: tc.version}
+		assert.Equal(t, tc.native, spec.HasNativeIngressKonnectivity(), "version: %q", tc.version)
+	}
+}


### PR DESCRIPTION
we added custom konnectivity deployment for v1.34.x and it's not needed for v1.35.x