### PR TITLE
Fix replica status report by using conditions

### DIFF
--- a/api/controlplane/v1beta2/k0s_types.go
+++ b/api/controlplane/v1beta2/k0s_types.go
@@ -182,15 +182,15 @@ type K0sControlPlaneStatus struct {
 	// +optional
 	Selector string `json:"selector"`
 
-	// readyReplicas is the total number of fully running and ready control plane machines.
+	// readyReplicas is the number of ready replicas for this K0sControlPlane. A machine is considered ready when Machine's Ready condition is true.
 	// +optional
 	ReadyReplicas *int32 `json:"readyReplicas,omitempty"`
 
-	// availableReplicas is the number of available replicas for this ControlPlane. A machine is considered available when Machine's Available condition is true.
+	// availableReplicas is the number of available replicas for this K0sControlPlane. A machine is considered available when Machine's Available condition is true.
 	// +optional
 	AvailableReplicas *int32 `json:"availableReplicas,omitempty"`
 
-	// upToDateReplicas is the number of up-to-date replicas targeted by this ControlPlane. A machine is considered available when Machine's UpToDate condition is true.
+	// upToDateReplicas is the number of up-to-date replicas targeted by this K0sControlPlane. A machine is considered up-to-date when Machine's UpToDate condition is true.
 	// +optional
 	UpToDateReplicas *int32 `json:"upToDateReplicas,omitempty"`
 

--- a/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -992,8 +992,8 @@ spec:
             properties:
               availableReplicas:
                 description: availableReplicas is the number of available replicas
-                  for this ControlPlane. A machine is considered available when Machine's
-                  Available condition is true.
+                  for this K0sControlPlane. A machine is considered available when
+                  Machine's Available condition is true.
                 format: int32
                 type: integer
               conditions:
@@ -1069,8 +1069,9 @@ spec:
                     type: boolean
                 type: object
               readyReplicas:
-                description: readyReplicas is the total number of fully running and
-                  ready control plane machines.
+                description: readyReplicas is the number of ready replicas for this
+                  K0sControlPlane. A machine is considered ready when Machine's Ready
+                  condition is true.
                 format: int32
                 type: integer
               replicas:
@@ -1089,7 +1090,7 @@ spec:
                 type: string
               upToDateReplicas:
                 description: upToDateReplicas is the number of up-to-date replicas
-                  targeted by this ControlPlane. A machine is considered available
+                  targeted by this K0sControlPlane. A machine is considered up-to-date
                   when Machine's UpToDate condition is true.
                 format: int32
                 type: integer

--- a/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -992,8 +992,8 @@ spec:
             properties:
               availableReplicas:
                 description: availableReplicas is the number of available replicas
-                  for this ControlPlane. A machine is considered available when Machine's
-                  Available condition is true.
+                  for this K0sControlPlane. A machine is considered available when
+                  Machine's Available condition is true.
                 format: int32
                 type: integer
               conditions:
@@ -1069,8 +1069,9 @@ spec:
                     type: boolean
                 type: object
               readyReplicas:
-                description: readyReplicas is the total number of fully running and
-                  ready control plane machines.
+                description: readyReplicas is the number of ready replicas for this
+                  K0sControlPlane. A machine is considered ready when Machine's Ready
+                  condition is true.
                 format: int32
                 type: integer
               replicas:
@@ -1089,7 +1090,7 @@ spec:
                 type: string
               upToDateReplicas:
                 description: upToDateReplicas is the number of up-to-date replicas
-                  targeted by this ControlPlane. A machine is considered available
+                  targeted by this K0sControlPlane. A machine is considered up-to-date
                   when Machine's UpToDate condition is true.
                 format: int32
                 type: integer

--- a/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta2.md
+++ b/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta2.md
@@ -949,7 +949,7 @@ K0sControlPlaneStatus defines the observed state of K0sControlPlane
         <td><b>availableReplicas</b></td>
         <td>integer</td>
         <td>
-          availableReplicas is the number of available replicas for this ControlPlane. A machine is considered available when Machine's Available condition is true.<br/>
+          availableReplicas is the number of available replicas for this K0sControlPlane. A machine is considered available when Machine's Available condition is true.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -980,7 +980,7 @@ NOTE: Fields in this struct are part of the Cluster API contract and are used to
         <td><b>readyReplicas</b></td>
         <td>integer</td>
         <td>
-          readyReplicas is the total number of fully running and ready control plane machines.<br/>
+          readyReplicas is the number of ready replicas for this K0sControlPlane. A machine is considered ready when Machine's Ready condition is true.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -1010,7 +1010,7 @@ More info about label selectors: http://kubernetes.io/docs/user-guide/labels#lab
         <td><b>upToDateReplicas</b></td>
         <td>integer</td>
         <td>
-          upToDateReplicas is the number of up-to-date replicas targeted by this ControlPlane. A machine is considered available when Machine's UpToDate condition is true.<br/>
+          upToDateReplicas is the number of up-to-date replicas targeted by this K0sControlPlane. A machine is considered up-to-date when Machine's UpToDate condition is true.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>

--- a/internal/controller/controlplane/status.go
+++ b/internal/controller/controlplane/status.go
@@ -27,7 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	clusterv2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -37,10 +37,6 @@ import (
 	"github.com/go-logr/logr"
 	cpv1beta2 "github.com/k0sproject/k0smotron/v2/api/controlplane/v1beta2"
 	"github.com/k0sproject/version"
-)
-
-var (
-	errUnsupportedPlanState = errors.New("unsupported plan state")
 )
 
 func (c *K0sController) updateStatus(ctx context.Context, controlplane *controlplane) (err error) {
@@ -64,36 +60,27 @@ func (c *K0sController) updateStatus(ctx context.Context, controlplane *controlp
 
 func computeReplicas(controlplane *controlplane) error {
 	controlplane.kcp.Status.Replicas = new(int32(len(controlplane.activeMachines)))
-	readyReplicas := 0
-	unavailableReplicas := 0
-	// Count the machines in different states
-	for _, machine := range controlplane.activeMachines {
-		switch machine.Status.Phase {
-		case string(clusterv2.MachinePhaseRunning):
+
+	var allReplicas []*clusterv1.Machine
+	allReplicas = append(allReplicas, controlplane.activeMachines.UnsortedList()...)
+	allReplicas = append(allReplicas, controlplane.deletedMachines.UnsortedList()...)
+
+	var readyReplicas, availableReplicas, upToDateReplicas int32
+	for _, machine := range allReplicas {
+		if conditions.IsTrue(machine, clusterv1.MachineReadyCondition) {
 			readyReplicas++
-		case string(clusterv2.MachinePhaseProvisioned):
-			// If we're running without --enable-worker, the machine will never transition
-			// to running state, so we need to count it as ready when it's provisioned
-			if !controlplane.kcp.WorkerEnabled() {
-				readyReplicas++
-			} else {
-				unavailableReplicas++
-			}
-		case string(clusterv2.MachinePhaseDeleting), string(clusterv2.MachinePhaseDeleted):
-			// Do nothing
-		default:
-			unavailableReplicas++
+		}
+		if conditions.IsTrue(machine, clusterv1.MachineAvailableCondition) {
+			availableReplicas++
+		}
+		if conditions.IsTrue(machine, clusterv1.MachineUpToDateCondition) {
+			upToDateReplicas++
 		}
 	}
 
-	// If some machines are missing, count them as unavailable
-	if int(controlplane.kcp.Spec.Replicas) > controlplane.activeMachines.Len() {
-		unavailableReplicas += int(controlplane.kcp.Spec.Replicas) - controlplane.activeMachines.Len()
-	}
-
 	controlplane.kcp.Status.ReadyReplicas = new(int32(readyReplicas))
-	controlplane.kcp.Status.UpToDateReplicas = new(int32(controlplane.upToDateMachines.Len()))
-	controlplane.kcp.Status.AvailableReplicas = new(int32(controlplane.activeMachines.Len() - unavailableReplicas))
+	controlplane.kcp.Status.UpToDateReplicas = new(int32(upToDateReplicas))
+	controlplane.kcp.Status.AvailableReplicas = new(int32(availableReplicas))
 
 	// Find the lowest version
 	lowestMachineVersion, err := minVersion(controlplane.activeMachines)
@@ -101,7 +88,6 @@ func computeReplicas(controlplane *controlplane) error {
 		log.Log.Error(err, "Failed to get the lowest version")
 		return err
 	}
-
 	controlplane.kcp.Status.Version = lowestMachineVersion
 
 	// If kcp has suffix but machines don't, we need to add it to minVersion
@@ -164,7 +150,7 @@ func setScalingConditions(controlplane *controlplane) {
 }
 
 // versionMatches checks if the machine version matches the kcp version taking the possibly missing suffix into account
-func versionMatches(machine *clusterv2.Machine, ver string) bool {
+func versionMatches(machine *clusterv1.Machine, ver string) bool {
 
 	if machine.Spec.Version == "" {
 		return false

--- a/internal/controller/controlplane/status_test.go
+++ b/internal/controller/controlplane/status_test.go
@@ -21,12 +21,13 @@ package controlplane
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	bootstrapv2 "github.com/k0sproject/k0smotron/v2/api/bootstrap/v1beta2"
 	cpv1beta2 "github.com/k0sproject/k0smotron/v2/api/controlplane/v1beta2"
 	"github.com/stretchr/testify/require"
-	clusterv2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/collections"
 )
 
@@ -48,39 +49,62 @@ func Test_machineStatusCompute(t *testing.T) {
 		require.NoError(t, err)
 		require.Zero(t, ptr.Deref(kcp.Status.Replicas, 0))
 		require.Empty(t, kcp.Status.Version)
+		require.True(t, *kcp.Status.ExternalManagedControlPlane)
 	})
 
-	t.Run("test all machines are ready", func(t *testing.T) {
+	t.Run("test all machines are ready and available", func(t *testing.T) {
 		kcp := &cpv1beta2.K0sControlPlane{
 			Spec: cpv1beta2.K0sControlPlaneSpec{
 				Version:  "v1.31.0",
 				Replicas: 2,
 			},
 		}
-		machines := collections.Machines{
-			"machine1": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
+		activeMachines := collections.Machines{
+			"machine1": &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
 					Version: "v1.31.0",
 				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseRunning),
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   clusterv1.MachineReadyCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   clusterv1.MachineAvailableCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   clusterv1.MachineUpToDateCondition,
+							Status: metav1.ConditionTrue,
+						},
+					},
 				},
 			},
-			"machine2": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
+			"machine2": &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
 					Version: "v1.30.0",
 				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseRunning),
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   clusterv1.MachineReadyCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   clusterv1.MachineAvailableCondition,
+							Status: metav1.ConditionTrue,
+						},
+					},
 				},
 			},
 		}
 
 		scope := &controlplane{
 			kcp:            kcp,
-			activeMachines: machines,
+			activeMachines: activeMachines,
 			upToDateMachines: collections.Machines{
-				"machine1": machines["machine1"],
+				"machine1": activeMachines["machine1"],
 			},
 		}
 		err := computeReplicas(scope)
@@ -90,10 +114,11 @@ func Test_machineStatusCompute(t *testing.T) {
 		require.Equal(t, int32(2), *kcp.Status.AvailableReplicas)
 		require.Equal(t, int32(1), *kcp.Status.UpToDateReplicas)
 		require.Equal(t, int32(2), *kcp.Status.ReadyReplicas)
+		require.True(t, *kcp.Status.ExternalManagedControlPlane)
 		require.Equal(t, "v1.30.0", kcp.Status.Version)
 	})
 
-	t.Run("test all machines are ready but not using suffix", func(t *testing.T) {
+	t.Run("test all ready and available are ready but not using suffix", func(t *testing.T) {
 		kcp := &cpv1beta2.K0sControlPlane{
 			Spec: cpv1beta2.K0sControlPlaneSpec{
 				Version:  "v1.31.0+k0s.0",
@@ -101,20 +126,42 @@ func Test_machineStatusCompute(t *testing.T) {
 			},
 		}
 		machines := collections.Machines{
-			"machine1": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
+			"machine1": &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
 					Version: "v1.31.0",
 				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseRunning),
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   clusterv1.MachineReadyCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   clusterv1.MachineAvailableCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   clusterv1.MachineUpToDateCondition,
+							Status: metav1.ConditionTrue,
+						},
+					},
 				},
 			},
-			"machine2": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
+			"machine2": &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
 					Version: "v1.30.0",
 				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseRunning),
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   clusterv1.MachineReadyCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   clusterv1.MachineAvailableCondition,
+							Status: metav1.ConditionTrue,
+						},
+					},
 				},
 			},
 		}
