### PR TITLE
Add e2e checks for each upgrade strategy

### DIFF
--- a/e2e/util/controlplane.go
+++ b/e2e/util/controlplane.go
@@ -83,11 +83,34 @@ type UpgradeControlPlaneAndWaitForUpgradeInput struct {
 	KubernetesUpgradeVersion         string
 	WaitForKubeProxyUpgradeInterval  Interval
 	WaitForControlPlaneReadyInterval Interval
+
+	// DuringUpgradeCheck is an optional strategy-specific check that runs in the
+	// background while the upgrade is in progress. It returns a cleanup function
+	// that is invoked after the upgrade completes; the returned error is checked then.
+	DuringUpgradeCheck func(ctx context.Context, input UpgradeControlPlaneAndWaitForUpgradeInput) (func() error, error)
+
+	// PostUpgradeCheck is an optional strategy-specific check invoked after the
+	// control plane reports ready but before the helper returns.
+	PostUpgradeCheck func(ctx context.Context, input UpgradeControlPlaneAndWaitForUpgradeInput) error
 }
 
 // UpgradeControlPlaneAndWaitForUpgrade upgrades a K0sControlPlane and waits for it to be upgraded.
-func UpgradeControlPlaneAndWaitForReadyUpgrade(ctx context.Context, input UpgradeControlPlaneAndWaitForUpgradeInput) error {
+func UpgradeControlPlaneAndWaitForReadyUpgrade(ctx context.Context, input UpgradeControlPlaneAndWaitForUpgradeInput) (resErr error) {
 	mgmtClient := input.ClusterProxy.GetClient()
+
+	if input.DuringUpgradeCheck != nil {
+		stop, err := input.DuringUpgradeCheck(ctx, input)
+		if err != nil {
+			return fmt.Errorf("failed to start during upgrade check: %w", err)
+		}
+		if stop != nil {
+			defer func() {
+				if err := stop(); err != nil && resErr == nil {
+					resErr = fmt.Errorf("during upgrade check failed: %w", err)
+				}
+			}()
+		}
+	}
 
 	fmt.Println("Patching the new kubernetes version to KCP")
 	patchHelper, err := patch.NewHelper(input.ControlPlane, mgmtClient)
@@ -112,10 +135,20 @@ func UpgradeControlPlaneAndWaitForReadyUpgrade(ctx context.Context, input Upgrad
 	fmt.Println("Waiting for kube-proxy to have the upgraded kubernetes version")
 	workloadCluster := input.ClusterProxy.GetWorkloadCluster(ctx, input.Cluster.Namespace, input.Cluster.Name)
 	workloadClient := workloadCluster.GetClient()
-	return WaitForKubeProxyUpgrade(ctx, WaitForKubeProxyUpgradeInput{
+	if err := WaitForKubeProxyUpgrade(ctx, WaitForKubeProxyUpgradeInput{
 		Getter:            workloadClient,
 		KubernetesVersion: input.KubernetesUpgradeVersion,
-	}, input.WaitForKubeProxyUpgradeInterval)
+	}, input.WaitForKubeProxyUpgradeInterval); err != nil {
+		return err
+	}
+
+	if input.PostUpgradeCheck != nil {
+		if err := input.PostUpgradeCheck(ctx, input); err != nil {
+			return fmt.Errorf("post upgrade check failed: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func DiscoveryAndWaitForControlPlaneInitialized(ctx context.Context, input capiframework.DiscoveryAndWaitForControlPlaneInitializedInput, interval Interval) (*cpv1beta1.K0sControlPlane, error) {

--- a/e2e/workload_cluster_upgrade_test.go
+++ b/e2e/workload_cluster_upgrade_test.go
@@ -323,7 +323,10 @@ func startStandaloneInPlaceCheck(ctx context.Context, input util.UpgradeControlP
 				return false, err
 			}
 			if targetVersion != input.KubernetesUpgradeVersion {
-				return false, fmt.Errorf("standalone in-place upgrade created an autopilot plan for version %s, expected %s", targetVersion, input.KubernetesUpgradeVersion)
+				// A completed plan from the previous upgrade can legitimately
+				// still exist until the next upgrade deletes and recreates it.
+				// Keep polling until the new plan for the target version appears.
+				return false, nil
 			}
 			planSeen = true
 			return true, nil

--- a/e2e/workload_cluster_upgrade_test.go
+++ b/e2e/workload_cluster_upgrade_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -26,11 +28,15 @@ import (
 	"time"
 
 	"github.com/k0sproject/k0smotron/v2/e2e/util"
+	"github.com/k0sproject/k0smotron/v2/internal/autopilot"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	runtimev1 "sigs.k8s.io/cluster-api/api/runtime/v1beta2"
 	capiframework "sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	capiutil "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestWorkloadClusterUpgrade(t *testing.T) {
@@ -126,6 +132,15 @@ func workloadClusterUpgradeSpec(t *testing.T) {
 
 	}
 
+	preMachines := &clusterv1.MachineList{}
+	err = bootstrapClusterProxy.GetClient().List(ctx, preMachines,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels{clusterv1.ClusterNameLabel: cluster.Name},
+	)
+	require.NoError(t, err)
+
+	upgradeChecks := newControlPlaneUpgradeChecks(preMachines)
+
 	fmt.Println("Upgrading the Kubernetes control-plane version")
 	err = util.UpgradeControlPlaneAndWaitForReadyUpgrade(ctx, util.UpgradeControlPlaneAndWaitForUpgradeInput{
 		ClusterProxy:                     bootstrapClusterProxy,
@@ -134,6 +149,8 @@ func workloadClusterUpgradeSpec(t *testing.T) {
 		KubernetesUpgradeVersion:         e2eConfig.MustGetVariable(KubernetesVersionFirstUpgradeTo),
 		WaitForKubeProxyUpgradeInterval:  util.GetInterval(e2eConfig, testName, "wait-kube-proxy-upgrade"),
 		WaitForControlPlaneReadyInterval: util.GetInterval(e2eConfig, testName, "wait-control-plane"),
+		DuringUpgradeCheck:               upgradeChecks.DuringUpgradeCheck,
+		PostUpgradeCheck:                 upgradeChecks.PostUpgradeCheck,
 	})
 	require.NoError(t, err)
 
@@ -150,6 +167,15 @@ func workloadClusterUpgradeSpec(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	preMachines = &clusterv1.MachineList{}
+	err = bootstrapClusterProxy.GetClient().List(ctx, preMachines,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels{clusterv1.ClusterNameLabel: cluster.Name},
+	)
+	require.NoError(t, err)
+
+	upgradeChecks = newControlPlaneUpgradeChecks(preMachines)
+
 	fmt.Println("Upgrading the Kubernetes control-plane version again")
 	err = util.UpgradeControlPlaneAndWaitForReadyUpgrade(ctx, util.UpgradeControlPlaneAndWaitForUpgradeInput{
 		ClusterProxy:                     bootstrapClusterProxy,
@@ -158,6 +184,8 @@ func workloadClusterUpgradeSpec(t *testing.T) {
 		KubernetesUpgradeVersion:         e2eConfig.MustGetVariable(KubernetesVersionSecondUpgradeTo),
 		WaitForKubeProxyUpgradeInterval:  util.GetInterval(e2eConfig, testName, "wait-kube-proxy-upgrade"),
 		WaitForControlPlaneReadyInterval: util.GetInterval(e2eConfig, testName, "wait-control-plane"),
+		DuringUpgradeCheck:               upgradeChecks.DuringUpgradeCheck,
+		PostUpgradeCheck:                 upgradeChecks.PostUpgradeCheck,
 	})
 	require.NoError(t, err)
 
@@ -172,5 +200,257 @@ func workloadClusterUpgradeSpec(t *testing.T) {
 			WaitForMachineDeploymentUpgradeInterval: util.GetInterval(e2eConfig, testName, "wait-md-upgrade"),
 		})
 		require.NoError(t, err)
+	}
+}
+
+// upgradeChecks bundles the strategy-specific checks that are injected into the
+// control plane upgrade helper.
+type upgradeChecks struct {
+	DuringUpgradeCheck func(ctx context.Context, input util.UpgradeControlPlaneAndWaitForUpgradeInput) (func() error, error)
+	PostUpgradeCheck   func(ctx context.Context, input util.UpgradeControlPlaneAndWaitForUpgradeInput) error
+}
+
+// newControlPlaneUpgradeChecks returns the strategy-specific checks for the
+// currently selected flavor. In-place flavors verify which update path was used
+// and that no control plane machine is recreated; recreate flavors verify that
+// the machines are replaced and the desired count is preserved.
+func newControlPlaneUpgradeChecks(preMachines *clusterv1.MachineList) upgradeChecks {
+	return upgradeChecks{
+		DuringUpgradeCheck: func(ctx context.Context, input util.UpgradeControlPlaneAndWaitForUpgradeInput) (func() error, error) {
+			switch {
+			case strings.EqualFold(flavor, "InPlace"):
+				return startStandaloneInPlaceCheck(ctx, input), nil
+			case strings.EqualFold(flavor, "InPlaceCAPI"):
+				return startCAPIInPlaceCheck(ctx, input), nil
+			case strings.EqualFold(flavor, "RecreateDeleteFirst"):
+				return startRecreateDeleteFirstMachineCountCheck(ctx, input), nil
+			default:
+				return nil, nil
+			}
+		},
+		PostUpgradeCheck: func(ctx context.Context, input util.UpgradeControlPlaneAndWaitForUpgradeInput) error {
+			return validateControlPlaneMachineRollout(ctx, input, preMachines)
+		},
+	}
+}
+
+// validateControlPlaneMachineRollout verifies update-strategy specific machine expectations
+// after a control plane upgrade. For in-place upgrades no control plane Machine must be
+// recreated. For recreate based strategies the final control plane machines must be new
+// machines and their count must match the desired number of replicas.
+func validateControlPlaneMachineRollout(ctx context.Context, input util.UpgradeControlPlaneAndWaitForUpgradeInput, preMachines *clusterv1.MachineList) error {
+	postMachines := &clusterv1.MachineList{}
+	if err := input.ClusterProxy.GetClient().List(ctx, postMachines,
+		client.InNamespace(input.Cluster.Namespace),
+		client.MatchingLabels{clusterv1.ClusterNameLabel: input.Cluster.Name},
+	); err != nil {
+		return fmt.Errorf("failed to list control plane machines after upgrade: %w", err)
+	}
+
+	desiredReplicas := int(input.ControlPlane.Spec.Replicas)
+	preControlPlaneMachines := controlPlaneMachineNamesByUID(preMachines)
+	postControlPlaneMachines := controlPlaneMachineNamesByUID(postMachines)
+
+	fmt.Printf("Control plane machines after upgrade: %d (desired %d)\n", len(postControlPlaneMachines), desiredReplicas)
+
+	switch {
+	case strings.HasPrefix(strings.ToLower(flavor), "inplace"):
+		if len(preControlPlaneMachines) != len(postControlPlaneMachines) {
+			return fmt.Errorf("in-place upgrade recreated control plane machines: expected %d machines, got %d", len(preControlPlaneMachines), len(postControlPlaneMachines))
+		}
+		for uid := range postControlPlaneMachines {
+			if _, ok := preControlPlaneMachines[uid]; !ok {
+				return fmt.Errorf("in-place upgrade recreated control plane machine %s", postControlPlaneMachines[uid])
+			}
+		}
+		fmt.Println("In-place upgrade did not recreate any control plane machine")
+	case strings.EqualFold(flavor, "Recreate"), strings.EqualFold(flavor, "RecreateDeleteFirst"):
+		if len(postControlPlaneMachines) != desiredReplicas {
+			return fmt.Errorf("recreate upgrade ended with %d control plane machines, expected %d", len(postControlPlaneMachines), desiredReplicas)
+		}
+		var reusedMachines []string
+		for uid := range postControlPlaneMachines {
+			if name, ok := preControlPlaneMachines[uid]; ok {
+				reusedMachines = append(reusedMachines, name)
+			}
+		}
+		if len(reusedMachines) > 0 {
+			return fmt.Errorf("recreate upgrade reused %d control plane machine(s): %s", len(reusedMachines), strings.Join(reusedMachines, ", "))
+		}
+		fmt.Println("Recreate upgrade replaced all control plane machines and kept the desired count")
+	default:
+		return fmt.Errorf("unsupported update strategy for machine rollout validation: %s", flavor)
+	}
+
+	return nil
+}
+
+// controlPlaneMachineNamesByUID returns the control plane machine names keyed by
+// their UID for the given machine list.
+func controlPlaneMachineNamesByUID(machines *clusterv1.MachineList) map[string]string {
+	byUID := make(map[string]string, len(machines.Items))
+	for i := range machines.Items {
+		m := machines.Items[i]
+		if m.Labels[clusterv1.MachineControlPlaneLabel] == "true" {
+			byUID[string(m.GetUID())] = m.Name
+		}
+	}
+	return byUID
+}
+
+// startStandaloneInPlaceCheck verifies that the standalone in-place update path is
+// used: an autopilot Plan must appear in the workload cluster and no control plane
+// Machine may carry the CAPI in-place update annotations while the upgrade runs.
+func startStandaloneInPlaceCheck(ctx context.Context, input util.UpgradeControlPlaneAndWaitForUpgradeInput) func() error {
+	checkCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	planSeen := false
+
+	workloadClientSet := input.ClusterProxy.GetWorkloadCluster(ctx, input.Cluster.Namespace, input.Cluster.Name).GetClientSet()
+
+	go func() {
+		done <- wait.PollUntilContextCancel(checkCtx, time.Second, true, func(fctx context.Context) (bool, error) {
+			if err := failOnInPlaceUpdateAnnotations(fctx, input); err != nil {
+				return false, err
+			}
+			plan, err := autopilot.GetPlan(fctx, workloadClientSet)
+			if err != nil {
+				// The plan has not been created yet; keep polling.
+				return false, nil
+			}
+			targetVersion, err := autopilot.GetPlanTargetVersion(plan)
+			if err != nil {
+				return false, err
+			}
+			if targetVersion != input.KubernetesUpgradeVersion {
+				return false, fmt.Errorf("standalone in-place upgrade created an autopilot plan for version %s, expected %s", targetVersion, input.KubernetesUpgradeVersion)
+			}
+			planSeen = true
+			return true, nil
+		})
+	}()
+
+	return func() error {
+		cancel()
+		err := <-done
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, context.Canceled) {
+			if planSeen {
+				return nil
+			}
+			return errors.New("standalone in-place upgrade did not create an autopilot plan in the workload cluster")
+		}
+		return err
+	}
+}
+
+// failOnInPlaceUpdateAnnotations returns an error if any control plane Machine
+// carries the CAPI in-place update annotations.
+func failOnInPlaceUpdateAnnotations(ctx context.Context, input util.UpgradeControlPlaneAndWaitForUpgradeInput) error {
+	machines := &clusterv1.MachineList{}
+	if err := input.ClusterProxy.GetClient().List(ctx, machines,
+		client.InNamespace(input.Cluster.Namespace),
+		client.MatchingLabels{clusterv1.ClusterNameLabel: input.Cluster.Name},
+	); err != nil {
+		return err
+	}
+	for i := range machines.Items {
+		m := machines.Items[i]
+		if m.Labels[clusterv1.MachineControlPlaneLabel] != "true" {
+			continue
+		}
+		if hasInPlaceUpdateAnnotations(m.Annotations) {
+			return fmt.Errorf("standalone in-place upgrade unexpectedly used CAPI in-place update annotations on machine %s", m.Name)
+		}
+	}
+	return nil
+}
+
+// startCAPIInPlaceCheck verifies that the runtime extension in-place update path is
+// used: at least one control plane Machine must carry the CAPI in-place update
+// annotations while the upgrade runs.
+func startCAPIInPlaceCheck(ctx context.Context, input util.UpgradeControlPlaneAndWaitForUpgradeInput) func() error {
+	checkCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+
+	go func() {
+		done <- wait.PollUntilContextCancel(checkCtx, time.Second, true, func(fctx context.Context) (bool, error) {
+			machines := &clusterv1.MachineList{}
+			if err := input.ClusterProxy.GetClient().List(fctx, machines,
+				client.InNamespace(input.Cluster.Namespace),
+				client.MatchingLabels{clusterv1.ClusterNameLabel: input.Cluster.Name},
+			); err != nil {
+				return false, err
+			}
+			for i := range machines.Items {
+				m := machines.Items[i]
+				if m.Labels[clusterv1.MachineControlPlaneLabel] == "true" && hasInPlaceUpdateAnnotations(m.Annotations) {
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+	}()
+
+	return func() error {
+		cancel()
+		err := <-done
+		if errors.Is(err, context.Canceled) {
+			return errors.New("InPlaceCAPI upgrade did not trigger the runtime extension: no control plane machine had CAPI in-place update annotations")
+		}
+		return err
+	}
+}
+
+// hasInPlaceUpdateAnnotations reports whether the given Machine annotations
+// indicate an in-place update triggered through the CAPI runtime extension.
+func hasInPlaceUpdateAnnotations(annotations map[string]string) bool {
+	if _, ok := annotations[clusterv1.UpdateInProgressAnnotation]; ok {
+		return true
+	}
+	_, ok := annotations[runtimev1.PendingHooksAnnotation]
+	return ok
+}
+
+// startRecreateDeleteFirstMachineCountCheck starts a background check that makes sure
+// the RecreateDeleteFirst strategy never exceeds the desired number of control plane machines
+// while the upgrade is in progress. The returned stop function waits for the check to finish
+// and returns its error, if any.
+func startRecreateDeleteFirstMachineCountCheck(ctx context.Context, input util.UpgradeControlPlaneAndWaitForUpgradeInput) func() error {
+	checkCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	desiredReplicas := int(input.ControlPlane.Spec.Replicas)
+
+	go func() {
+		done <- wait.PollUntilContextCancel(checkCtx, time.Second, true, func(fctx context.Context) (bool, error) {
+			machineList := &clusterv1.MachineList{}
+			if err := input.ClusterProxy.GetClient().List(fctx, machineList,
+				client.InNamespace(input.Cluster.Namespace),
+				client.MatchingLabels{clusterv1.ClusterNameLabel: input.Cluster.Name},
+			); err != nil {
+				return false, err
+			}
+			count := 0
+			for _, m := range machineList.Items {
+				if m.Labels[clusterv1.MachineControlPlaneLabel] == "true" {
+					count++
+				}
+			}
+			if count > desiredReplicas {
+				return false, fmt.Errorf("RecreateDeleteFirst upgrade exceeded desired control plane machine count: got %d, expected max %d", count, desiredReplicas)
+			}
+			return false, nil
+		})
+	}()
+
+	return func() error {
+		cancel()
+		err := <-done
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

Adds strategy-specific e2e checks for control plane upgrades in the workload cluster upgrade spec:

- `InPlace` (standalone): verifies an autopilot Plan appears in the workload cluster and that no control plane Machine carries the CAPI in-place update annotations during the upgrade.
- `InPlaceCAPI` (runtime extension): verifies at least one control plane Machine carries the CAPI in-place update annotations during the upgrade.
- Both in-place flavors: verifies no control plane Machine is recreated.
- `Recreate` / `RecreateDeleteFirst`: verifies the final control plane Machines are all new (no UID overlap with the pre-upgrade set) and the final count matches the desired replicas.
- `RecreateDeleteFirst`: verifies the control plane Machine count never exceeds the desired replicas while the upgrade is in progress.

The checks are injected into the shared upgrade helper via `DuringUpgradeCheck` / `PostUpgradeCheck` hooks, keeping the spec shared across flavors.

**Which issue(s) this PR fixes:**

Fixes: https://github.com/k0sproject/k0smotron/issues/1541

**Test plan:**

- `gofmt` and `git diff --check` pass.
- `go test -tags e2e -c ./e2e/` compiles the e2e test binary.
- Full e2e runs require kind/Docker and were not executed locally; they run in the project e2e CI.