### PR TITLE
Fix duplicate Machine creation when cache lags after scale-up

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -346,6 +346,7 @@ func main() {
 
 			if err = (&controlplane.K0sController{
 				Client:              mgr.GetClient(),
+				APIReader:           mgr.GetAPIReader(),
 				SecretCachingClient: secretCachingClient,
 				ClusterCache:        clusterCache,
 				ClientSet:           clientSet,

--- a/internal/controller/controlplane/k0s_controlplane_controller.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller.go
@@ -104,6 +104,10 @@ type controlplane struct {
 // K0sController is responsible for reconciling K0sControlPlane objects.
 type K0sController struct {
 	client.Client
+	// APIReader is an uncached client reader, used for authoritative reads against the
+	// API server when the cached client may lag behind it (e.g. right after a Machine
+	// has been created). If unset, the cached client is used instead.
+	APIReader           client.Reader
 	SecretCachingClient client.Client
 	ClusterCache        clustercache.ClusterCache
 	ClientSet           *kubernetes.Clientset

--- a/internal/controller/controlplane/scale.go
+++ b/internal/controller/controlplane/scale.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/failuredomains"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -67,6 +68,22 @@ func (c *K0sController) reconcileMachines(ctx context.Context, scope *controlpla
 
 	switch {
 	case isNeededScaleUp(scope):
+		// Authoritative guard before creating a Machine: the informer cache can lag behind the
+		// API server, so a scale-up decision based on the cached scope may undercount Machines
+		// and, because Machines get random names, create duplicates (see issue #1534). Read
+		// directly from the API server and never create a new Machine while it knows Machines
+		// the cache has not observed yet.
+		stale, err := c.isMachineViewStale(ctx, scope)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("error verifying machine view against the API server: %w", err)
+		}
+		if stale {
+			// The cache usually catches up within milliseconds, so requeue quickly instead of
+			// stalling the scale-up. Same duration Cluster API uses for stale-cache requeues.
+			logger.Info("Cached machine view is stale compared to the API server, requeuing before scaling up")
+			return ctrl.Result{RequeueAfter: 100 * time.Millisecond}, nil
+		}
+
 		logger.Info("Scaling up control plane")
 		if err := c.scaleUp(ctx, scope); err != nil {
 			return ctrl.Result{}, fmt.Errorf("error scaling up control plane: %w", err)
@@ -452,4 +469,41 @@ func (c *K0sController) removePreTerminateHookAnnotationFromMachine(ctx context.
 	}
 
 	return nil
+}
+
+// isMachineViewStale checks, via an authoritative read against the API server, whether the
+// cache-backed scope is missing Machines that already exist on the API server. The scale-up path
+// must stay idempotent when the controller-runtime informer cache lags behind the API server (see
+// issue #1534): Machines are created with randomly generated names, so a reconciliation acting on
+// a stale cache that has not observed a Machine created by a previous reconciliation would happily
+// create another one. Because this check does not rely on any process-local state, it also covers
+// leader changes, controller restarts, and writes that time out on the client but are committed by
+// the API server.
+func (c *K0sController) isMachineViewStale(ctx context.Context, scope *controlplane) (bool, error) {
+	authoritativeMachines, err := collections.GetFilteredMachinesForCluster(ctx, c.authoritativeReader(), scope.cluster, collections.ControlPlaneMachines(scope.cluster.Name))
+	if err != nil {
+		return false, fmt.Errorf("failed to list control plane machines from the API server: %w", err)
+	}
+
+	for name := range authoritativeMachines {
+		if _, observed := scope.activeMachines[name]; observed {
+			continue
+		}
+		if _, observed := scope.deletedMachines[name]; observed {
+			continue
+		}
+		// The API server knows a Machine that the cache has not observed yet.
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// authoritativeReader returns a reader that reads directly from the API server, falling back to
+// the cached client if no uncached reader is configured.
+func (c *K0sController) authoritativeReader() client.Reader {
+	if c.APIReader != nil {
+		return c.APIReader
+	}
+	return c.Client
 }

--- a/internal/controller/controlplane/scale_env_test.go
+++ b/internal/controller/controlplane/scale_env_test.go
@@ -19,6 +19,7 @@ package controlplane
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -1117,4 +1118,99 @@ func createControlPlaneMachine(t *testing.T, name, namespace string, cluster *cl
 	}
 	require.NoError(t, testEnv.Create(ctx, config))
 	return machine, config
+}
+
+// staleMachineCacheClient simulates a controller-runtime informer cache that lags behind the
+// API server: List calls for MachineList never return any Machines, mimicking a cache that has
+// not observed Machines created in previous reconciliations (read-after-write inconsistency).
+// All other operations (including writes) go directly to the API server.
+type staleMachineCacheClient struct {
+	client.Client
+}
+
+func (c *staleMachineCacheClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if err := c.Client.List(ctx, list, opts...); err != nil {
+		return err
+	}
+	if machineList, ok := list.(*clusterv1.MachineList); ok {
+		machineList.Items = nil
+	}
+	return nil
+}
+
+// TestReconcileMachinesScaleUpIdempotentWithStaleCache is a regression test for
+// https://github.com/k0sproject/k0smotron/issues/1534: when the cached client does not observe
+// a newly created Machine, subsequent reconciliations must not create duplicate Machines.
+func TestReconcileMachinesScaleUpIdempotentWithStaleCache(t *testing.T) {
+	ns, err := testEnv.CreateNamespace(ctx, "test-scale-up-stale-cache")
+	require.NoError(t, err)
+
+	cluster, kcp, gmt := createClusterWithControlPlane(ns.Name)
+	require.NoError(t, testEnv.Create(ctx, cluster))
+	require.NoError(t, testEnv.Create(ctx, gmt))
+
+	kcp.Spec.Replicas = 1
+	require.NoError(t, testEnv.Create(ctx, kcp))
+
+	defer func(do ...client.Object) {
+		require.NoError(t, testEnv.Cleanup(ctx, do...))
+	}(kcp, gmt, cluster, ns)
+
+	clientSet, err := kubernetes.NewForConfig(testEnv.Config)
+	require.NoError(t, err)
+
+	// The controller reads through a client whose Machine lists are permanently stale,
+	// while the authoritative reader reads directly from the API server.
+	r := &K0sController{
+		Client:    &staleMachineCacheClient{Client: testEnv},
+		APIReader: testEnv.GetAPIReader(),
+		ClientSet: clientSet,
+	}
+
+	// Run several reconciliations. Every one of them sees zero active machines through the
+	// stale client, so without the authoritative pre-create check each of them would create a
+	// new Machine.
+	for i := 0; i < 5; i++ {
+		controlplane, err := r.retrieveControlPlaneState(ctx, cluster, kcp)
+		require.NoError(t, err)
+
+		res, err := r.reconcileMachines(ctx, controlplane)
+		require.NoError(t, err)
+		// The desired state can't be reached while the cache is stale, so a requeue is expected.
+		require.False(t, res.IsZero())
+	}
+
+	machines, err := collections.GetFilteredMachinesForCluster(ctx, testEnv.GetAPIReader(), cluster, collections.ControlPlaneMachines(cluster.Name), collections.ActiveMachines)
+	require.NoError(t, err)
+	require.Len(t, machines, 1, "exactly one Machine must be created despite the stale cache")
+
+	// Simulate a leader change / controller restart: a brand new controller instance holds no
+	// process-local state, but still sees the stale cache. The authoritative pre-create check
+	// reads straight from the API server, so it must prevent duplicate Machines all the same.
+	rebooted := &K0sController{
+		Client:    &staleMachineCacheClient{Client: testEnv},
+		APIReader: testEnv.GetAPIReader(),
+		ClientSet: clientSet,
+	}
+	for i := 0; i < 3; i++ {
+		controlplane, err := rebooted.retrieveControlPlaneState(ctx, cluster, kcp)
+		require.NoError(t, err)
+
+		res, err := rebooted.reconcileMachines(ctx, controlplane)
+		require.NoError(t, err)
+		require.False(t, res.IsZero())
+	}
+
+	machines, err = collections.GetFilteredMachinesForCluster(ctx, testEnv.GetAPIReader(), cluster, collections.ControlPlaneMachines(cluster.Name), collections.ActiveMachines)
+	require.NoError(t, err)
+	require.Len(t, machines, 1, "no duplicate Machine must be created across a simulated leader change")
+
+	// Once a non-stale client observes the Machine, the cached view matches the API server and
+	// the staleness guard no longer blocks scaling.
+	freshController := &K0sController{Client: testEnv, APIReader: testEnv.GetAPIReader(), ClientSet: clientSet}
+	freshScope, err := freshController.retrieveControlPlaneState(ctx, cluster, kcp)
+	require.NoError(t, err)
+	stale, err := freshController.isMachineViewStale(ctx, freshScope)
+	require.NoError(t, err)
+	require.False(t, stale, "cached view must not be considered stale once the Machine is observed")
 }


### PR DESCRIPTION
## What this PR does

Fixes #1534

`K0sControlPlane` scale-up creates Machines with randomly generated names. When the controller-runtime informer cache lags behind the API server, reconciliations following a successful creation still see the stale Machine list (`active=0`), generate a new random name, and create duplicate Machines — six Machines were observed for `spec.replicas: 1`.

This PR adds an **authoritative pre-create check**: right before creating a Machine, an uncached List via the new `APIReader` verifies the API server doesn't know any Machines the cache hasn't observed yet, and requeues if it does. Reading directly from the API server (rather than tracking process-local state) means the guard also covers leader changes, controller restarts, and writes that time out on the client but are committed by the API server. The check only runs when a scale-up is actually being considered, so it is not on the hot path.

## Testing

Added `TestReconcileMachinesScaleUpIdempotentWithStaleCache`, which simulates permanent cache lag with a client whose Machine lists never return new Machines, and asserts exactly one Machine is created across repeated reconciliations — including after a simulated leader change (a fresh controller instance with no process-local state).