@@ -133,31 +180,53 @@ func Test_machineStatusCompute(t *testing.T) {
 		require.Equal(t, int32(2), *kcp.Status.AvailableReplicas)
 		require.Equal(t, int32(1), *kcp.Status.UpToDateReplicas)
 		require.Equal(t, int32(2), *kcp.Status.ReadyReplicas)
+		require.True(t, *kcp.Status.ExternalManagedControlPlane)
 		require.Equal(t, "v1.30.0+k0s.0", kcp.Status.Version)
 	})
 
-	t.Run("test non existent machines are unavailable", func(t *testing.T) {
+	t.Run("test non existent machines are unavailable and external managed is true", func(t *testing.T) {
 		kcp := &cpv1beta2.K0sControlPlane{
 			Spec: cpv1beta2.K0sControlPlaneSpec{
 				Version:  "v1.31.0",
 				Replicas: 3,
+				K0sConfigSpec: bootstrapv2.K0sConfigSpec{
+					Args: []string{"--enable-worker"},
+				},
 			},
 		}
 		machines := collections.Machines{
-			"machine1": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
+			"machine1": &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
 					Version: "v1.31.0",
 				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseRunning),
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   clusterv1.MachineReadyCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   clusterv1.MachineUpToDateCondition,
+							Status: metav1.ConditionTrue,
+						},
+					},
 				},
 			},
