### PR TITLE
Run publish to ttl registry isolated in its own job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,12 +48,6 @@ jobs:
           # Build Docker image and create image bundle
           make k0smotron-image-bundle.tar
 
-      - name: Publish the previously built imageto ttl.sh with the commit sha
-        run: |
-          docker tag quay.io/k0sproject/k0smotron:latest ttl.sh/k0smotron-${{ github.sha }}:24h
-          docker push ttl.sh/k0smotron-${{ github.sha }}:24h
-        continue-on-error: true
-
       - name: Upload image bundle
         uses: actions/upload-artifact@v4
         with:
@@ -91,6 +85,23 @@ jobs:
         with:
           name: install-standalone-yaml
           path: install-standalone.yaml
+
+  publish-ttl:
+    name: Publish to ttl.sh (best effort)
+    needs: build
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Download image bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: k0smotron-image-bundle
+
+      - name: Load and publish image
+        run: |
+          docker load -i k0smotron-image-bundle.tar
+          docker tag quay.io/k0sproject/k0smotron:latest ttl.sh/k0smotron-${{ github.sha }}:24h
+          docker push ttl.sh/k0smotron-${{ github.sha }}:24h
 
   unittest:
     name: Unit tests


### PR DESCRIPTION
Even with the recent changes avoiding to fail if push to ttl fails, we are still waiting to the step to finish. In cases where the registry is not available we wait several minutes until step ends and next steps start running. Lets run this on a different job instead `build` one