### PR TITLE
Fix K0sWorkerConfig ignoring Machine's spec.version

### DIFF
--- a/internal/controller/bootstrap/worker_bootstrap_controller.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller.go
@@ -130,6 +130,12 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 
 	log = log.WithValues("kind", configOwner.GetKind(), "version", configOwner.GetResourceVersion(), "name", configOwner.GetName())
 
+	// If the K0sWorkerConfig does not have a version set, fall back to the owner's
+	// (Machine or MachinePool) Kubernetes version, e.g. as set by a ClusterClass topology.
+	if config.Spec.Version == "" {
+		config.Spec.Version = configOwner.KubernetesVersion()
+	}
+
 	// If the version does not contain the k0s suffix, append it.
 	if config.Spec.Version != "" {
 		// When machine is created by CAPI, for example by using a clusterclass template, the version

--- a/internal/controller/bootstrap/worker_bootstrap_controller_env_test.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller_env_test.go
@@ -481,6 +481,107 @@ func TestReconcileControlPlaneNotReady(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
+func TestReconcileWorkerConfigVersionFallsBackToMachineVersion(t *testing.T) {
+	ns, err := testEnv.CreateNamespace(ctx, "test-reconcile-workerconfig-version-fallback")
+	require.NoError(t, err)
+
+	cluster, kcp, _ := createClusterWithControlPlane(ns.GetName())
+	require.NoError(t, testEnv.Create(ctx, cluster))
+	require.NoError(t, testEnv.Create(ctx, kcp))
+
+	conditions.Set(cluster, metav1.Condition{
+		Type:   string(clusterv1.ClusterControlPlaneInitializedCondition),
+		Status: metav1.ConditionTrue,
+		Reason: "ControlPlaneReady",
+	})
+	require.NoError(t, testEnv.Status().Update(ctx, cluster))
+
+	machineForWorkerConfig := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", "machine-for-worker", 0),
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:             cluster.Name,
+				clusterv1.MachineControlPlaneLabel:     "true",
+				clusterv1.MachineControlPlaneNameLabel: "machineForWorkerConfig",
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: cluster.Name,
+			// As set by a ClusterClass topology, e.g. `.spec.topology.version`.
+			Version: "v1.30.5",
+			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+				Kind:     "GenericInfrastructureMachine",
+				Name:     "machine-for-controller-infra",
+				APIGroup: clusterv1.GroupVersionInfrastructure.Group,
+			},
+			Bootstrap: clusterv1.Bootstrap{
+				ConfigRef: clusterv1.ContractVersionedObjectReference{
+					Name:     "machine-for-controller-bootstrap",
+					APIGroup: clusterv1.GroupVersionBootstrap.Group,
+					Kind:     "K0sControllerConfig",
+				},
+			},
+		},
+	}
+	require.NoError(t, testEnv.Create(ctx, machineForWorkerConfig))
+
+	// K0sWorkerConfig deliberately has no Spec.Version set, as is the case when it is
+	// created from a K0sWorkerConfigTemplate referenced by a ClusterClass.
+	k0sWorkerConfig := &bootstrapv1.K0sWorkerConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bootstrap.cluster.x-k8s.io/v1beta2",
+			Kind:       "K0sWorkerConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-config",
+			Namespace: ns.Name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "Machine",
+					APIVersion: clusterv1.GroupVersion.String(),
+					Name:       machineForWorkerConfig.Name,
+					UID:        "1",
+				},
+			},
+		},
+	}
+	require.NoError(t, testEnv.Create(ctx, k0sWorkerConfig))
+
+	defer func(do ...client.Object) {
+		require.NoError(t, testEnv.Cleanup(ctx, do...))
+	}(k0sWorkerConfig, cluster, machineForWorkerConfig, kcp, ns)
+
+	workloadClient, _ := fakeremote.NewClusterClient(ctx, "", testEnv, types.NamespacedName{})
+	r := &Controller{
+		Client:                testEnv,
+		workloadClusterClient: workloadClient,
+		SecretCachingClient:   testEnv,
+	}
+
+	clusterCerts := secret.NewCertificatesForInitialControlPlane(&kubeadmbootstrapv1.ClusterConfiguration{})
+	require.NoError(t, clusterCerts.Generate())
+	caCert := clusterCerts.GetByPurpose(secret.ClusterCA)
+	caCertSecret := caCert.AsSecret(
+		client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name},
+		*metav1.NewControllerRef(kcp, cpv1beta2.GroupVersion.WithKind("K0sControlPlane")),
+	)
+	require.NoError(t, testEnv.Create(ctx, caCertSecret))
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(k0sWorkerConfig)})
+		assert.NoError(c, err)
+		assert.Equal(c, ctrl.Result{}, result)
+
+		bootstrapSecret := &corev1.Secret{}
+		assert.NoError(c, testEnv.Get(ctx, client.ObjectKey{Namespace: k0sWorkerConfig.Namespace, Name: k0sWorkerConfig.Name}, bootstrapSecret))
+
+		// The K0sWorkerConfig had no version set, so it must fall back to the owning
+		// Machine's spec.version (normalized with the k0s suffix) instead of installing latest.
+		assert.Contains(c, string(bootstrapSecret.Data["value"]), "K0S_VERSION=v1.30.5+k0s.0")
+	}, 20*time.Second, 100*time.Millisecond)
+}
+
 func TestReconcileGenerateBootstrapData(t *testing.T) {
 	ns, err := testEnv.CreateNamespace(ctx, "test-reconcile-workerconfig-generate-bootstrap-data")
 	require.NoError(t, err)


### PR DESCRIPTION
Motivation:
When a K0sWorkerConfig has no Spec.Version set, the worker bootstrap
controller always installs the latest k0s release instead of falling
back to the owning Machine's (or MachinePool's) Kubernetes version.
This is especially problematic with ClusterClass, where the k0s
version is set on the Machine via the Cluster topology and
K0sWorkerConfigTemplate intentionally omits Spec.Version. Workers then
join with an unexpected k0s version, which can get stuck instead of
joining the cluster with the version the topology requested.

The fallback was previously implemented by converting the config
owner to a Machine and reading its Spec.Version, but that code was
removed in a refactor (f1e352029dadccab25dd40ab581cb369ca6ccfa5)
without a replacement.

Approach:
Restore the fallback using configOwner.KubernetesVersion(), a helper
already available on CAPI's bsutil.ConfigOwner that reads spec.version
for a Machine and spec.template.spec.version for a MachinePool. This
covers both owner kinds, unlike the original manual Machine
conversion. The fallback runs before the existing "-k0s." to "+k0s."
normalization and default-suffix logic, so a version picked up from
the owner is normalized the same way an explicitly set version is.
An explicitly set Spec.Version is never overwritten.

Validation:
Added an envtest-tagged regression test,
TestReconcileWorkerConfigVersionFallsBackToMachineVersion, which
creates a Machine with spec.version "v1.30.5" and a K0sWorkerConfig
with no version owned by it, reconciles to completion, and asserts
the generated bootstrap secret's install script contains
"K0S_VERSION=v1.30.5+k0s.0" rather than installing k0s with no
version pin (which would resolve to latest). Confirmed the test fails
without the fix (falls back to installing latest) and passes with it.

Ran:
  KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.32.0 --bin-dir "$(pwd)/bin" -p path)" \
    go test ./internal/controller/bootstrap/... -tags envtest
  go test ./internal/controller/bootstrap/...
  go build ./...
  go vet ./internal/controller/bootstrap/...
All passed.

Fixes #1524

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>