### PR TITLE
Add merge conflicts workflow

### DIFF
--- a/.github/workflows/conflicts.yaml
+++ b/.github/workflows/conflicts.yaml
@@ -1,0 +1,30 @@
+name: Check for merge conflicts
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+      - release-*
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  main:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check for merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          dirtyLabel: merge-conflict
+          commentOnDirty: This pull request has merge conflicts that need to be resolved.


### PR DESCRIPTION
Copied from k0sproject/k0s . I find this workflow useful for easily detect PR needs some care without clicking on it.