### PR TITLE
fix topology upgrade test by not using worker replicas

### DIFF
--- a/inttest/capi-docker-clusterclass-recreate-upgrade/capi_docker_clusterclass_test.go
+++ b/inttest/capi-docker-clusterclass-recreate-upgrade/capi_docker_clusterclass_test.go
@@ -327,6 +327,7 @@ spec:
       machineDeployments:
       - class: docker-test-default-worker
         name: md
+        # TODO: add worker replicas again once https://github.com/kubernetes-sigs/cluster-api/pull/13973 is merged and released
         replicas: 1
 `
 


### PR DESCRIPTION
Until a fix like https://github.com/kubernetes-sigs/cluster-api/pull/13973 is released, we cannot update a machinedeployment/machinepool version using topology version