-			"machine2": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
+			"machine2": &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
 					Version: "v1.30.0",
 				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseRunning),
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   clusterv1.MachineReadyCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   clusterv1.MachineAvailableCondition,
+							Status: metav1.ConditionTrue,
+						},
+					},
 				},
 			},
 		}
@@ -176,162 +245,14 @@ func Test_machineStatusCompute(t *testing.T) {
 		require.Equal(t, int32(1), *kcp.Status.AvailableReplicas)
 		require.Equal(t, int32(1), *kcp.Status.UpToDateReplicas)
 		require.Equal(t, int32(2), *kcp.Status.ReadyReplicas)
+		require.Nil(t, kcp.Status.ExternalManagedControlPlane)
 		require.Equal(t, "v1.30.0", kcp.Status.Version)
-	})
-
-	t.Run("test some machines are not ready", func(t *testing.T) {
-		kcp := &cpv1beta2.K0sControlPlane{
-			Spec: cpv1beta2.K0sControlPlaneSpec{
-				Version:  "v1.31.0",
-				Replicas: 2,
-			},
-		}
-		machines := collections.Machines{
-			"machine1": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
-					Version: "v1.31.0",
-				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseRunning),
-				},
-			},
-			"machine2": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
-					Version: "v1.30.0",
-				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseProvisioning),
-				},
-			},
-			"machine3": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
-					Version: "v1.30.0",
-				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseFailed),
-				},
-			},
-		}
-		scope := &controlplane{
-			kcp:            kcp,
-			activeMachines: machines,
-			upToDateMachines: collections.Machines{
-				"machine1": machines["machine1"],
-			},
-		}
-		err := computeReplicas(scope)
-
-		require.NoError(t, err)
-		require.Equal(t, int32(3), *kcp.Status.Replicas)
-		require.Equal(t, int32(1), *kcp.Status.AvailableReplicas)
-		require.Equal(t, int32(1), *kcp.Status.UpToDateReplicas)
-		require.Equal(t, int32(1), *kcp.Status.ReadyReplicas)
-		require.Equal(t, "v1.30.0", kcp.Status.Version)
-	})
-
-	t.Run("machines provisioned but kcp not using --enable-worker", func(t *testing.T) {
-		kcp := &cpv1beta2.K0sControlPlane{
-			Spec: cpv1beta2.K0sControlPlaneSpec{
-				Version:  "v1.31.0",
-				Replicas: 2,
-			},
-		}
-		machines := collections.Machines{
-			"machine1": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
-					Version: "v1.31.0",
-				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseProvisioned),
-				},
-			},
-			"machine2": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
-					Version: "v1.30.0",
-				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseProvisioning),
-				},
-			},
-			"machine3": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
-					Version: "v1.30.0",
-				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseFailed),
-				},
-			},
-		}
-
-		scope := &controlplane{
-			kcp:            kcp,
-			activeMachines: machines,
-			upToDateMachines: collections.Machines{
-				"machine1": machines["machine1"],
-			},
-		}
-		err := computeReplicas(scope)
-
-		require.NoError(t, err)
-		require.Equal(t, int32(3), *kcp.Status.Replicas)
-		require.Equal(t, int32(1), *kcp.Status.AvailableReplicas)
-		require.Equal(t, int32(1), *kcp.Status.UpToDateReplicas)
-		require.Equal(t, int32(1), *kcp.Status.ReadyReplicas)
-		require.Equal(t, "v1.30.0", kcp.Status.Version)
-
-	})
-
-	t.Run("some machines stuck as provisioned but kcp using --enable-worker", func(t *testing.T) {
-		kcp := &cpv1beta2.K0sControlPlane{
-			Spec: cpv1beta2.K0sControlPlaneSpec{
-				Version:  "v1.31.0",
-				Replicas: 2,
-				K0sConfigSpec: bootstrapv2.K0sConfigSpec{
-					Args: []string{"--enable-worker"},
-				},
-			},
-		}
-		machines := collections.Machines{
-			"machine1": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
-					Version: "v1.31.0",
-				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseProvisioned),
-				},
-			},
-			"machine2": &clusterv2.Machine{
-				Spec: clusterv2.MachineSpec{
-					Version: "v1.30.0",
-				},
-				Status: clusterv2.MachineStatus{
-					Phase: string(clusterv2.MachinePhaseRunning),
-				},
-			},
-		}
-
-		scope := &controlplane{
-			kcp:            kcp,
-			activeMachines: machines,
-			upToDateMachines: collections.Machines{
-				"machine1": machines["machine1"],
-			},
-		}
-		err := computeReplicas(scope)
-
-		require.NoError(t, err)
-		require.Equal(t, int32(2), *kcp.Status.Replicas)
-		require.Equal(t, int32(1), *kcp.Status.AvailableReplicas)
-		require.Equal(t, int32(1), *kcp.Status.UpToDateReplicas)
-		require.Equal(t, int32(1), *kcp.Status.ReadyReplicas)
-		require.Equal(t, "v1.30.0", kcp.Status.Version)
-
 	})
 }
 
 func Test_versionMatches(t *testing.T) {
 	type args struct {
-		machine *clusterv2.Machine
+		machine *clusterv1.Machine
 		ver     string
 	}
 	tests := []struct {
@@ -342,8 +263,8 @@ func Test_versionMatches(t *testing.T) {
 		{
 			name: "version matches, both without suffix",
 			args: args{
-				machine: &clusterv2.Machine{
-					Spec: clusterv2.MachineSpec{
+				machine: &clusterv1.Machine{
+					Spec: clusterv1.MachineSpec{
 						Version: "v1.31.0",
 					},
 				},
@@ -354,8 +275,8 @@ func Test_versionMatches(t *testing.T) {
 		{
 			name: "version does not match",
 			args: args{
-				machine: &clusterv2.Machine{
-					Spec: clusterv2.MachineSpec{
+				machine: &clusterv1.Machine{
+					Spec: clusterv1.MachineSpec{
 						Version: "v1.31.0",
 					},
 				},
@@ -366,8 +287,8 @@ func Test_versionMatches(t *testing.T) {
 		{
 			name: "semver version match, machine version is missing the suffix",
 			args: args{
-				machine: &clusterv2.Machine{
-					Spec: clusterv2.MachineSpec{
+				machine: &clusterv1.Machine{
+					Spec: clusterv1.MachineSpec{
 						Version: "v1.31.0",
 					},
 				},
@@ -378,8 +299,8 @@ func Test_versionMatches(t *testing.T) {
 		{
 			name: "semver version match, kcp version is missing the suffix",
 			args: args{
-				machine: &clusterv2.Machine{
-					Spec: clusterv2.MachineSpec{
+				machine: &clusterv1.Machine{
+					Spec: clusterv1.MachineSpec{
 						Version: "v1.31.0+k0s.0",
 					},
 				},
@@ -390,8 +311,8 @@ func Test_versionMatches(t *testing.T) {
 		{
 			name: "versions match, both with the suffix",
 			args: args{
-				machine: &clusterv2.Machine{
-					Spec: clusterv2.MachineSpec{
+				machine: &clusterv1.Machine{
+					Spec: clusterv1.MachineSpec{
 						Version: "v1.31.0+k0s.0",
 					},
 				},
@@ -402,8 +323,8 @@ func Test_versionMatches(t *testing.T) {
 		{
 			name: "versions do not match, machine version is missing",
 			args: args{
-				machine: &clusterv2.Machine{
-					Spec: clusterv2.MachineSpec{
+				machine: &clusterv1.Machine{
+					Spec: clusterv1.MachineSpec{
 						Version: "",
 					},
 				},
@@ -414,8 +335,8 @@ func Test_versionMatches(t *testing.T) {
 		{
 			name: "versions do not match, machine version is empty",
 			args: args{
-				machine: &clusterv2.Machine{
-					Spec: clusterv2.MachineSpec{
+				machine: &clusterv1.Machine{
+					Spec: clusterv1.MachineSpec{
 						Version: "",
 					},
 				},


### PR DESCRIPTION
fix #1543 

Rely on machine conditions to determine replica status for the k0scontrolplane instead machine phase. Same approach followed by KuebadmControlplane controller