### PR TITLE
deprecate version field in k0s config resources

### DIFF
--- a/api/bootstrap/v1beta2/k0s_types.go
+++ b/api/bootstrap/v1beta2/k0s_types.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/k0sproject/k0smotron/v2/internal/provisioner"
 )
@@ -135,6 +136,7 @@ type K0sWorkerConfigSpec struct {
 	// Make sure the version is compatible with the k0s version running on the control plane.
 	// For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
 	// +kubebuilder:validation:Optional
+	// Deprecated: Use Machine version instead.
 	Version string `json:"version,omitempty"`
 
 	// UseSystemHostname specifies whether to use the system hostname for the kubernetes node name.
@@ -282,6 +284,7 @@ type K0sControllerConfigSpec struct {
 	// Make sure the version is compatible with the k0s version running on the control plane.
 	// For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
 	// +kubebuilder:validation:Optional
+	// Deprecated: Use Machine version instead.
 	Version string `json:"version,omitempty"`
 
 	*K0sConfigSpec `json:",inline"`
@@ -460,15 +463,17 @@ func (c *K0sWorkerConfig) GetJoinTokenPath() string {
 }
 
 // Validate validates the K0sWorkerConfigSpec.
-func (cs *K0sWorkerConfigSpec) Validate(pathPrefix *field.Path) field.ErrorList {
+func (cs *K0sWorkerConfigSpec) Validate(pathPrefix *field.Path) (admission.Warnings, field.ErrorList) {
 	var allErrs field.ErrorList
 
 	// TODO: validate Ignition
-	allErrs = append(allErrs, cs.validateVersion(pathPrefix)...)
+
+	warnings, versionErrs := cs.validateVersion(pathPrefix)
+	allErrs = append(allErrs, versionErrs...)
 	allErrs = append(allErrs, cs.validateFiles(pathPrefix)...)
 	allErrs = append(allErrs, cs.validateWindows(pathPrefix)...)
 
-	return allErrs
+	return warnings, allErrs
 }
 
 func (cs *K0sWorkerConfigSpec) validateFiles(pathPrefix *field.Path) field.ErrorList {
@@ -548,8 +553,15 @@ func (cs *K0sWorkerConfigSpec) validateFiles(pathPrefix *field.Path) field.Error
 	return allErrs
 }
 
-func (cs *K0sWorkerConfigSpec) validateVersion(pathPrefix *field.Path) field.ErrorList {
+const deprecatedK0sConfigVersionField = "K0sWorkerConfig.spec.version is deprecated and will be removed in a future release. It currently takes precedence over the Machine's version field."
+
+func (cs *K0sWorkerConfigSpec) validateVersion(pathPrefix *field.Path) (admission.Warnings, field.ErrorList) {
 	var allErrs field.ErrorList
+
+	var warnings admission.Warnings
+	if cs.Version != "" {
+		warnings = append(warnings, deprecatedK0sConfigVersionField)
+	}
 
 	if strings.Contains(cs.Version, "-k0s.") {
 		allErrs = append(
@@ -560,10 +572,10 @@ func (cs *K0sWorkerConfigSpec) validateVersion(pathPrefix *field.Path) field.Err
 				"k0s specific versions must be specified using the '+k0s' suffix",
 			),
 		)
-		return allErrs
+		return warnings, allErrs
 	}
 
-	return allErrs
+	return warnings, allErrs
 }
 
 func (cs *K0sWorkerConfigSpec) validateWindows(pathPrefix *field.Path) field.ErrorList {

--- a/api/bootstrap/v1beta2/worker_bootstrap_webhook.go
+++ b/api/bootstrap/v1beta2/worker_bootstrap_webhook.go
@@ -19,6 +19,7 @@ package v1beta2
 import (
 	"context"
 	"fmt"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -56,7 +57,7 @@ func (v *K0sWorkerConfigValidator) ValidateCreate(_ context.Context, obj runtime
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a K0sWorkerConfig but got a %T", obj))
 	}
 
-	return nil, v.validate(c.Spec, c.Name)
+	return v.validate(c.Spec, c.Name)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
@@ -66,7 +67,7 @@ func (v *K0sWorkerConfigValidator) ValidateUpdate(_ context.Context, _, newObj r
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a K0sWorkerConfig but got a %T", newObj))
 	}
 
-	return nil, v.validate(newC.Spec, newC.Name)
+	return v.validate(newC.Spec, newC.Name)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
@@ -74,14 +75,14 @@ func (v *K0sWorkerConfigValidator) ValidateDelete(_ context.Context, _ runtime.O
 	return nil, nil
 }
 
-func (v *K0sWorkerConfigValidator) validate(c K0sWorkerConfigSpec, name string) error {
-	allErrs := c.Validate(field.NewPath("spec"))
+func (v *K0sWorkerConfigValidator) validate(c K0sWorkerConfigSpec, name string) (admission.Warnings, error) {
+	warnings, allErrs := c.Validate(field.NewPath("spec"))
 
 	if len(allErrs) == 0 {
-		return nil
+		return warnings, nil
 	}
 
-	return apierrors.NewInvalid(GroupVersion.WithKind("K0sWorkerConfig").GroupKind(), name, allErrs)
+	return warnings, apierrors.NewInvalid(GroupVersion.WithKind("K0sWorkerConfig").GroupKind(), name, allErrs)
 }
 
 // SetupK0sWorkerConfigWebhookWithManager registers the webhook for K0sWorkerConfig in the manager.

--- a/api/bootstrap/v1beta2/worker_bootstrap_webhook_test.go
+++ b/api/bootstrap/v1beta2/worker_bootstrap_webhook_test.go
@@ -215,7 +215,8 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			require.Empty(t, warnings)
+			require.Len(t, warnings, 1)
+			require.Equal(t, warnings[0], deprecatedK0sConfigVersionField)
 
 			warnings, err = validator.ValidateUpdate(context.Background(), nil, tc.in)
 			if tc.expectingError {
@@ -223,7 +224,8 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			require.Empty(t, warnings)
+			require.Len(t, warnings, 1)
+			require.Equal(t, warnings[0], deprecatedK0sConfigVersionField)
 
 		})
 	}

--- a/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -614,6 +614,7 @@ spec:
                   a version field of the Machine object. If it's empty, the latest version is used.
                   Make sure the version is compatible with the k0s version running on the control plane.
                   For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
+                  Deprecated: Use Machine version instead.
                 type: string
               workingDir:
                 description: WorkingDir specifies the working directory where k0smotron

--- a/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -532,6 +532,7 @@ spec:
                   a version field of the Machine object. If it's empty, the latest version is used.
                   Make sure the version is compatible with the k0s version running on the control plane.
                   For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
+                  Deprecated: Use Machine version instead.
                 type: string
               workingDir:
                 description: WorkingDir specifies the working directory where k0smotron

--- a/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -526,6 +526,7 @@ spec:
                           a version field of the Machine object. If it's empty, the latest version is used.
                           Make sure the version is compatible with the k0s version running on the control plane.
                           For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
+                          Deprecated: Use Machine version instead.
                         type: string
                       workingDir:
                         description: WorkingDir specifies the working directory where

--- a/docs/advanced/components.md
+++ b/docs/advanced/components.md
@@ -160,7 +160,7 @@ spec:
         pool: worker-pool-1
     spec:
       clusterName: docker-test
-      version: v1.34.3
+      version: v1.34.3+k0s.0
       bootstrap:
         configRef:
           apiGroup: bootstrap.cluster.x-k8s.io
@@ -188,8 +188,7 @@ metadata:
   name: docker-test-machine-config
 spec:
   template:
-    spec:
-      version: v1.34.3+k0s.0
+    spec: {}
 ```
 
 After the cluster is provisioned, verify that the patches were applied. Resource names follow the conventions described in [Generated Resources](../generated-resources.md).

--- a/docs/capi-aws-vm.md
+++ b/docs/capi-aws-vm.md
@@ -130,6 +130,7 @@ spec:
         cluster.x-k8s.io/cluster-name: aws-test-cluster
         pool: worker-pool-1
     spec:
+      version: v1.33.2+k0s.0
       clusterName: aws-test-cluster
       failureDomain: eu-west-1
       bootstrap:
@@ -148,8 +149,7 @@ metadata:
   name: k0s-aws-test-machine-config
 spec:
   template:
-    spec:
-      version: v1.33.2+k0s.0
+    spec: {}
 ```
 
 ```shell

--- a/docs/capi-aws.md
+++ b/docs/capi-aws.md
@@ -93,6 +93,7 @@ spec:
         cluster.x-k8s.io/cluster-name: k0s-aws-test
         pool: worker-pool-1
     spec:
+      version: v1.27.2+k0s.0
       clusterName: k0s-aws-test
       failureDomain: eu-central-1a
       bootstrap:
@@ -135,8 +136,7 @@ metadata:
   name: k0s-aws-test-machine-config
 spec:
   template:
-    spec:
-      version: v1.27.2+k0s.0
+    spec: {}
       # More details of the worker configuration can be set here
 ---
 ```

--- a/docs/capi-bootstrap.md
+++ b/docs/capi-bootstrap.md
@@ -16,6 +16,7 @@ metadata:
   namespace: default
 spec:
   clusterName: cp-test
+  version: v1.27.2+k0s.0
   bootstrap:
     configRef: # This triggers our controller to create cloud-init secret
       apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
@@ -31,8 +32,7 @@ kind: K0sWorkerConfig
 metadata:
   name: machine-test-config
   namespace: default
-spec:
-  version: v1.27.2+k0s.0
+spec: {}
   # Details of the worker configuration can be set here
 ```
 
@@ -60,7 +60,6 @@ kind: K0sWorkerConfig
 metadata:
   name: worker-config
 spec:
-  version: v1.27.2+k0s.0
   preK0sCommands:
     - "apt-get update && apt-get install -y curl jq"
     - "mkdir -p /etc/k0s/monitoring"
@@ -77,7 +76,6 @@ kind: K0sWorkerConfig
 metadata:
   name: worker-config
 spec:
-  version: v1.27.2+k0s.0
   postK0sCommands:
     - "systemctl enable monitoring-agent"
     - "systemctl start monitoring-agent"
@@ -103,7 +101,6 @@ kind: K0sWorkerConfig
 metadata:
   name: worker-with-monitoring
 spec:
-  version: v1.27.2+k0s.0
   preK0sCommands:
     - "curl -fsSL https://get.docker.com | sh"
     - "systemctl enable docker"
@@ -121,7 +118,6 @@ kind: K0sWorkerConfig
 metadata:
   name: worker-with-config
 spec:
-  version: v1.27.2+k0s.0
   preK0sCommands:
     - "echo 'vm.max_map_count=262144' >> /etc/sysctl.conf"
     - "sysctl -p"
@@ -140,7 +136,6 @@ kind: K0sWorkerConfig
 metadata:
   name: worker-with-health-checks
 spec:
-  version: v1.27.2+k0s.0
   postK0sCommands:
     - "kubectl get nodes --kubeconfig=/var/lib/k0s/pki/admin.conf"
     - "kubectl describe node $(hostname) --kubeconfig=/var/lib/k0s/pki/admin.conf"
@@ -191,6 +186,7 @@ spec:
         cluster.x-k8s.io/cluster-name: cp-test
         pool: worker-pool-1
     spec:
+      version: v1.27.2+k0s.0
       clusterName: cp-test
       bootstrap:
         configRef:
@@ -209,8 +205,7 @@ metadata:
   namespace: default
 spec:
   template:
-    spec:
-      version: v1.27.2+k0s.0
+    spec: {}
       # More details of the worker configuration can be set here
 ```
 

--- a/docs/capi-clusterclass.md
+++ b/docs/capi-clusterclass.md
@@ -157,8 +157,7 @@ metadata:
   namespace: default
 spec:
   template:
-    spec:
-      version: v1.27.2+k0s.0
+    spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DevMachineTemplate

--- a/docs/capi-docker.md
+++ b/docs/capi-docker.md
@@ -89,7 +89,7 @@ spec:
         pool: worker-pool-1
     spec:
       clusterName: docker-test
-      version: v1.27.2 # Docker Provider requires a version to be set (see https://hub.docker.com/r/kindest/node/tags)
+      version: v1.27.2+k0s.0
       bootstrap:
         configRef:
           apiGroup: bootstrap.cluster.x-k8s.io
@@ -118,8 +118,7 @@ metadata:
   name: docker-test-machine-config
 spec:
   template:
-    spec:
-      version: v1.27.2+k0s.0
+    spec: {}
       # More details of the worker configuration can be set here
 ```
 

--- a/docs/capi-hetzner.md
+++ b/docs/capi-hetzner.md
@@ -101,6 +101,7 @@ spec:
     spec:
       clusterName: hetzner-test
       failureDomain: fsn1
+      version: v1.27.2+k0s.0
       bootstrap:
         configRef: # This triggers our controller to create cloud-init secret
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
@@ -128,8 +129,7 @@ metadata:
   name: hetzner-test-machine-config
 spec:
   template:
-    spec:
-      version: v1.27.2+k0s.0
+    spec: {}
       # More details of the worker configuration can be set here
 ---
 apiVersion: v1

--- a/docs/capi-kubevirt.md
+++ b/docs/capi-kubevirt.md
@@ -97,6 +97,7 @@ spec:
         cluster.x-k8s.io/cluster-name: kubevirt-test
     spec:
       clusterName: kubevirt-test
+      version: v1.27.4+k0s.0
       bootstrap:
         configRef:
           apiGroup: bootstrap.cluster.x-k8s.io
@@ -145,8 +146,7 @@ metadata:
   name: kubevirt-test-machine-config
 spec:
   template:
-    spec:
-      version: v1.27.4+k0s.0
+    spec: {}
       # More details of the worker configuration can be set here
 ```
 

--- a/docs/capi-openstack.md
+++ b/docs/capi-openstack.md
@@ -195,7 +195,7 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: OpenStackMachineTemplate
         name: openstack-hcp-cluster-mt
-      version: v1.32.6
+      version: v1.32.6+k0s.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OpenStackMachineTemplate
@@ -333,7 +333,6 @@ spec:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
       - --debug=true
-      version: v1.32.6+k0s.0
 ```
 
 ## Deployment and Monitoring

--- a/docs/capi-remote.md
+++ b/docs/capi-remote.md
@@ -69,6 +69,7 @@ metadata:
   namespace: default
 spec:
   clusterName: remote-test
+  version: v1.27.2+k0s.0
   bootstrap:
     configRef:
       apiGroup: bootstrap.cluster.x-k8s.io
@@ -84,8 +85,7 @@ kind: K0sWorkerConfig
 metadata:
   name: remote-test-0
   namespace: default
-spec:
-  version: v1.27.2+k0s.0
+spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: RemoteMachine
@@ -291,7 +291,6 @@ metadata:
   name: machine-test-config
   namespace: default
 spec:
-  version: v1.32.2+k0s.0
   files:
     - path: /custom-cleanup-script.sh
       content: |

--- a/docs/capi-remotemachine-windows.md
+++ b/docs/capi-remotemachine-windows.md
@@ -207,7 +207,6 @@ metadata:
   name: win-remote-worker-0
   namespace: default
 spec:
-  version: v1.34.2+k0s.0
   k0sInstallDir: 'C:\k0s'    # must be a Windows path
   provisioner:
     platform: windows

--- a/docs/ignition-support.md
+++ b/docs/ignition-support.md
@@ -167,6 +167,7 @@ spec:
   template:
     spec:
       clusterName: ignition-test-cluster
+      version: v1.30.2+k0s.0
       bootstrap:
         configRef: # This triggers our controller to create cloud-init secret
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
@@ -186,7 +187,6 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.30.2+k0s.0
       # Flatcar, as inmutable OS, needs k0s in /opt/bin. It cannot write k0s binary in the default /usr/local/bin.
       k0sInstallDir: /opt/bin 
       ignition:

--- a/docs/resource-reference/bootstrap.cluster.x-k8s.io-v1beta2.md
+++ b/docs/resource-reference/bootstrap.cluster.x-k8s.io-v1beta2.md
@@ -194,7 +194,8 @@ By default, k0smotron will use Machine name as a node name. If true, it will pic
           Version is the version of k0s to use. In case this is not set, k0smotron will use
 a version field of the Machine object. If it's empty, the latest version is used.
 Make sure the version is compatible with the k0s version running on the control plane.
-For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
+For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
+Deprecated: Use Machine version instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -971,7 +972,8 @@ By default, k0smotron will use Machine name as a node name. If true, it will pic
           Version is the version of k0s to use. In case this is not set, k0smotron will use
 a version field of the Machine object. If it's empty, the latest version is used.
 Make sure the version is compatible with the k0s version running on the control plane.
-For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
+For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
+Deprecated: Use Machine version instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1787,7 +1789,8 @@ By default, k0smotron will use Machine name as a node name. If true, it will pic
           Version is the version of k0s to use. In case this is not set, k0smotron will use
 a version field of the Machine object. If it's empty, the latest version is used.
 Make sure the version is compatible with the k0s version running on the control plane.
-For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/<br/>
+For reference see the Kubernetes version skew policy: https://kubernetes.io/docs/setup/release/version-skew-policy/
+Deprecated: Use Machine version instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/update/update-cluster-pod.md
+++ b/docs/update/update-cluster-pod.md
@@ -78,8 +78,8 @@ with the new names to create machines for the target k0smotron version. For exam
      name:  docker-test-1 # new machine
      namespace: default
    spec:
-     version: v1.28.7 # new version
      clusterName: docker-test
+     version: v1.28.7+k0s.0 # new version
      bootstrap:
        configRef:
          apiGroup: bootstrap.cluster.x-k8s.io
@@ -95,8 +95,7 @@ with the new names to create machines for the target k0smotron version. For exam
    metadata:
      name: docker-test-1 # new machine
      namespace: default
-   spec:
-     version: v1.28.7+k0s.0 # new version
+   spec: {}
    ```
 
 5. Update the resources:

--- a/docs/windows-workers.md
+++ b/docs/windows-workers.md
@@ -56,7 +56,6 @@ kind: K0sWorkerConfig
 metadata:
   name: windows-worker
 spec:
-  version: v1.34.2+k0s.0
   provisioner:
     platform: windows # Specify Windows platform (default is linux)
     type: powershell # Specify provisioning format 
@@ -218,6 +217,7 @@ spec:
         pool: worker-pool-1
     spec:
       clusterName: aws-test-cluster
+      version: v1.34.2+k0s.0
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -235,7 +235,6 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.34.2+k0s.0
       provisioner:
         platform: windows
         type: powershell-xml

--- a/e2e/data/infrastructure-aws/cluster-template-ignition-fedora/k0sworkerconfigtemplate-patch.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition-fedora/k0sworkerconfigtemplate-patch.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.30.2+k0s.0
       ignition:
         variant: fcos
         version: 1.4.0

--- a/e2e/data/infrastructure-aws/cluster-template-ignition-flatcar/k0sworkerconfigtemplate-patch.yaml
+++ b/e2e/data/infrastructure-aws/cluster-template-ignition-flatcar/k0sworkerconfigtemplate-patch.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   template:
     spec:
-      version: v1.30.2+k0s.0
       k0sInstallDir: /opt/bin # Flatcar, as inmutable OS, needs k0s in /opt/bin. It cannot write k0s binary in the default /usr/local/bin.
       ignition:
         variant: flatcar

--- a/e2e/data/infrastructure-docker/main/bases/machine.yaml
+++ b/e2e/data/infrastructure-docker/main/bases/machine.yaml
@@ -4,7 +4,7 @@ metadata:
   name:  ${CLUSTER_NAME}-docker-test-worker-0
   namespace: ${NAMESPACE}
 spec:
-  version: v1.30.1
+  version: v1.30.1+k0s.0
   clusterName: ${CLUSTER_NAME}
   bootstrap:
     configRef:
@@ -22,8 +22,6 @@ metadata:
   name: docker-test-worker-0
   namespace: ${NAMESPACE}
 spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.30.1+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/e2e/data/infrastructure-docker/main/bases/machinedeployment.yaml
+++ b/e2e/data/infrastructure-docker/main/bases/machinedeployment.yaml
@@ -60,7 +60,7 @@ spec:
         cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
         pool: worker-pool-1
     spec:
-      version: ${KUBERNETES_VERSION}
+      version: ${KUBERNETES_VERSION}+k0s.0
       clusterName: ${CLUSTER_NAME}
       bootstrap:
         configRef:
@@ -79,8 +79,7 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   template:
-    spec:
-      version: ${KUBERNETES_VERSION}+k0s.0
+    spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DevMachineTemplate

--- a/e2e/data/infrastructure-docker/main/cluster-template-ingress/cluster-with-ingress.yaml
+++ b/e2e/data/infrastructure-docker/main/cluster-template-ingress/cluster-with-ingress.yaml
@@ -73,7 +73,7 @@ spec:
         cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
         pool: worker-pool-1
     spec:
-      version: v1.36.2
+      version: v1.36.2+k0s.0
       clusterName: ${CLUSTER_NAME}
       bootstrap:
         configRef:
@@ -92,8 +92,7 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   template:
-    spec:
-      version: v1.36.2+k0s.0
+    spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DevMachineTemplate

--- a/e2e/data/infrastructure-docker/main/cluster-template-remote-hcp/machine-with-hostname-override.yaml
+++ b/e2e/data/infrastructure-docker/main/cluster-template-remote-hcp/machine-with-hostname-override.yaml
@@ -4,7 +4,7 @@ metadata:
   name:  ${CLUSTER_NAME}-docker-test-worker-0
   namespace: ${NAMESPACE}
 spec:
-  version: v1.30.1
+  version: v1.30.1+k0s.0
   clusterName: ${CLUSTER_NAME}
   bootstrap:
     configRef:
@@ -22,8 +22,6 @@ metadata:
   name: docker-test-worker-0
   namespace: ${NAMESPACE}
 spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.30.1+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
     # docker infra provider gets node by name format: <cluster-name>-<container-name>

--- a/internal/controller/bootstrap/worker_bootstrap_controller.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller.go
@@ -73,9 +73,14 @@ type Controller struct {
 	workloadClusterClient client.Client
 }
 
+type k0sWorkerConfig struct {
+	*bootstrapv2.K0sWorkerConfig
+	version string
+}
+
 // Scope contains the information required to generate the bootstrap data for a worker machine.
 type Scope struct {
-	Config              *bootstrapv2.K0sWorkerConfig
+	Config              *k0sWorkerConfig
 	ConfigOwner         *bsutil.ConfigOwner
 	Cluster             *clusterv1.Cluster
 	ingressSpec         *km.IngressSpec
@@ -136,6 +141,7 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		config.Spec.Version = configOwner.KubernetesVersion()
 	}
 
+	var k0sWorkerVersion string
 	// If the version does not contain the k0s suffix, append it.
 	if config.Spec.Version != "" {
 		// When machine is created by CAPI, for example by using a clusterclass template, the version
@@ -145,6 +151,7 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 			config.Spec.Version = fmt.Sprintf("%s+%s", config.Spec.Version, defaultK0sSuffix)
 		}
 	}
+	k0sWorkerVersion = config.Spec.Version
 
 	// Lookup the cluster the config owner is associated with
 	cluster, err := capiutil.GetClusterByName(ctx, r.Client, configOwner.GetNamespace(), configOwner.ClusterName())
@@ -206,7 +213,10 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	}()
 
 	scope := &Scope{
-		Config:      config,
+		Config: &k0sWorkerConfig{
+			K0sWorkerConfig: config,
+			version:         k0sWorkerVersion,
+		},
 		ConfigOwner: configOwner,
 		Cluster:     cluster,
 		provisioner: getProvisioner(&config.Spec.Provisioner),
@@ -413,7 +423,7 @@ Invoke-WebRequest -Uri $k0sUrl -OutFile $dest -UseBasicParsing
 
 Write-Host "=== Executing k0s to check version ==="
 & $dest --version
-`, scope.Config.Spec.Version, scope.Config.Spec.Version, k0sPath, scope.Config.Spec.K0sInstallDir)
+`, scope.Config.version, scope.Config.version, k0sPath, scope.Config.Spec.K0sInstallDir)
 
 	inlineCommands := scope.Config.Spec.PreK0sCommands
 	// Download and enable containers and k0s bootstrap script
@@ -452,7 +462,7 @@ Stop-Transcript
 func getLinuxCommands(scope *Scope) ([]string, map[provisioner.VarName]string, error) {
 	commandsMap := make(map[provisioner.VarName]string)
 
-	downloadCommands, err := util.DownloadCommands(scope.Config.Spec.PreInstalledK0s, scope.Config.Spec.DownloadURL, scope.Config.Spec.Version, scope.Config.Spec.K0sInstallDir)
+	downloadCommands, err := util.DownloadCommands(scope.Config.Spec.PreInstalledK0s, scope.Config.Spec.DownloadURL, scope.Config.version, scope.Config.Spec.K0sInstallDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error generating download commands: %w", err)
 	}

--- a/internal/controller/bootstrap/worker_bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller_test.go
@@ -21,12 +21,10 @@ package bootstrap
 import (
 	"testing"
 
+	bootstrapv2 "github.com/k0sproject/k0smotron/v2/api/bootstrap/v1beta2"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	bsutil "sigs.k8s.io/cluster-api/bootstrap/util"
-
-	bootstrapv1 "github.com/k0sproject/k0smotron/v2/api/bootstrap/v1beta2"
-	bootstrapv2 "github.com/k0sproject/k0smotron/v2/api/bootstrap/v1beta2"
 )
 
 func Test_createInstallCmd(t *testing.T) {
@@ -39,7 +37,9 @@ func Test_createInstallCmd(t *testing.T) {
 		{
 			name: "with default config",
 			scope: &Scope{
-				Config: &bootstrapv1.K0sWorkerConfig{},
+				Config: &k0sWorkerConfig{
+					K0sWorkerConfig: &bootstrapv2.K0sWorkerConfig{},
+				},
 				ConfigOwner: &bsutil.ConfigOwner{Unstructured: &unstructured.Unstructured{Object: map[string]any{
 					"metadata": map[string]any{"name": "test"},
 				}}},
@@ -49,9 +49,11 @@ func Test_createInstallCmd(t *testing.T) {
 		{
 			name: "with args",
 			scope: &Scope{
-				Config: &bootstrapv2.K0sWorkerConfig{
-					Spec: bootstrapv2.K0sWorkerConfigSpec{
-						Args: []string{"--debug", "--labels=k0sproject.io/foo=bar", `--kubelet-extra-args="--hostname-override=test-from-arg"`},
+				Config: &k0sWorkerConfig{
+					K0sWorkerConfig: &bootstrapv2.K0sWorkerConfig{
+						Spec: bootstrapv2.K0sWorkerConfigSpec{
+							Args: []string{"--debug", "--labels=k0sproject.io/foo=bar", `--kubelet-extra-args="--hostname-override=test-from-arg"`},
+						},
 					},
 				},
 				ConfigOwner: &bsutil.ConfigOwner{Unstructured: &unstructured.Unstructured{Object: map[string]any{
@@ -63,10 +65,12 @@ func Test_createInstallCmd(t *testing.T) {
 		{
 			name: "with useSystemHostname set",
 			scope: &Scope{
-				Config: &bootstrapv2.K0sWorkerConfig{
-					Spec: bootstrapv2.K0sWorkerConfigSpec{
-						UseSystemHostname: true,
-						Args:              []string{"--debug", "--labels=k0sproject.io/foo=bar", `--kubelet-extra-args="--hostname-override=test-from-arg"`},
+				Config: &k0sWorkerConfig{
+					K0sWorkerConfig: &bootstrapv2.K0sWorkerConfig{
+						Spec: bootstrapv2.K0sWorkerConfigSpec{
+							UseSystemHostname: true,
+							Args:              []string{"--debug", "--labels=k0sproject.io/foo=bar", `--kubelet-extra-args="--hostname-override=test-from-arg"`},
+						},
 					},
 				},
 				ConfigOwner: &bsutil.ConfigOwner{Unstructured: &unstructured.Unstructured{Object: map[string]any{
@@ -78,10 +82,12 @@ func Test_createInstallCmd(t *testing.T) {
 		{
 			name: "with extra args and useSystemHostname not set",
 			scope: &Scope{
-				Config: &bootstrapv2.K0sWorkerConfig{
-					Spec: bootstrapv2.K0sWorkerConfigSpec{
-						UseSystemHostname: false,
-						Args:              []string{"--debug", "--labels=k0sproject.io/foo=bar", `--kubelet-extra-args="--my-arg=value"`},
+				Config: &k0sWorkerConfig{
+					K0sWorkerConfig: &bootstrapv2.K0sWorkerConfig{
+						Spec: bootstrapv2.K0sWorkerConfigSpec{
+							UseSystemHostname: false,
+							Args:              []string{"--debug", "--labels=k0sproject.io/foo=bar", `--kubelet-extra-args="--my-arg=value"`},
+						},
 					},
 				},
 				ConfigOwner: &bsutil.ConfigOwner{Unstructured: &unstructured.Unstructured{Object: map[string]any{
@@ -93,10 +99,12 @@ func Test_createInstallCmd(t *testing.T) {
 		{
 			name: "with extra args and useSystemHostname set",
 			scope: &Scope{
-				Config: &bootstrapv2.K0sWorkerConfig{
-					Spec: bootstrapv2.K0sWorkerConfigSpec{
-						UseSystemHostname: true,
-						Args:              []string{"--debug", "--labels=k0sproject.io/foo=bar", `--kubelet-extra-args="--my-arg=value"`},
+				Config: &k0sWorkerConfig{
+					K0sWorkerConfig: &bootstrapv2.K0sWorkerConfig{
+						Spec: bootstrapv2.K0sWorkerConfigSpec{
+							UseSystemHostname: true,
+							Args:              []string{"--debug", "--labels=k0sproject.io/foo=bar", `--kubelet-extra-args="--my-arg=value"`},
+						},
 					},
 				},
 				ConfigOwner: &bsutil.ConfigOwner{Unstructured: &unstructured.Unstructured{Object: map[string]any{
@@ -122,10 +130,12 @@ func Test_getWindowsCommands(t *testing.T) {
 		{
 			name: "with default config",
 			scope: &Scope{
-				Config: &bootstrapv2.K0sWorkerConfig{
-					Spec: bootstrapv2.K0sWorkerConfigSpec{
-						Provisioner: bootstrapv2.ProvisionerSpec{
-							Platform: bootstrapv2.PlatformWindows,
+				Config: &k0sWorkerConfig{
+					K0sWorkerConfig: &bootstrapv2.K0sWorkerConfig{
+						Spec: bootstrapv2.K0sWorkerConfigSpec{
+							Provisioner: bootstrapv2.ProvisionerSpec{
+								Platform: bootstrapv2.PlatformWindows,
+							},
 						},
 					},
 				},

--- a/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
+++ b/inttest/capi-controlplane-docker-downscaling/capi_controlplane_docker_downscaling_test.go
@@ -294,7 +294,7 @@ metadata:
   name:  docker-test-cluster-docker-test-worker-0
   namespace: default
 spec:
-  version: v1.32.2
+  version: v1.32.2+k0s.0
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -312,8 +312,6 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.32.2+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/inttest/capi-controlplane-docker-rm/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker-rm/capi_controlplane_docker_test.go
@@ -281,7 +281,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.27.1
+  version: v1.27.1+k0s.0
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -299,8 +299,6 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
+++ b/inttest/capi-controlplane-docker-tunneling-proxy/capi_controlplane_docker_tunneling_proxy_test.go
@@ -292,7 +292,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.27.1
+  version: v1.27.1+k0s.0
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -310,8 +310,6 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
+++ b/inttest/capi-controlplane-docker-tunneling/capi_controlplane_docker_tunneling_test.go
@@ -278,7 +278,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.27.1
+  version: v1.27.1+k0s.0
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -296,8 +296,6 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
+++ b/inttest/capi-controlplane-docker/capi_controlplane_docker_test.go
@@ -384,7 +384,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.33.2
+  version: v1.33.2+k0s.0
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -402,8 +402,6 @@ metadata:
   name: docker-test-worker-0
   namespace: default
 spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.33.2+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
+++ b/inttest/capi-docker-clusterclass-k0smotron/capi_docker_clusterclass_k0smotron_test.go
@@ -201,8 +201,7 @@ metadata:
   namespace: default
 spec:
   template:
-    spec:
-      version: v1.27.2
+    spec: {}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass

--- a/inttest/capi-docker-clusterclass-recreate-upgrade/capi_docker_clusterclass_test.go
+++ b/inttest/capi-docker-clusterclass-recreate-upgrade/capi_docker_clusterclass_test.go
@@ -447,8 +447,7 @@ metadata:
   namespace: default
 spec:
   template:
-    spec:
-      version: v1.30.0+k0s.0
+    spec: {}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass

--- a/inttest/capi-docker-clusterclass/capi_docker_clusterclass_test.go
+++ b/inttest/capi-docker-clusterclass/capi_docker_clusterclass_test.go
@@ -342,8 +342,7 @@ metadata:
   namespace: default
 spec:
   template:
-    spec:
-      version: v1.27.2+k0s.0
+    spec: {}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass

--- a/inttest/capi-docker-machine-change-args/capi_docker_machine_change_args_test.go
+++ b/inttest/capi-docker-machine-change-args/capi_docker_machine_change_args_test.go
@@ -297,7 +297,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.31.2
+  version: v1.31.2+k0s.0
   clusterName: docker-test
   bootstrap:
     configRef:
@@ -314,9 +314,7 @@ kind: K0sWorkerConfig
 metadata:
   name: docker-test-worker-0
   namespace: default
-spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.31.2+k0s.0
+spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DevMachine

--- a/inttest/capi-docker-machine-change-template/capi_docker_machine_change_template_test.go
+++ b/inttest/capi-docker-machine-change-template/capi_docker_machine_change_template_test.go
@@ -334,7 +334,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.31.2
+  version: v1.31.2+k0s.0
   clusterName: docker-test
   bootstrap:
     configRef:
@@ -351,9 +351,7 @@ kind: K0sWorkerConfig
 metadata:
   name: docker-test-worker-0
   namespace: default
-spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.31.2+k0s.0
+spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DevMachine

--- a/inttest/capi-docker-machine-template-update-recreate-kine/capi_docker_machine_template_update_recreate_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate-kine/capi_docker_machine_template_update_recreate_test.go
@@ -325,7 +325,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.27.1
+  version: v1.27.1+k0s.0
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -342,9 +342,7 @@ kind: K0sWorkerConfig
 metadata:
   name: docker-test-worker-0
   namespace: default
-spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.27.1+k0s.0
+spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DevMachine

--- a/inttest/capi-docker-machine-template-update-recreate-single/capi_docker_machine_template_update_recreate_single_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate-single/capi_docker_machine_template_update_recreate_single_test.go
@@ -299,7 +299,7 @@ metadata:
   name:  docker-test-cluster-docker-test-worker-0
   namespace: default
 spec:
-  version: v1.30.0
+  version: v1.30.0+k0s.0
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -316,9 +316,7 @@ kind: K0sWorkerConfig
 metadata:
   name: docker-test-worker-0
   namespace: default
-spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.30.0+k0s.0
+spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DevMachine

--- a/inttest/capi-docker-machine-template-update-recreate/capi_docker_machine_template_update_recreate_test.go
+++ b/inttest/capi-docker-machine-template-update-recreate/capi_docker_machine_template_update_recreate_test.go
@@ -310,7 +310,7 @@ metadata:
   name:  docker-test-worker-0
   namespace: default
 spec:
-  version: v1.31.6
+  version: v1.31.6+k0s.0
   clusterName: docker-test
   bootstrap:
     configRef:
@@ -327,9 +327,7 @@ kind: K0sWorkerConfig
 metadata:
   name: docker-test-worker-0
   namespace: default
-spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.31.6+k0s.0
+spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DevMachine

--- a/inttest/capi-docker-machine-template-update/capi_docker_machine_template_update_test.go
+++ b/inttest/capi-docker-machine-template-update/capi_docker_machine_template_update_test.go
@@ -344,7 +344,7 @@ metadata:
   name:  docker-test-cluster-docker-test-worker-0
   namespace: default
 spec:
-  version: v1.30.1
+  version: v1.30.1+k0s.0
   clusterName: docker-test-cluster
   bootstrap:
     configRef:
@@ -361,9 +361,7 @@ kind: K0sWorkerConfig
 metadata:
   name: docker-test-worker-0
   namespace: default
-spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.30.1+k0s.0
+spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DevMachine

--- a/inttest/capi-docker/capi_docker_test.go
+++ b/inttest/capi-docker/capi_docker_test.go
@@ -301,7 +301,7 @@ metadata:
   name:  docker-test-0
   namespace: default
 spec:
-  version: v1.31.1
+  version: v1.31.1+k0s.0
   clusterName: docker-test
   bootstrap:
     configRef:
@@ -319,8 +319,6 @@ metadata:
   name: docker-test-0
   namespace: default
 spec:
-  # version is deliberately different to be able to verify we actually pick it up :)
-  version: v1.31.1+k0s.0
   args:
     - --labels=k0sproject.io/foo=bar
   preStartCommands:

--- a/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
+++ b/inttest/capi-remote-machine-job-provision/capi_remote_machine_job_provision_test.go
@@ -295,6 +295,7 @@ metadata:
   namespace: default
 spec:
   clusterName: remote-test
+  version: v1.27.2+k0s.0
   bootstrap:
     configRef:
       apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -310,8 +311,7 @@ kind: K0sWorkerConfig
 metadata:
   name: remote-test-0
   namespace: default
-spec:
-  version: v1.27.2+k0s.0
+spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: RemoteMachine

--- a/inttest/capi-remote-machine/capi_remote_machine_test.go
+++ b/inttest/capi-remote-machine/capi_remote_machine_test.go
@@ -313,6 +313,7 @@ metadata:
   namespace: default
 spec:
   clusterName: remote-test
+  version: {{ .K0SVersion }}+k0s.0
   bootstrap:
     configRef:
       apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -328,8 +329,7 @@ kind: K0sWorkerConfig
 metadata:
   name: remote-test-0
   namespace: default
-spec:
-  version: {{ .K0SVersion }}+k0s.0
+spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: RemoteMachine

--- a/templates/cluster-template-hcp.yaml
+++ b/templates/cluster-template-hcp.yaml
@@ -44,6 +44,7 @@ metadata:
   name:  ${CLUSTER_NAME}
 spec:
   clusterName: ${CLUSTER_NAME}
+  version: ${KUBERNETES_VERSION}+k0s.0
   bootstrap:
     configRef:
       apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -58,8 +59,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfig
 metadata:
   name: ${CLUSTER_NAME}
-spec:
-  version: ${KUBERNETES_VERSION}+k0s.0
+spec: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: RemoteMachine


### PR DESCRIPTION
link a k0sworkerconfig with a fixed version does not allow a mahcine deployment version using cluster topology. When a new version in cluster.spec.topology.version is detected, machines controller tries to roll out the machine but the machine deployment is still using  the version from its k0sworkerconfig. The k0s version should be set from the machine resources instead, that way the new machine will still use the old k0sworkerconfig but getting the new version set by the machine owner controller