### PR TITLE
feat: bootstrap file owner/encoding/append

### DIFF
--- a/api/bootstrap/v1beta2/k0s_template_types.go
+++ b/api/bootstrap/v1beta2/k0s_template_types.go
@@ -25,6 +25,8 @@ var (
 	conflictingContentFromMsg = "only one of contentFrom.secretKeyRef or contentFrom.configMapKeyRef may be specified for a single file"
 	pathConflictMsg           = "path property must be unique among all files"
 	noContentMsg              = "either content or contentFrom must be specified for a file"
+	ownerFormatMsg            = "owner must be of the form user[:group], using only alphanumerics, '.', '_' or '-'"
+	ownerOnPowerShellMsg      = "owner is not supported by the powershell provisioner formats or on the windows platform"
 )
 
 func init() {

--- a/api/bootstrap/v1beta2/k0s_types.go
+++ b/api/bootstrap/v1beta2/k0s_types.go
@@ -1,6 +1,5 @@
 /*
 
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -18,6 +17,7 @@ package v1beta2
 
 import (
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -459,6 +459,54 @@ func (c *K0sWorkerConfig) GetJoinTokenPath() string {
 	return filepath.Join(c.Spec.WorkingDir, "k0s.token")
 }
 
+// appliesOwner reports whether the selected provisioner writes file ownership.
+func (p ProvisionerSpec) appliesOwner() bool {
+	if p.Platform == PlatformWindows {
+		return false
+	}
+
+	return p.Type != provisioner.PowershellProvisioningFormat &&
+		p.Type != provisioner.PowershellXMLProvisioningFormat
+}
+
+// ownerRegex matches a user name and an optional group name, built from
+// characters portable across useradd implementations.
+var ownerRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]+(:[a-zA-Z0-9._-]+)?$`)
+
+// ValidateFileOwners rejects a file owner that the chosen format cannot apply,
+// or one whose shape could be mistaken for an argument by the chown it feeds.
+func ValidateFileOwners(files []File, spec ProvisionerSpec, pathPrefix *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	for i, file := range files {
+		if file.Owner == "" {
+			continue
+		}
+
+		// Nothing applies an owner on windows, whichever of the two fields
+		// selected it.
+		msg := ownerFormatMsg
+		if spec.appliesOwner() {
+			if ownerRegex.MatchString(file.Owner) {
+				continue
+			}
+		} else {
+			msg = ownerOnPowerShellMsg
+		}
+
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				pathPrefix.Child("files").Index(i).Child("owner"),
+				file.Owner,
+				msg,
+			),
+		)
+	}
+
+	return allErrs
+}
+
 // Validate validates the K0sWorkerConfigSpec.
 func (cs *K0sWorkerConfigSpec) Validate(pathPrefix *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
@@ -544,6 +592,8 @@ func (cs *K0sWorkerConfigSpec) validateFiles(pathPrefix *field.Path) field.Error
 		}
 		knownPaths[file.Path] = struct{}{}
 	}
+
+	allErrs = append(allErrs, ValidateFileOwners(cs.Files, cs.Provisioner, pathPrefix)...)
 
 	return allErrs
 }

--- a/api/bootstrap/v1beta2/worker_bootstrap_webhook_test.go
+++ b/api/bootstrap/v1beta2/worker_bootstrap_webhook_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/k0sproject/k0smotron/v2/internal/provisioner"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -225,6 +226,85 @@ func TestK0sWorkerConfigValidate(t *testing.T) {
 			}
 			require.Empty(t, warnings)
 
+		})
+	}
+}
+
+func TestValidateFileOwnerChecksEveryFile(t *testing.T) {
+	spec := &K0sWorkerConfigSpec{
+		Files: []File{
+			{File: provisioner.File{Path: "/a", Content: "x", Owner: "etcd:etcd"}},
+			{File: provisioner.File{Path: "/b", Content: "x", Owner: "root; rm -rf /"}},
+		},
+	}
+
+	errs := spec.validateFiles(field.NewPath("spec"))
+
+	require.Len(t, errs, 1)
+	require.Equal(t, "spec.files[1].owner", errs[0].Field, "the index must follow the offending file")
+}
+
+func TestValidateFileOwner(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   provisioner.ProvisioningFormat
+		platform Platform
+		owner    string
+		wantErr  string
+	}{
+		{name: "empty owner is allowed", owner: ""},
+		{name: "user only", owner: "root"},
+		{name: "user and group", owner: "etcd:etcd"},
+		{name: "dots, dashes and underscores", owner: "sys_user.1:sys-group"},
+		{name: "shell metacharacters are rejected", owner: "root; rm -rf /", wantErr: ownerFormatMsg},
+		{name: "command substitution is rejected", owner: "$(id -u)", wantErr: ownerFormatMsg},
+		{name: "spaces are rejected", owner: "root root", wantErr: ownerFormatMsg},
+		{name: "trailing separator is rejected", owner: "root:", wantErr: ownerFormatMsg},
+		{name: "more than one separator is rejected", owner: "a:b:c", wantErr: ownerFormatMsg},
+		{
+			name:    "owner is rejected for the powershell format",
+			format:  provisioner.PowershellProvisioningFormat,
+			owner:   "root:root",
+			wantErr: ownerOnPowerShellMsg,
+		},
+		{
+			name:    "owner is rejected for the powershell xml format",
+			format:  provisioner.PowershellXMLProvisioningFormat,
+			owner:   "root:root",
+			wantErr: ownerOnPowerShellMsg,
+		},
+		{
+			name:   "owner is allowed for the ignition format",
+			format: provisioner.IgnitionProvisioningFormat,
+			owner:  "etcd:etcd",
+		},
+		{
+			name:     "owner is rejected on the windows platform",
+			platform: PlatformWindows,
+			owner:    "root:root",
+			wantErr:  ownerOnPowerShellMsg,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &K0sWorkerConfigSpec{
+				Provisioner: ProvisionerSpec{Type: tt.format, Platform: tt.platform},
+				Files: []File{
+					{File: provisioner.File{Path: "/etc/thing", Content: "x", Owner: tt.owner}},
+				},
+			}
+
+			errs := spec.validateFiles(field.NewPath("spec"))
+
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.files[0].owner", errs[0].Field)
+			require.Contains(t, errs[0].Detail, tt.wantErr)
 		})
 	}
 }

--- a/api/controlplane/v1beta2/k0s_controlplane_webhook.go
+++ b/api/controlplane/v1beta2/k0s_controlplane_webhook.go
@@ -26,6 +26,7 @@ import (
 	"github.com/k0sproject/k0smotron/v2/internal/provisioner"
 	"github.com/k0sproject/version"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -124,6 +125,16 @@ func validateK0sControlPlane(kcp *K0sControlPlane) error {
 	// nolint:revive
 	if err := denyRecreateOnSingleClusters(kcp); err != nil {
 		return err
+	}
+
+	// K0sControllerConfig has no webhook of its own, so validate the files here
+	// where they are still part of the control plane spec.
+	if errs := bootstrapv1.ValidateFileOwners(
+		kcp.Spec.K0sConfigSpec.Files,
+		kcp.Spec.K0sConfigSpec.Provisioner,
+		field.NewPath("spec", "k0sConfigSpec"),
+	); len(errs) > 0 {
+		return errs.ToAggregate()
 	}
 
 	return nil

--- a/api/controlplane/v1beta2/k0s_controlplane_webhook_files_test.go
+++ b/api/controlplane/v1beta2/k0s_controlplane_webhook_files_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	bootstrapv1 "github.com/k0sproject/k0smotron/v2/api/bootstrap/v1beta2"
+	"github.com/k0sproject/k0smotron/v2/internal/provisioner"
+)
+
+// K0sControllerConfig has no webhook of its own, so the control plane webhook is
+// the only admission time check for the files it will generate.
+func TestValidateK0sControlPlaneChecksFileOwners(t *testing.T) {
+	kcp := func(owner string) *K0sControlPlane {
+		return &K0sControlPlane{
+			Spec: K0sControlPlaneSpec{
+				Version: "v1.30.0+k0s.0",
+				K0sConfigSpec: bootstrapv1.K0sConfigSpec{
+					Files: []bootstrapv1.File{
+						{File: provisioner.File{Path: "/etc/thing", Content: "x", Owner: owner}},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("a sane owner is accepted", func(t *testing.T) {
+		require.NoError(t, validateK0sControlPlane(kcp("etcd:etcd")))
+	})
+
+	t.Run("no owner is accepted", func(t *testing.T) {
+		require.NoError(t, validateK0sControlPlane(kcp("")))
+	})
+
+	t.Run("an owner that could be read as an argument is rejected", func(t *testing.T) {
+		err := validateK0sControlPlane(kcp("root; rm -rf /"))
+		require.ErrorContains(t, err, "spec.k0sConfigSpec.files[0].owner")
+	})
+
+	t.Run("command substitution is rejected", func(t *testing.T) {
+		require.Error(t, validateK0sControlPlane(kcp("$(id -u)")))
+	})
+}

--- a/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
+++ b/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0scontrollerconfigs.yaml
@@ -108,6 +108,11 @@ spec:
                   description: File defines a file to be passed to user_data upon
                     creation.
                   properties:
+                    append:
+                      description: |-
+                        Append specifies whether Content is appended to an existing file rather
+                        than replacing it. If the file does not exist it is created either way.
+                      type: boolean
                     content:
                       type: string
                     contentFrom:
@@ -144,6 +149,19 @@ spec:
                           - name
                           type: object
                       type: object
+                    encoding:
+                      description: |-
+                        Encoding specifies how Content is encoded. When empty Content is used
+                        verbatim. Use it to carry bytes that a plain string cannot hold.
+                      enum:
+                      - base64
+                      type: string
+                    owner:
+                      description: |-
+                        Owner sets file ownership as a user name and an optional group name
+                        separated by a colon. Empty means the file is owned by root.
+                      maxLength: 256
+                      type: string
                     path:
                       type: string
                     permissions:
@@ -390,6 +408,11 @@ spec:
                   description: File defines a file to be passed to user_data upon
                     creation.
                   properties:
+                    append:
+                      description: |-
+                        Append specifies whether Content is appended to an existing file rather
+                        than replacing it. If the file does not exist it is created either way.
+                      type: boolean
                     content:
                       type: string
                     contentFrom:
@@ -426,6 +449,19 @@ spec:
                           - name
                           type: object
                       type: object
+                    encoding:
+                      description: |-
+                        Encoding specifies how Content is encoded. When empty Content is used
+                        verbatim. Use it to carry bytes that a plain string cannot hold.
+                      enum:
+                      - base64
+                      type: string
+                    owner:
+                      description: |-
+                        Owner sets file ownership as a user name and an optional group name
+                        separated by a colon. Empty means the file is owned by root.
+                      maxLength: 256
+                      type: string
                     path:
                       type: string
                     permissions:

--- a/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
+++ b/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigs.yaml
@@ -102,6 +102,11 @@ spec:
                   description: File defines a file to be passed to user_data upon
                     creation.
                   properties:
+                    append:
+                      description: |-
+                        Append specifies whether Content is appended to an existing file rather
+                        than replacing it. If the file does not exist it is created either way.
+                      type: boolean
                     content:
                       type: string
                     contentFrom:
@@ -138,6 +143,19 @@ spec:
                           - name
                           type: object
                       type: object
+                    encoding:
+                      description: |-
+                        Encoding specifies how Content is encoded. When empty Content is used
+                        verbatim. Use it to carry bytes that a plain string cannot hold.
+                      enum:
+                      - base64
+                      type: string
+                    owner:
+                      description: |-
+                        Owner sets file ownership as a user name and an optional group name
+                        separated by a colon. Empty means the file is owned by root.
+                      maxLength: 256
+                      type: string
                     path:
                       type: string
                     permissions:
@@ -351,6 +369,11 @@ spec:
                   description: File defines a file to be passed to user_data upon
                     creation.
                   properties:
+                    append:
+                      description: |-
+                        Append specifies whether Content is appended to an existing file rather
+                        than replacing it. If the file does not exist it is created either way.
+                      type: boolean
                     content:
                       type: string
                     contentFrom:
@@ -387,6 +410,19 @@ spec:
                           - name
                           type: object
                       type: object
+                    encoding:
+                      description: |-
+                        Encoding specifies how Content is encoded. When empty Content is used
+                        verbatim. Use it to carry bytes that a plain string cannot hold.
+                      enum:
+                      - base64
+                      type: string
+                    owner:
+                      description: |-
+                        Owner sets file ownership as a user name and an optional group name
+                        separated by a colon. Empty means the file is owned by root.
+                      maxLength: 256
+                      type: string
                     path:
                       type: string
                     permissions:

--- a/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
+++ b/config/clusterapi/bootstrap/crd/bases/bootstrap.cluster.x-k8s.io_k0sworkerconfigtemplates.yaml
@@ -131,6 +131,11 @@ spec:
                           description: File defines a file to be passed to user_data
                             upon creation.
                           properties:
+                            append:
+                              description: |-
+                                Append specifies whether Content is appended to an existing file rather
+                                than replacing it. If the file does not exist it is created either way.
+                              type: boolean
                             content:
                               type: string
                             contentFrom:
@@ -168,6 +173,19 @@ spec:
                                   - name
                                   type: object
                               type: object
+                            encoding:
+                              description: |-
+                                Encoding specifies how Content is encoded. When empty Content is used
+                                verbatim. Use it to carry bytes that a plain string cannot hold.
+                              enum:
+                              - base64
+                              type: string
+                            owner:
+                              description: |-
+                                Owner sets file ownership as a user name and an optional group name
+                                separated by a colon. Empty means the file is owned by root.
+                              maxLength: 256
+                              type: string
                             path:
                               type: string
                             permissions:
@@ -343,6 +361,11 @@ spec:
                           description: File defines a file to be passed to user_data
                             upon creation.
                           properties:
+                            append:
+                              description: |-
+                                Append specifies whether Content is appended to an existing file rather
+                                than replacing it. If the file does not exist it is created either way.
+                              type: boolean
                             content:
                               type: string
                             contentFrom:
@@ -380,6 +403,19 @@ spec:
                                   - name
                                   type: object
                               type: object
+                            encoding:
+                              description: |-
+                                Encoding specifies how Content is encoded. When empty Content is used
+                                verbatim. Use it to carry bytes that a plain string cannot hold.
+                              enum:
+                              - base64
+                              type: string
+                            owner:
+                              description: |-
+                                Owner sets file ownership as a user name and an optional group name
+                                separated by a colon. Empty means the file is owned by root.
+                              maxLength: 256
+                              type: string
                             path:
                               type: string
                             permissions:

--- a/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -150,6 +150,11 @@ spec:
                       description: File defines a file to be passed to user_data upon
                         creation.
                       properties:
+                        append:
+                          description: |-
+                            Append specifies whether Content is appended to an existing file rather
+                            than replacing it. If the file does not exist it is created either way.
+                          type: boolean
                         content:
                           type: string
                         contentFrom:
@@ -186,6 +191,19 @@ spec:
                               - name
                               type: object
                           type: object
+                        encoding:
+                          description: |-
+                            Encoding specifies how Content is encoded. When empty Content is used
+                            verbatim. Use it to carry bytes that a plain string cannot hold.
+                          enum:
+                          - base64
+                          type: string
+                        owner:
+                          description: |-
+                            Owner sets file ownership as a user name and an optional group name
+                            separated by a colon. Empty means the file is owned by root.
+                          maxLength: 256
+                          type: string
                         path:
                           type: string
                         permissions:
@@ -644,6 +662,11 @@ spec:
                       description: File defines a file to be passed to user_data upon
                         creation.
                       properties:
+                        append:
+                          description: |-
+                            Append specifies whether Content is appended to an existing file rather
+                            than replacing it. If the file does not exist it is created either way.
+                          type: boolean
                         content:
                           type: string
                         contentFrom:
@@ -680,6 +703,19 @@ spec:
                               - name
                               type: object
                           type: object
+                        encoding:
+                          description: |-
+                            Encoding specifies how Content is encoded. When empty Content is used
+                            verbatim. Use it to carry bytes that a plain string cannot hold.
+                          enum:
+                          - base64
+                          type: string
+                        owner:
+                          description: |-
+                            Owner sets file ownership as a user name and an optional group name
+                            separated by a colon. Empty means the file is owned by root.
+                          maxLength: 256
+                          type: string
                         path:
                           type: string
                         permissions:

--- a/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
+++ b/config/clusterapi/controlplane/crd/bases/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
@@ -137,6 +137,11 @@ spec:
                               description: File defines a file to be passed to user_data
                                 upon creation.
                               properties:
+                                append:
+                                  description: |-
+                                    Append specifies whether Content is appended to an existing file rather
+                                    than replacing it. If the file does not exist it is created either way.
+                                  type: boolean
                                 content:
                                   type: string
                                 contentFrom:
@@ -174,6 +179,19 @@ spec:
                                       - name
                                       type: object
                                   type: object
+                                encoding:
+                                  description: |-
+                                    Encoding specifies how Content is encoded. When empty Content is used
+                                    verbatim. Use it to carry bytes that a plain string cannot hold.
+                                  enum:
+                                  - base64
+                                  type: string
+                                owner:
+                                  description: |-
+                                    Owner sets file ownership as a user name and an optional group name
+                                    separated by a colon. Empty means the file is owned by root.
+                                  maxLength: 256
+                                  type: string
                                 path:
                                   type: string
                                 permissions:
@@ -444,6 +462,11 @@ spec:
                               description: File defines a file to be passed to user_data
                                 upon creation.
                               properties:
+                                append:
+                                  description: |-
+                                    Append specifies whether Content is appended to an existing file rather
+                                    than replacing it. If the file does not exist it is created either way.
+                                  type: boolean
                                 content:
                                   type: string
                                 contentFrom:
@@ -481,6 +504,19 @@ spec:
                                       - name
                                       type: object
                                   type: object
+                                encoding:
+                                  description: |-
+                                    Encoding specifies how Content is encoded. When empty Content is used
+                                    verbatim. Use it to carry bytes that a plain string cannot hold.
+                                  enum:
+                                  - base64
+                                  type: string
+                                owner:
+                                  description: |-
+                                    Owner sets file ownership as a user name and an optional group name
+                                    separated by a colon. Empty means the file is owned by root.
+                                  maxLength: 256
+                                  type: string
                                 path:
                                   type: string
                                 permissions:

--- a/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
+++ b/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanes.yaml
@@ -150,6 +150,11 @@ spec:
                       description: File defines a file to be passed to user_data upon
                         creation.
                       properties:
+                        append:
+                          description: |-
+                            Append specifies whether Content is appended to an existing file rather
+                            than replacing it. If the file does not exist it is created either way.
+                          type: boolean
                         content:
                           type: string
                         contentFrom:
@@ -186,6 +191,19 @@ spec:
                               - name
                               type: object
                           type: object
+                        encoding:
+                          description: |-
+                            Encoding specifies how Content is encoded. When empty Content is used
+                            verbatim. Use it to carry bytes that a plain string cannot hold.
+                          enum:
+                          - base64
+                          type: string
+                        owner:
+                          description: |-
+                            Owner sets file ownership as a user name and an optional group name
+                            separated by a colon. Empty means the file is owned by root.
+                          maxLength: 256
+                          type: string
                         path:
                           type: string
                         permissions:
@@ -644,6 +662,11 @@ spec:
                       description: File defines a file to be passed to user_data upon
                         creation.
                       properties:
+                        append:
+                          description: |-
+                            Append specifies whether Content is appended to an existing file rather
+                            than replacing it. If the file does not exist it is created either way.
+                          type: boolean
                         content:
                           type: string
                         contentFrom:
@@ -680,6 +703,19 @@ spec:
                               - name
                               type: object
                           type: object
+                        encoding:
+                          description: |-
+                            Encoding specifies how Content is encoded. When empty Content is used
+                            verbatim. Use it to carry bytes that a plain string cannot hold.
+                          enum:
+                          - base64
+                          type: string
+                        owner:
+                          description: |-
+                            Owner sets file ownership as a user name and an optional group name
+                            separated by a colon. Empty means the file is owned by root.
+                          maxLength: 256
+                          type: string
                         path:
                           type: string
                         permissions:

--- a/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
+++ b/config/crd/controlplane.cluster.x-k8s.io_k0scontrolplanetemplates.yaml
@@ -137,6 +137,11 @@ spec:
                               description: File defines a file to be passed to user_data
                                 upon creation.
                               properties:
+                                append:
+                                  description: |-
+                                    Append specifies whether Content is appended to an existing file rather
+                                    than replacing it. If the file does not exist it is created either way.
+                                  type: boolean
                                 content:
                                   type: string
                                 contentFrom:
@@ -174,6 +179,19 @@ spec:
                                       - name
                                       type: object
                                   type: object
+                                encoding:
+                                  description: |-
+                                    Encoding specifies how Content is encoded. When empty Content is used
+                                    verbatim. Use it to carry bytes that a plain string cannot hold.
+                                  enum:
+                                  - base64
+                                  type: string
+                                owner:
+                                  description: |-
+                                    Owner sets file ownership as a user name and an optional group name
+                                    separated by a colon. Empty means the file is owned by root.
+                                  maxLength: 256
+                                  type: string
                                 path:
                                   type: string
                                 permissions:
@@ -444,6 +462,11 @@ spec:
                               description: File defines a file to be passed to user_data
                                 upon creation.
                               properties:
+                                append:
+                                  description: |-
+                                    Append specifies whether Content is appended to an existing file rather
+                                    than replacing it. If the file does not exist it is created either way.
+                                  type: boolean
                                 content:
                                   type: string
                                 contentFrom:
@@ -481,6 +504,19 @@ spec:
                                       - name
                                       type: object
                                   type: object
+                                encoding:
+                                  description: |-
+                                    Encoding specifies how Content is encoded. When empty Content is used
+                                    verbatim. Use it to carry bytes that a plain string cannot hold.
+                                  enum:
+                                  - base64
+                                  type: string
+                                owner:
+                                  description: |-
+                                    Owner sets file ownership as a user name and an optional group name
+                                    separated by a colon. Empty means the file is owned by root.
+                                  maxLength: 256
+                                  type: string
                                 path:
                                   type: string
                                 permissions:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,8 +16,14 @@ TARGET_VERSION ?= latest
 # mkdocs.yml refuses to live in the docs-directory, this is why "cd .." is needed
 # gives: "Error: The 'docs_dir' should not be the parent directory of the config file."
 # even if docs_dir is "."
-docs: .require-mkdocs
+docs: .require-mkdocs validate-examples
 	cd .. && mkdocs build --strict
+
+# The jinja examples are a contract with users of the CloudInitVars gate, so
+# render them the way cloud init would and check the result parses.
+.PHONY: validate-examples
+validate-examples:
+	python3 ../hack/validate-doc-examples.py
 
 .PHONY: .require-mkdocs
 .require-mkdocs:

--- a/docs/advanced/cloud-init.md
+++ b/docs/advanced/cloud-init.md
@@ -111,7 +111,15 @@ The variables include:
 - `{{ k0smotron_k0sDownloadCommands }}` — shell line with all download steps chained by &&.
 - `{{ k0smotron_k0sInstallCommand }}` — the k0s install command (controller/worker specific).
 - `{{ k0smotron_k0sStartCommand }}` — the command that starts k0s.
-- `{{ k0smotron_files }}` — a list of file objects with fields: path, content, permissions.
+- `{{ k0smotron_files }}` — a list of file objects with fields: path, content, permissions, and owner, encoding or append when set.
+
+!!! note
+
+    `append` is rejected when the machine is provisioned by the RemoteMachine provider, over SSH or through a job. Those paths re-run from the start on every retry, so appending would duplicate the content.
+
+!!! warning
+
+    In this mode k0smotron does not write the files, so your template must honour `owner`, `encoding` and `append` itself. Ignoring `encoding` leaves `base64` content encoded, and ignoring `append` replaces the file instead. The optional keys are only present when set, so read them with `f.get(...)`.
 
 Example customUserData using variables:
 
@@ -122,17 +130,29 @@ runcmd:
   - {{ k0smotron_k0sStartCommand }}
   
 write_files:
-  {% for f in k0smotron_files %}
+{% for f in k0smotron_files %}
   - path: {{ f.path }}
     permissions: "{{ f.permissions }}"
-    content: |
-      {{ f.content | indent(6) }}
-  {% endfor %}
+{% if f.get('owner') %}
+    owner: "{{ f.owner }}"
+{% endif %}
+{% if f.get('encoding') %}
+    encoding: "{{ f.encoding }}"
+{% endif %}
+{% if f.get('append') %}
+    append: true
+{% endif %}
+    content: {{ f.content | tojson }}
+{% endfor %}
   - path: /my/custom/file.txt
     permissions: "0644"
     content: |
       Welcome from custom cloud-init with variables
 ```
+
+Keep the block tags at column zero. cloud-init enables `trim_blocks` but not `lstrip_blocks`, so indented tags emit whitespace that breaks the list.
+
+Use `tojson` for `content` instead of a block scalar, which would take its indentation from the first line.
 
 Another approach is to use the variables in a completely custom script:
 
@@ -143,20 +163,19 @@ runcmd:
   
 write_files:
   - path: /root/cloud-init.sh
+    permissions: "0755"
     content: |
       #!/usr/bin/bash
       set -euo pipefail
-  
+
       {{ k0smotron_k0sDownloadCommands }}
       {{ k0smotron_k0sInstallCommand }}
       {{ k0smotron_k0sStartCommand }}
-    permissions: "0755"
-  {% for f in k0smotron_files %}
+{% for f in k0smotron_files %}
   - path: {{ f.path }}
-    content: |
-      {{ f.content | indent(6) }}
     permissions: "{{ f.permissions }}"
-  {% endfor %}
+    content: {{ f.content | tojson }}
+{% endfor %}
   - path: /root/my-extra-file
     content: test
     permissions: "0600"

--- a/docs/resource-reference/bootstrap.cluster.x-k8s.io-v1beta1.md
+++ b/docs/resource-reference/bootstrap.cluster.x-k8s.io-v1beta1.md
@@ -331,6 +331,14 @@ File defines a file to be passed to user_data upon creation.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>append</b></td>
+        <td>boolean</td>
+        <td>
+          Append specifies whether Content is appended to an existing file rather
+than replacing it. If the file does not exist it is created either way.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>content</b></td>
         <td>string</td>
         <td>
@@ -342,6 +350,24 @@ File defines a file to be passed to user_data upon creation.
         <td>object</td>
         <td>
           ContentFrom specifies the source of the content.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>encoding</b></td>
+        <td>enum</td>
+        <td>
+          Encoding specifies how Content is encoded. When empty Content is used
+verbatim. Use it to carry bytes that a plain string cannot hold.<br/>
+          <br/>
+            <i>Enum</i>: base64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>owner</b></td>
+        <td>string</td>
+        <td>
+          Owner sets file ownership as a user name and an optional group name
+separated by a colon. Empty means the file is owned by root.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1000,6 +1026,14 @@ File defines a file to be passed to user_data upon creation.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>append</b></td>
+        <td>boolean</td>
+        <td>
+          Append specifies whether Content is appended to an existing file rather
+than replacing it. If the file does not exist it is created either way.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>content</b></td>
         <td>string</td>
         <td>
@@ -1011,6 +1045,24 @@ File defines a file to be passed to user_data upon creation.
         <td>object</td>
         <td>
           ContentFrom specifies the source of the content.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>encoding</b></td>
+        <td>enum</td>
+        <td>
+          Encoding specifies how Content is encoded. When empty Content is used
+verbatim. Use it to carry bytes that a plain string cannot hold.<br/>
+          <br/>
+            <i>Enum</i>: base64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>owner</b></td>
+        <td>string</td>
+        <td>
+          Owner sets file ownership as a user name and an optional group name
+separated by a colon. Empty means the file is owned by root.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1742,6 +1794,14 @@ File defines a file to be passed to user_data upon creation.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>append</b></td>
+        <td>boolean</td>
+        <td>
+          Append specifies whether Content is appended to an existing file rather
+than replacing it. If the file does not exist it is created either way.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>content</b></td>
         <td>string</td>
         <td>
@@ -1753,6 +1813,24 @@ File defines a file to be passed to user_data upon creation.
         <td>object</td>
         <td>
           ContentFrom specifies the source of the content.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>encoding</b></td>
+        <td>enum</td>
+        <td>
+          Encoding specifies how Content is encoded. When empty Content is used
+verbatim. Use it to carry bytes that a plain string cannot hold.<br/>
+          <br/>
+            <i>Enum</i>: base64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>owner</b></td>
+        <td>string</td>
+        <td>
+          Owner sets file ownership as a user name and an optional group name
+separated by a colon. Empty means the file is owned by root.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/resource-reference/bootstrap.cluster.x-k8s.io-v1beta2.md
+++ b/docs/resource-reference/bootstrap.cluster.x-k8s.io-v1beta2.md
@@ -225,6 +225,14 @@ File defines a file to be passed to user_data upon creation.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>append</b></td>
+        <td>boolean</td>
+        <td>
+          Append specifies whether Content is appended to an existing file rather
+than replacing it. If the file does not exist it is created either way.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>content</b></td>
         <td>string</td>
         <td>
@@ -236,6 +244,24 @@ File defines a file to be passed to user_data upon creation.
         <td>object</td>
         <td>
           ContentFrom specifies the source of the content.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>encoding</b></td>
+        <td>enum</td>
+        <td>
+          Encoding specifies how Content is encoded. When empty Content is used
+verbatim. Use it to carry bytes that a plain string cannot hold.<br/>
+          <br/>
+            <i>Enum</i>: base64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>owner</b></td>
+        <td>string</td>
+        <td>
+          Owner sets file ownership as a user name and an optional group name
+separated by a colon. Empty means the file is owned by root.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1002,6 +1028,14 @@ File defines a file to be passed to user_data upon creation.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>append</b></td>
+        <td>boolean</td>
+        <td>
+          Append specifies whether Content is appended to an existing file rather
+than replacing it. If the file does not exist it is created either way.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>content</b></td>
         <td>string</td>
         <td>
@@ -1013,6 +1047,24 @@ File defines a file to be passed to user_data upon creation.
         <td>object</td>
         <td>
           ContentFrom specifies the source of the content.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>encoding</b></td>
+        <td>enum</td>
+        <td>
+          Encoding specifies how Content is encoded. When empty Content is used
+verbatim. Use it to carry bytes that a plain string cannot hold.<br/>
+          <br/>
+            <i>Enum</i>: base64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>owner</b></td>
+        <td>string</td>
+        <td>
+          Owner sets file ownership as a user name and an optional group name
+separated by a colon. Empty means the file is owned by root.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1818,6 +1870,14 @@ File defines a file to be passed to user_data upon creation.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>append</b></td>
+        <td>boolean</td>
+        <td>
+          Append specifies whether Content is appended to an existing file rather
+than replacing it. If the file does not exist it is created either way.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>content</b></td>
         <td>string</td>
         <td>
@@ -1829,6 +1889,24 @@ File defines a file to be passed to user_data upon creation.
         <td>object</td>
         <td>
           ContentFrom specifies the source of the content.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>encoding</b></td>
+        <td>enum</td>
+        <td>
+          Encoding specifies how Content is encoded. When empty Content is used
+verbatim. Use it to carry bytes that a plain string cannot hold.<br/>
+          <br/>
+            <i>Enum</i>: base64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>owner</b></td>
+        <td>string</td>
+        <td>
+          Owner sets file ownership as a user name and an optional group name
+separated by a colon. Empty means the file is owned by root.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
+++ b/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta1.md
@@ -396,6 +396,14 @@ File defines a file to be passed to user_data upon creation.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>append</b></td>
+        <td>boolean</td>
+        <td>
+          Append specifies whether Content is appended to an existing file rather
+than replacing it. If the file does not exist it is created either way.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>content</b></td>
         <td>string</td>
         <td>
@@ -407,6 +415,24 @@ File defines a file to be passed to user_data upon creation.
         <td>object</td>
         <td>
           ContentFrom specifies the source of the content.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>encoding</b></td>
+        <td>enum</td>
+        <td>
+          Encoding specifies how Content is encoded. When empty Content is used
+verbatim. Use it to carry bytes that a plain string cannot hold.<br/>
+          <br/>
+            <i>Enum</i>: base64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>owner</b></td>
+        <td>string</td>
+        <td>
+          Owner sets file ownership as a user name and an optional group name
+separated by a colon. Empty means the file is owned by root.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1533,6 +1559,14 @@ File defines a file to be passed to user_data upon creation.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>append</b></td>
+        <td>boolean</td>
+        <td>
+          Append specifies whether Content is appended to an existing file rather
+than replacing it. If the file does not exist it is created either way.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>content</b></td>
         <td>string</td>
         <td>
@@ -1544,6 +1578,24 @@ File defines a file to be passed to user_data upon creation.
         <td>object</td>
         <td>
           ContentFrom specifies the source of the content.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>encoding</b></td>
+        <td>enum</td>
+        <td>
+          Encoding specifies how Content is encoded. When empty Content is used
+verbatim. Use it to carry bytes that a plain string cannot hold.<br/>
+          <br/>
+            <i>Enum</i>: base64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>owner</b></td>
+        <td>string</td>
+        <td>
+          Owner sets file ownership as a user name and an optional group name
+separated by a colon. Empty means the file is owned by root.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta2.md
+++ b/docs/resource-reference/controlplane.cluster.x-k8s.io-v1beta2.md
@@ -290,6 +290,14 @@ File defines a file to be passed to user_data upon creation.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>append</b></td>
+        <td>boolean</td>
+        <td>
+          Append specifies whether Content is appended to an existing file rather
+than replacing it. If the file does not exist it is created either way.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>content</b></td>
         <td>string</td>
         <td>
@@ -301,6 +309,24 @@ File defines a file to be passed to user_data upon creation.
         <td>object</td>
         <td>
           ContentFrom specifies the source of the content.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>encoding</b></td>
+        <td>enum</td>
+        <td>
+          Encoding specifies how Content is encoded. When empty Content is used
+verbatim. Use it to carry bytes that a plain string cannot hold.<br/>
+          <br/>
+            <i>Enum</i>: base64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>owner</b></td>
+        <td>string</td>
+        <td>
+          Owner sets file ownership as a user name and an optional group name
+separated by a colon. Empty means the file is owned by root.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1494,6 +1520,14 @@ File defines a file to be passed to user_data upon creation.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>append</b></td>
+        <td>boolean</td>
+        <td>
+          Append specifies whether Content is appended to an existing file rather
+than replacing it. If the file does not exist it is created either way.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>content</b></td>
         <td>string</td>
         <td>
@@ -1505,6 +1539,24 @@ File defines a file to be passed to user_data upon creation.
         <td>object</td>
         <td>
           ContentFrom specifies the source of the content.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>encoding</b></td>
+        <td>enum</td>
+        <td>
+          Encoding specifies how Content is encoded. When empty Content is used
+verbatim. Use it to carry bytes that a plain string cannot hold.<br/>
+          <br/>
+            <i>Enum</i>: base64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>owner</b></td>
+        <td>string</td>
+        <td>
+          Owner sets file ownership as a user name and an optional group name
+separated by a colon. Empty means the file is owned by root.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	github.com/vincent-petithory/dataurl v1.0.0
 	gomodules.xyz/jsonpatch/v2 v2.5.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.2
@@ -176,7 +177,6 @@ require (
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tidwall/transform v0.0.0-20201103190739-32f242e2dbde // indirect
-	github.com/vincent-petithory/dataurl v1.0.0 // indirect
 	github.com/weppos/publicsuffix-go v0.15.1-0.20210511084619-b1f36a2d6c0b // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/zmap/zcrypto v0.0.0-20210511125630-18f1e0152cfc // indirect

--- a/hack/validate-doc-examples.py
+++ b/hack/validate-doc-examples.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Render the jinja examples in the docs the way cloud init would.
+
+A template can look fine and still emit invalid yaml, so parse the result.
+"""
+
+import pathlib
+import re
+import sys
+
+import jinja2
+import yaml
+
+# cloud init renders user data with trim_blocks enabled and lstrip_blocks off.
+# See cloudinit/handlers/jinja_template.py upstream.
+ENV = jinja2.Environment(trim_blocks=True, undefined=jinja2.StrictUndefined)
+
+BLOCK_RE = re.compile(r"^```jinja\n(.*?)^```$", re.MULTILINE | re.DOTALL)
+
+# Names come from the VarK0s constants in internal/provisioner/cloudinit.go.
+COMMAND_VARS = {
+    "k0smotron_k0sDownloadCommands": "curl -sSf https://get.k0s.sh | sh",
+    "k0smotron_k0sInstallCommand": "k0s install worker --token-file /etc/k0s.token",
+    "k0smotron_k0sStartCommand": "k0s start",
+}
+
+# Contents that have broken a documented template before, or plausibly could.
+CONTENTS = {
+    "plain": "hello\n",
+    "multiline": "line1\nline2\n",
+    "leading spaces": "  extraArgs:\n    foo: bar\n",
+    "leading tab": "\thi\n",
+    "leading newline": "\nfoo\n",
+    "quotes and backslash": 'a"b\\c\n',
+    "blank lines": "a\n\n\nb\n",
+    "non ascii": "café München\n",
+    "no trailing newline": "Zm9vYmFy",
+    "yaml lookalike": "- item\nkey: value\n",
+}
+
+
+def files_var(content):
+    """Mirror what writeFilesVars emits, with every key always present."""
+    return [
+        {
+            "path": "/etc/k0smotron-example.conf",
+            "permissions": "0640",
+            "owner": "test:test",
+            "content": content,
+        }
+    ]
+
+
+def check_block(source, doc, index):
+    failures = []
+    uses_files = "k0smotron_files" in source
+
+    for label, content in CONTENTS.items() if uses_files else {"none": ""}.items():
+        variables = dict(COMMAND_VARS, k0smotron_files=files_var(content))
+
+        try:
+            rendered = ENV.from_string(source).render(**variables)
+        except jinja2.TemplateError as err:
+            failures.append(f"{label}: template error {err}")
+            continue
+
+        try:
+            parsed = yaml.safe_load(rendered)
+        except yaml.YAMLError as err:
+            first = str(err).split("\n")[0]
+            failures.append(f"{label}: rendered to invalid yaml, {first}")
+            continue
+
+        if not uses_files:
+            continue
+
+        written = [f for f in parsed.get("write_files", []) if f.get("path", "").startswith("/etc/k0smotron")]
+        if len(written) != 1:
+            failures.append(f"{label}: expected one generated file, found {len(written)}")
+            continue
+
+        # Content must survive exactly. An example is free to forward only
+        # some of the other fields, but must not corrupt the ones it does.
+        got = written[0]
+        if got.get("content") != content:
+            failures.append(f"{label}: content changed, {got.get('content')!r} != {content!r}")
+
+        expected = {"owner": "test:test", "permissions": "0640"}
+        for key, want in expected.items():
+            if key in got and got[key] != want:
+                failures.append(f"{label}: {key} changed, {got[key]!r} != {want!r}")
+
+    for failure in failures:
+        print(f"{doc} block {index}: {failure}", file=sys.stderr)
+
+    return not failures
+
+
+def main():
+    root = pathlib.Path(__file__).resolve().parent.parent
+    docs = sorted((root / "docs").rglob("*.md"))
+
+    blocks = 0
+    ok = True
+    for doc in docs:
+        text = doc.read_text(encoding="utf-8")
+        for index, match in enumerate(BLOCK_RE.finditer(text), start=1):
+            blocks += 1
+            if not check_block(match.group(1), doc.relative_to(root), index):
+                ok = False
+
+    if not ok:
+        print(f"checked {blocks} jinja examples, some are broken", file=sys.stderr)
+        return 1
+
+    print(f"checked {blocks} jinja examples, all render to valid yaml")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/internal/controller/infrastructure/job_provisioner.go
+++ b/internal/controller/infrastructure/job_provisioner.go
@@ -99,7 +99,10 @@ func (p *JobProvisioner) Provision(ctx context.Context) error {
 		},
 	}
 
-	volume, volumeMounts, secretData := p.extractCloudInit(p.cloudInit)
+	volume, volumeMounts, secretData, err := p.extractCloudInit(p.cloudInit)
+	if err != nil {
+		return err
+	}
 	job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, volume)
 	job.Spec.Template.Spec.Containers[0].VolumeMounts = append(job.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMounts...)
 	volume.Secret.SecretName = secret.Name
@@ -140,7 +143,7 @@ func (p *JobProvisioner) Provision(ctx context.Context) error {
 	return nil
 }
 
-func (p *JobProvisioner) extractCloudInit(cloudInit *provisioner.InputProvisionData) (volume v1.Volume, volumeMounts []v1.VolumeMount, secretData map[string][]byte) {
+func (p *JobProvisioner) extractCloudInit(cloudInit *provisioner.InputProvisionData) (volume v1.Volume, volumeMounts []v1.VolumeMount, secretData map[string][]byte, err error) {
 	machineDSN := p.machineDSN()
 
 	var sshCommand, scpCommand string
@@ -161,14 +164,30 @@ func (p *JobProvisioner) extractCloudInit(cloudInit *provisioner.InputProvisionD
 		},
 	}
 
+	var sudoPrefix string
+	if p.remoteMachine.Spec.UseSudo {
+		sudoPrefix = "sudo "
+	}
+
 	var buf bytes.Buffer
 	buf.WriteString("#!/bin/sh\n")
 
 	secretData = make(map[string][]byte)
 
 	for _, file := range cloudInit.Files {
+		// The file is placed by scp, which always replaces the target.
+		if file.Append {
+			return volume, volumeMounts, secretData, fmt.Errorf("file %s uses append, which is not supported when provisioning through a job", file.Path)
+		}
+
+		// The remote host receives the file as is, so decode before staging it.
+		content, err := file.DecodedContent()
+		if err != nil {
+			return volume, volumeMounts, secretData, err
+		}
+
 		fileName := genFileName(file.Path)
-		secretData[fileName] = []byte(file.Content)
+		secretData[fileName] = content
 
 		volume.VolumeSource.Secret.Items = append(volume.VolumeSource.Secret.Items, v1.KeyToPath{
 			Key:  fileName,
@@ -176,7 +195,12 @@ func (p *JobProvisioner) extractCloudInit(cloudInit *provisioner.InputProvisionD
 		})
 
 		buf.WriteString(fmt.Sprintf("%s /var/lib/bootstrap-data/%s %s:%s\n", scpCommand, fileName, machineDSN, file.Path))
-		buf.WriteString(fmt.Sprintf("%s chmod %s %s\n", sshCommand, file.Permissions, file.Path))
+		// These run through the entrypoint shell inside the job, so quote them.
+		// Giving a file away also needs the same privilege the commands use.
+		buf.WriteString(fmt.Sprintf("%s %schmod %s %s\n", sshCommand, sudoPrefix, shellQuote(file.Permissions), shellQuote(file.Path)))
+		if file.Owner != "" {
+			buf.WriteString(fmt.Sprintf("%s %schown -- %s %s\n", sshCommand, sudoPrefix, shellQuote(file.Owner), shellQuote(file.Path)))
+		}
 	}
 	volumeMounts = append(volumeMounts, v1.VolumeMount{
 		Name:      "bootstrap-data",
@@ -197,7 +221,7 @@ func (p *JobProvisioner) extractCloudInit(cloudInit *provisioner.InputProvisionD
 		Mode: new(int32(0755)),
 	})
 
-	return volume, volumeMounts, secretData
+	return volume, volumeMounts, secretData, nil
 }
 
 func (p *JobProvisioner) machineDSN() (dsn string) {

--- a/internal/controller/infrastructure/ssh_provisioner.go
+++ b/internal/controller/infrastructure/ssh_provisioner.go
@@ -1,6 +1,5 @@
 /*
 
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -20,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -118,7 +116,7 @@ func (p *SSHProvisioner) Provision(ctx context.Context) error {
 	// Write files first
 	for _, file := range p.cloudInit.Files {
 		p.log.Info("Uploading file", "path", file.Path, "permissions", file.Permissions)
-		if err := p.uploadFile(fsys, file); err != nil {
+		if err := p.uploadFile(connection, execOpts, fsys, file); err != nil {
 			return fmt.Errorf("failed to upload file: %w", err)
 		}
 		p.log.Info("Uploaded file", "path", file.Path, "permissions", file.Permissions)
@@ -255,7 +253,19 @@ func (p *SSHProvisioner) Cleanup(_ context.Context, mode RemoteMachineMode) erro
 	return nil
 }
 
-func (p *SSHProvisioner) uploadFile(fsys rigfs.Fsys, file provisioner.File) error {
+// commandRunner runs a command on the remote machine. rig.Connection satisfies
+// it, and a test can substitute a recorder.
+type commandRunner interface {
+	ExecOutput(cmd string, opts ...exec.Option) (string, error)
+}
+
+// shellQuote wraps s in single quotes so it survives a POSIX shell as one
+// literal argument, rather than being interpolated into a remote command.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func (p *SSHProvisioner) uploadFile(runner commandRunner, execOpts []exec.Option, fsys rigfs.Fsys, file provisioner.File) error {
 	// Ensure base dir exists for target. Change Windows-style slashes to Unix-style. Windows is ok with forward slashes, but filepath.Dir is not.
 	dir := filepath.Dir(strings.Replace(file.Path, `\`, `/`, -1))
 	perms, err := file.PermissionsAsInt()
@@ -263,21 +273,44 @@ func (p *SSHProvisioner) uploadFile(fsys rigfs.Fsys, file provisioner.File) erro
 		return fmt.Errorf("failed to parse permissions: %w", err)
 	}
 
+	// Provision uploads every file again whenever it is retried, so appending
+	// here would duplicate the content on each attempt.
+	if file.Append {
+		return fmt.Errorf("file %s uses append, which is not supported when provisioning over ssh", file.Path)
+	}
+
+	// Nothing on the remote host understands a content encoding, so decode here.
+	content, err := file.DecodedContent()
+	if err != nil {
+		return err
+	}
+
+	// The file mode is deliberately not reused for the directory. A mode such as
+	// 0600 would leave the directory untraversable for the file owner.
 	if _, err := fsys.Stat(dir); errors.Is(err, fs.ErrNotExist) {
-		if err := fsys.MkDirAll(dir, fs.FileMode(perms)); err != nil {
+		if err := fsys.MkDirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("failed to create directory: %w", err)
 		}
 	}
 
-	destFile, err := fsys.OpenFile(file.Path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, fs.FileMode(perms))
+	destFile, err := fsys.OpenFile(file.Path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fs.FileMode(perms))
 	if err != nil {
 		return fmt.Errorf("failed to open remote file for writing: %w", err)
 	}
 	defer destFile.Close()
-	if _, err := io.WriteString(destFile, file.Content); err != nil {
+	if _, err := destFile.Write(content); err != nil {
 		return fmt.Errorf("failed to write to remote file: %w", err)
 	}
 
-	p.log.Info("uploaded file", "path", file.Path, "permissions", perms)
+	// rigfs.Fsys cannot change ownership, so shell out for it. Done after the
+	// write, which already created the file with its restrictive mode.
+	if file.Owner != "" {
+		cmd := fmt.Sprintf("chown -- %s %s", shellQuote(file.Owner), shellQuote(file.Path))
+		if output, err := runner.ExecOutput(cmd, execOpts...); err != nil {
+			return fmt.Errorf("failed to set owner %q on %s: %w (output: %s)", file.Owner, file.Path, err, output)
+		}
+	}
+
+	p.log.Info("uploaded file", "path", file.Path, "permissions", perms, "owner", file.Owner)
 	return nil
 }

--- a/internal/controller/infrastructure/ssh_provisioner_test.go
+++ b/internal/controller/infrastructure/ssh_provisioner_test.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/k0sproject/rig/exec"
+	"github.com/k0sproject/rig/pkg/rigfs"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/k0sproject/k0smotron/v2/api/infrastructure/v1beta2"
+	"github.com/k0sproject/k0smotron/v2/internal/provisioner"
+)
+
+// fakeFile records what was written to it.
+type fakeFile struct {
+	buf bytes.Buffer
+}
+
+func (f *fakeFile) Write(p []byte) (int, error)           { return f.buf.Write(p) }
+func (f *fakeFile) Read(_ []byte) (int, error)            { return 0, io.EOF }
+func (f *fakeFile) Close() error                          { return nil }
+func (f *fakeFile) Stat() (fs.FileInfo, error)            { return fakeInfo{name: "file"}, nil }
+func (f *fakeFile) Seek(_ int64, _ int) (int64, error)    { return 0, nil }
+func (f *fakeFile) CopyFrom(src io.Reader) (int64, error) { return io.Copy(&f.buf, src) }
+func (f *fakeFile) CopyTo(dst io.Writer) (int64, error)   { return io.Copy(dst, &f.buf) }
+
+// fakeInfo stands in for a real FileInfo so the fakes never hand back a nil
+// one, which the io/fs contract forbids.
+type fakeInfo struct {
+	name string
+}
+
+func (i fakeInfo) Name() string       { return i.name }
+func (i fakeInfo) Size() int64        { return 0 }
+func (i fakeInfo) Mode() fs.FileMode  { return 0o755 | fs.ModeDir }
+func (i fakeInfo) ModTime() time.Time { return time.Time{} }
+func (i fakeInfo) IsDir() bool        { return true }
+func (i fakeInfo) Sys() any           { return nil }
+
+// fakeFsys is the smallest rigfs.Fsys that uploadFile exercises.
+type fakeFsys struct {
+	file      *fakeFile
+	openFlag  int
+	openPerm  fs.FileMode
+	openPath  string
+	mkdirPath string
+	mkdirPerm fs.FileMode
+	dirExists bool
+}
+
+func (f *fakeFsys) OpenFile(path string, flag int, perm fs.FileMode) (rigfs.File, error) {
+	f.openPath, f.openFlag, f.openPerm = path, flag, perm
+	f.file = &fakeFile{}
+	return f.file, nil
+}
+
+func (f *fakeFsys) MkDirAll(path string, perm fs.FileMode) error {
+	f.mkdirPath, f.mkdirPerm = path, perm
+	return nil
+}
+
+func (f *fakeFsys) Stat(name string) (fs.FileInfo, error) {
+	if f.dirExists {
+		return fakeInfo{name: name}, nil
+	}
+	return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+}
+
+func (f *fakeFsys) Open(_ string) (fs.File, error)  { return nil, nil }
+func (f *fakeFsys) Sha256(_ string) (string, error) { return "", nil }
+func (f *fakeFsys) Remove(_ string) error           { return nil }
+func (f *fakeFsys) RemoveAll(_ string) error        { return nil }
+
+// fakeRunner records the commands uploadFile asks the host to run, how many
+// exec options came with them, and what the file looked like at that moment.
+type fakeRunner struct {
+	fsys       *fakeFsys
+	cmds       []string
+	optCounts  []int
+	bodyAtExec []string
+	err        error
+}
+
+func (r *fakeRunner) ExecOutput(cmd string, opts ...exec.Option) (string, error) {
+	r.cmds = append(r.cmds, cmd)
+	r.optCounts = append(r.optCounts, len(opts))
+
+	body := ""
+	if r.fsys != nil && r.fsys.file != nil {
+		body = r.fsys.file.buf.String()
+	}
+	r.bodyAtExec = append(r.bodyAtExec, body)
+
+	return "", r.err
+}
+
+func newProvisioner() *SSHProvisioner {
+	return &SSHProvisioner{log: logr.Discard()}
+}
+
+func TestUploadFileWritesDecodedContent(t *testing.T) {
+	fsys, runner := &fakeFsys{}, &fakeRunner{}
+
+	err := newProvisioner().uploadFile(runner, nil, fsys, provisioner.File{
+		Path:        "/etc/thing",
+		Content:     base64.StdEncoding.EncodeToString([]byte("secret body")),
+		Encoding:    provisioner.Base64,
+		Permissions: "0600",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "secret body", fsys.file.buf.String(), "content must be decoded before it is written")
+	require.Equal(t, "/etc/thing", fsys.openPath)
+	require.Equal(t, fs.FileMode(0o600), fsys.openPerm)
+	require.Empty(t, runner.cmds, "no owner means no chown")
+}
+
+func TestUploadFileTruncates(t *testing.T) {
+	fsys := &fakeFsys{}
+
+	err := newProvisioner().uploadFile(&fakeRunner{}, nil, fsys, provisioner.File{
+		Path: "/etc/thing", Content: "body", Permissions: "0644",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fsys.openFlag)
+	require.Zero(t, fsys.openFlag&os.O_APPEND)
+}
+
+func TestUploadFileRejectsAppend(t *testing.T) {
+	fsys, runner := &fakeFsys{}, &fakeRunner{}
+
+	err := newProvisioner().uploadFile(runner, nil, fsys, provisioner.File{
+		Path: "/etc/thing", Content: "body", Permissions: "0644", Append: true,
+	})
+
+	require.ErrorContains(t, err, "not supported when provisioning over ssh")
+	require.Nil(t, fsys.file, "nothing should be written when the file is rejected")
+	require.Empty(t, runner.cmds)
+}
+
+// TestUploadFileCreatesDirectoryTraversable covers the edge case where a
+// restrictive file mode would have left the parent directory unusable.
+func TestUploadFileCreatesDirectoryTraversable(t *testing.T) {
+	// Reusing the file mode gave a directory with no execute bit for modes
+	// like 0600, so the owner of the file could not reach it.
+	for _, permissions := range []string{"", "0600", "0400", "0640", "0644", "0700", "0755"} {
+		fsys := &fakeFsys{}
+
+		err := newProvisioner().uploadFile(&fakeRunner{}, nil, fsys, provisioner.File{
+			Path: "/var/lib/k0s/thing", Content: "body", Permissions: permissions,
+		})
+		require.NoError(t, err, "permissions %q", permissions)
+
+		require.Equal(t, "/var/lib/k0s", fsys.mkdirPath, "permissions %q", permissions)
+		require.Equal(t, fs.FileMode(0o755), fsys.mkdirPerm,
+			"the directory mode must not follow the file mode %q", permissions)
+
+		// The file itself still gets exactly what was asked for.
+		want := fs.FileMode(0o644)
+		if permissions != "" {
+			parsed, err := provisioner.File{Permissions: permissions}.PermissionsAsInt()
+			require.NoError(t, err)
+			want = fs.FileMode(parsed)
+		}
+		require.Equal(t, want, fsys.openPerm, "file mode for permissions %q", permissions)
+	}
+}
+
+func TestUploadFileChownsQuotedAndAfterTheWrite(t *testing.T) {
+	fsys := &fakeFsys{}
+	runner := &fakeRunner{fsys: fsys}
+
+	err := newProvisioner().uploadFile(runner, nil, fsys, provisioner.File{
+		Path: "/etc/thing", Content: "body", Permissions: "0640", Owner: "etcd:etcd",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"chown -- 'etcd:etcd' '/etc/thing'"}, runner.cmds)
+
+	// rig creates the file on open, so a chown before the write would target a
+	// path that does not exist yet.
+	require.Equal(t, []string{"body"}, runner.bodyAtExec,
+		"the content must already be written when the chown runs")
+}
+
+func TestUploadFileSkipsMkdirWhenParentExists(t *testing.T) {
+	fsys := &fakeFsys{dirExists: true}
+
+	err := newProvisioner().uploadFile(&fakeRunner{}, nil, fsys, provisioner.File{
+		Path: "/etc/thing", Content: "body", Permissions: "0644",
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, fsys.mkdirPath, "an existing parent must not be recreated")
+}
+
+func TestUploadFileChownInheritsExecOptions(t *testing.T) {
+	// Without these the chown runs unprivileged on every machine that asked
+	// for sudo.
+	fsys := &fakeFsys{}
+	runner := &fakeRunner{fsys: fsys}
+	execOpts := []exec.Option{exec.HideOutput()}
+
+	err := newProvisioner().uploadFile(runner, execOpts, fsys, provisioner.File{
+		Path: "/etc/thing", Content: "body", Permissions: "0644", Owner: "nobody",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []int{len(execOpts)}, runner.optCounts)
+}
+
+func TestUploadFileChownQuotingResistsInjection(t *testing.T) {
+	// The webhook rejects these, but the objects it does not cover reach here,
+	// so the quoting has to hold on its own.
+	for _, owner := range []string{"root; rm -rf /", "$(id -u)", "a'b", "root\nid"} {
+		runner := &fakeRunner{}
+
+		err := newProvisioner().uploadFile(runner, nil, &fakeFsys{}, provisioner.File{
+			Path: "/etc/thing", Content: "body", Permissions: "0644", Owner: owner,
+		})
+		require.NoError(t, err)
+		require.Len(t, runner.cmds, 1)
+
+		quoted := shellQuote(owner)
+		require.Equal(t, "chown -- "+quoted+" '/etc/thing'", runner.cmds[0])
+
+		// The payload is still present, but inert. What matters is that it is
+		// wrapped and that every embedded quote is escaped.
+		require.True(t, strings.HasPrefix(quoted, "'"))
+		require.True(t, strings.HasSuffix(quoted, "'"))
+		inner := strings.ReplaceAll(quoted[1:len(quoted)-1], `'\''`, "")
+		require.NotContains(t, inner, "'", "a bare quote would end the wrapper early")
+	}
+}
+
+func TestUploadFileSurfacesChownFailure(t *testing.T) {
+	runner := &fakeRunner{err: errors.New("operation not permitted")}
+
+	err := newProvisioner().uploadFile(runner, nil, &fakeFsys{}, provisioner.File{
+		Path: "/etc/thing", Content: "body", Permissions: "0644", Owner: "nobody",
+	})
+
+	require.ErrorContains(t, err, "failed to set owner")
+	require.ErrorContains(t, err, "nobody")
+}
+
+func TestUploadFileRejectsUndecodableContent(t *testing.T) {
+	fsys := &fakeFsys{}
+
+	err := newProvisioner().uploadFile(&fakeRunner{}, nil, fsys, provisioner.File{
+		Path: "/etc/thing", Content: "!!!", Encoding: provisioner.Base64, Permissions: "0644",
+	})
+
+	require.ErrorContains(t, err, "failed to base64 decode")
+	require.Nil(t, fsys.file, "nothing should be written when content cannot be decoded")
+}
+
+func TestShellQuote(t *testing.T) {
+	for in, want := range map[string]string{
+		"etcd":           `'etcd'`,
+		"etcd:etcd":      `'etcd:etcd'`,
+		"a'b":            `'a'\''b'`,
+		"root; rm -rf /": `'root; rm -rf /'`,
+		"$(id)":          `'$(id)'`,
+	} {
+		require.Equal(t, want, shellQuote(in), "quoting %q", in)
+	}
+}
+
+func TestExtractCloudInitDecodesAndChowns(t *testing.T) {
+	p := &JobProvisioner{
+		remoteMachine: &api.RemoteMachine{Spec: api.RemoteMachineSpec{Address: "host", User: "root"}},
+		provisionJob: &api.ProvisionJob{
+			SSHCommand:  "ssh",
+			SCPCommand:  "scp",
+			JobTemplate: &batchv1.JobTemplateSpec{ObjectMeta: metav1.ObjectMeta{Name: "job"}},
+		},
+	}
+
+	_, _, secretData, err := p.extractCloudInit(&provisioner.InputProvisionData{
+		Files: []provisioner.File{{
+			Path:        "/etc/thing",
+			Content:     base64.StdEncoding.EncodeToString([]byte("decoded body")),
+			Encoding:    provisioner.Base64,
+			Permissions: "0640",
+			Owner:       "etcd:etcd",
+		}},
+	})
+	require.NoError(t, err)
+
+	var staged string
+	for name, data := range secretData {
+		if name != "k0smotron-entrypoint.sh" {
+			staged = string(data)
+		}
+	}
+	require.Equal(t, "decoded body", staged, "content must be decoded before it is staged")
+
+	script := string(secretData["k0smotron-entrypoint.sh"])
+	// The job entrypoint is a shell script, so both must be quoted.
+	require.Contains(t, script, "chown -- 'etcd:etcd' '/etc/thing'")
+	require.Contains(t, script, "chmod '0640' '/etc/thing'")
+}
+
+func TestExtractCloudInitQuotesOwnerAgainstInjection(t *testing.T) {
+	p := &JobProvisioner{
+		remoteMachine: &api.RemoteMachine{Spec: api.RemoteMachineSpec{Address: "host", User: "root"}},
+		provisionJob: &api.ProvisionJob{
+			SSHCommand:  "ssh",
+			SCPCommand:  "scp",
+			JobTemplate: &batchv1.JobTemplateSpec{ObjectMeta: metav1.ObjectMeta{Name: "job"}},
+		},
+	}
+
+	_, _, secretData, err := p.extractCloudInit(&provisioner.InputProvisionData{
+		Files: []provisioner.File{{Path: "/etc/thing", Content: "body", Owner: "root; rm -rf /"}},
+	})
+	require.NoError(t, err)
+
+	script := string(secretData["k0smotron-entrypoint.sh"])
+	require.Contains(t, script, "chown -- "+shellQuote("root; rm -rf /"))
+	require.NotContains(t, script, "chown -- root; rm")
+}
+
+func TestExtractCloudInitUsesSudoWhenRequested(t *testing.T) {
+	// Giving a file to another user needs privilege, the same way the commands
+	// in the same script get it.
+	for _, useSudo := range []bool{false, true} {
+		p := &JobProvisioner{
+			remoteMachine: &api.RemoteMachine{Spec: api.RemoteMachineSpec{Address: "host", User: "root", UseSudo: useSudo}},
+			provisionJob: &api.ProvisionJob{
+				SSHCommand:  "ssh",
+				SCPCommand:  "scp",
+				JobTemplate: &batchv1.JobTemplateSpec{ObjectMeta: metav1.ObjectMeta{Name: "job"}},
+			},
+		}
+
+		_, _, secretData, err := p.extractCloudInit(&provisioner.InputProvisionData{
+			Files: []provisioner.File{{Path: "/etc/thing", Content: "body", Permissions: "0640", Owner: "etcd:etcd"}},
+		})
+		require.NoError(t, err)
+
+		script := string(secretData["k0smotron-entrypoint.sh"])
+		if useSudo {
+			require.Contains(t, script, "ssh root@host sudo chown -- 'etcd:etcd'")
+			require.Contains(t, script, "ssh root@host sudo chmod '0640'")
+		} else {
+			require.Contains(t, script, "ssh root@host chown -- 'etcd:etcd'")
+			require.NotContains(t, script, "sudo chown")
+		}
+	}
+}
+
+func TestExtractCloudInitRejectsAppend(t *testing.T) {
+	p := &JobProvisioner{
+		remoteMachine: &api.RemoteMachine{Spec: api.RemoteMachineSpec{Address: "host", User: "root"}},
+		provisionJob: &api.ProvisionJob{
+			SSHCommand:  "ssh",
+			SCPCommand:  "scp",
+			JobTemplate: &batchv1.JobTemplateSpec{ObjectMeta: metav1.ObjectMeta{Name: "job"}},
+		},
+	}
+
+	_, _, _, err := p.extractCloudInit(&provisioner.InputProvisionData{
+		Files: []provisioner.File{{Path: "/etc/thing", Content: "body", Append: true}},
+	})
+
+	require.ErrorContains(t, err, "not supported when provisioning through a job")
+}

--- a/internal/provisioner/cloudinit.go
+++ b/internal/provisioner/cloudinit.go
@@ -109,10 +109,31 @@ func writeFilesVars(b *bytes.Buffer, files []File) {
 	}
 	b.WriteString("{% set k0smotron_files = [\n")
 	for i, f := range files {
+		// The optional keys are omitted when unset, so a file using none of
+		// them renders exactly as it did before they existed.
+		entries := [][2]string{
+			{"path", strconv.Quote(f.Path)},
+			{"content", strconv.Quote(f.Content)},
+			{"permissions", strconv.Quote(f.Permissions)},
+		}
+		if f.Owner != "" {
+			entries = append(entries, [2]string{"owner", strconv.Quote(f.Owner)})
+		}
+		if f.Encoding != "" {
+			entries = append(entries, [2]string{"encoding", strconv.Quote(string(f.Encoding))})
+		}
+		if f.Append {
+			entries = append(entries, [2]string{"append", strconv.FormatBool(f.Append)})
+		}
+
 		b.WriteString("  {\n")
-		b.WriteString(fmt.Sprintf("    \"path\": \"%s\",\n", f.Path))
-		b.WriteString(fmt.Sprintf("    \"content\": \"%s\",\n", escapeNewlines(f.Content)))
-		b.WriteString(fmt.Sprintf("    \"permissions\": \"%s\"\n", f.Permissions))
+		for j, e := range entries {
+			sep := ","
+			if j == len(entries)-1 {
+				sep = ""
+			}
+			fmt.Fprintf(b, "    %q: %s%s\n", e[0], e[1], sep)
+		}
 		if i < len(files)-1 {
 			b.WriteString("  },\n")
 		} else {
@@ -120,8 +141,4 @@ func writeFilesVars(b *bytes.Buffer, files []File) {
 		}
 	}
 	b.WriteString("] %}\n")
-}
-
-func escapeNewlines(s string) string {
-	return fmt.Sprintf("%q", s)[1 : len(fmt.Sprintf("%q", s))-1]
 }

--- a/internal/provisioner/cloudinit_test.go
+++ b/internal/provisioner/cloudinit_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package provisioner
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/k0sproject/k0smotron/v2/internal/featuregate"
 )
@@ -98,7 +100,7 @@ runcmd:
 }
 
 func TestCustomCloudInitWithVars(t *testing.T) {
-	featuregate.Configure("CloudInitVars=true", "")
+	withCloudInitVars(t, true)
 
 	input := &InputProvisionData{
 		Files: []File{
@@ -151,4 +153,91 @@ func TestPermissions(t *testing.T) {
 	perm, err := f.PermissionsAsInt()
 	assert.NoError(t, err)
 	assert.Equal(t, int64(420), perm)
+}
+
+// withCloudInitVars sets the gate for one test and puts it back afterwards.
+func withCloudInitVars(t *testing.T, enabled bool) {
+	t.Helper()
+
+	before := featuregate.IsEnabled(featuregate.CloudInitVars)
+	t.Cleanup(func() {
+		_ = featuregate.Configure(fmt.Sprintf("CloudInitVars=%t", before), "")
+	})
+
+	require.NoError(t, featuregate.Configure(fmt.Sprintf("CloudInitVars=%t", enabled), ""))
+}
+
+func TestCloudInitPassesFileOwnerEncodingAndAppendThrough(t *testing.T) {
+	// cloud init decodes and applies these itself, so they must reach
+	// write_files verbatim rather than being interpreted here.
+	withCloudInitVars(t, false)
+
+	input := &InputProvisionData{
+		Files: []File{
+			{
+				Path:        "/etc/hosts",
+				Content:     "Zm9vYmFy",
+				Permissions: "0600",
+				Owner:       "root:root",
+				Encoding:    Base64,
+				Append:      true,
+			},
+		},
+	}
+
+	b, err := (&CloudInitProvisioner{}).ToProvisionData(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, `## template: jinja
+#cloud-config
+write_files:
+  - path: /etc/hosts
+    content: Zm9vYmFy
+    permissions: "0600"
+    owner: root:root
+    encoding: base64
+    append: true
+runcmd: []
+`, string(b))
+}
+
+func TestCloudInitVarsOmitsUnsetFileFields(t *testing.T) {
+	withCloudInitVars(t, true)
+
+	input := &InputProvisionData{
+		Files: []File{
+			// Multi line content guards against the body being escaped twice,
+			// which would reach the host as a literal backslash n.
+			{Path: "/a", Content: "line1\nline2\n", Permissions: "0644"},
+			{Path: "/b", Content: "Zm9v", Permissions: "0600", Owner: "etcd:etcd", Encoding: Base64, Append: true},
+		},
+		Vars: map[VarName]string{"v": "1"},
+	}
+
+	b, err := (&CloudInitProvisioner{}).ToProvisionData(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, `## template: jinja
+#cloud-config
+{% set v = '1' %}
+{% set k0smotron_files = [
+  {
+    "path": "/a",
+    "content": "line1\nline2\n",
+    "permissions": "0644"
+  },
+  {
+    "path": "/b",
+    "content": "Zm9v",
+    "permissions": "0600",
+    "owner": "etcd:etcd",
+    "encoding": "base64",
+    "append": true
+  }
+] %}
+`, string(b))
 }

--- a/internal/provisioner/file_test.go
+++ b/internal/provisioner/file_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodedContent(t *testing.T) {
+	const plain = "hello\nworld\n"
+
+	t.Run("no encoding is verbatim", func(t *testing.T) {
+		got, err := File{Content: plain}.DecodedContent()
+		require.NoError(t, err)
+		assert.Equal(t, plain, string(got))
+	})
+
+	t.Run("base64", func(t *testing.T) {
+		got, err := File{Content: base64.StdEncoding.EncodeToString([]byte(plain)), Encoding: Base64}.DecodedContent()
+		require.NoError(t, err)
+		assert.Equal(t, plain, string(got))
+	})
+
+	t.Run("base64 tolerates wrapped whitespace", func(t *testing.T) {
+		enc := base64.StdEncoding.EncodeToString([]byte(plain))
+		got, err := File{Content: enc[:4] + "\n  " + enc[4:], Encoding: Base64}.DecodedContent()
+		require.NoError(t, err)
+		assert.Equal(t, plain, string(got))
+	})
+
+	t.Run("binary payload survives base64", func(t *testing.T) {
+		raw := []byte{0x00, 0xff, 0x1b, 0x7f, 0x0a}
+		got, err := File{Content: base64.StdEncoding.EncodeToString(raw), Encoding: Base64}.DecodedContent()
+		require.NoError(t, err)
+		assert.Equal(t, raw, got)
+	})
+
+	t.Run("decoding never grows the input", func(t *testing.T) {
+		// This is why no size cap is needed. Anything base64 can express is
+		// smaller than the field that carried it.
+		raw := make([]byte, 4096)
+		enc := base64.StdEncoding.EncodeToString(raw)
+
+		got, err := File{Content: enc, Encoding: Base64}.DecodedContent()
+		require.NoError(t, err)
+		require.Less(t, len(got), len(enc))
+	})
+
+	t.Run("invalid base64 errors", func(t *testing.T) {
+		_, err := File{Path: "/tmp/x", Content: "!!!not base64!!!", Encoding: Base64}.DecodedContent()
+		require.ErrorContains(t, err, "failed to base64 decode")
+	})
+
+	t.Run("gzip is not an accepted encoding", func(t *testing.T) {
+		// Decoding gzip would mean expanding untrusted input in the controller,
+		// so it is rejected rather than supported.
+		for _, enc := range []Encoding{"gzip", "gzip+base64"} {
+			_, err := File{Path: "/etc/thing", Content: "x", Encoding: enc}.DecodedContent()
+			require.ErrorContains(t, err, "unsupported encoding")
+		}
+	})
+
+	t.Run("unknown encoding errors and names the file", func(t *testing.T) {
+		_, err := File{Path: "/etc/thing", Content: "x", Encoding: Encoding("rot13")}.DecodedContent()
+		require.ErrorContains(t, err, `unsupported encoding "rot13"`)
+		require.ErrorContains(t, err, "/etc/thing")
+	})
+}
+
+func TestOwnerUserAndGroup(t *testing.T) {
+	for _, tc := range []struct {
+		owner, user, group string
+	}{
+		{"", "", ""},
+		{"root", "root", ""},
+		{"root:root", "root", "root"},
+		{"etcd:etcd", "etcd", "etcd"},
+	} {
+		u, g := File{Owner: tc.owner}.OwnerUserAndGroup()
+		assert.Equal(t, tc.user, u, "user for owner %q", tc.owner)
+		assert.Equal(t, tc.group, g, "group for owner %q", tc.owner)
+	}
+}

--- a/internal/provisioner/ignition.go
+++ b/internal/provisioner/ignition.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"text/template"
 
+	butaneutil "github.com/coreos/butane/base/util"
 	"github.com/coreos/butane/config"
 	bcommon "github.com/coreos/butane/config/common"
 	"gopkg.in/yaml.v3"
@@ -58,11 +59,47 @@ func (i *IgnitionProvisioner) ToProvisionData(input *InputProvisionData) ([]byte
 		if err != nil {
 			return nil, err
 		}
-		files = append(files, map[string]any{
-			"path":     f.Path,
-			"contents": map[string]string{"inline": f.Content},
-			"mode":     int(mi),
-		})
+
+		// Ignition has no notion of a content encoding, so decode here rather
+		// than passing it along the way cloud init does.
+		content, err := f.DecodedContent()
+		if err != nil {
+			return nil, err
+		}
+
+		file := map[string]any{
+			"path": f.Path,
+			"mode": int(mi),
+		}
+
+		// An Ignition file entry carries either contents or append, never both.
+		// Append is new, so it can use a data URL, which holds any byte.
+		if f.Append {
+			uri, compression, err := butaneutil.MakeDataURL(content, nil, false)
+			if err != nil {
+				return nil, fmt.Errorf("error encoding contents of file %s: %w", f.Path, err)
+			}
+
+			body := map[string]string{"source": uri}
+			if compression != nil {
+				body["compression"] = *compression
+			}
+
+			file["append"] = []map[string]string{body}
+		} else {
+			file["contents"] = map[string]string{"inline": string(content)}
+		}
+
+		if user, group := f.OwnerUserAndGroup(); user != "" || group != "" {
+			if user != "" {
+				file["user"] = map[string]string{"name": user}
+			}
+			if group != "" {
+				file["group"] = map[string]string{"name": group}
+			}
+		}
+
+		files = append(files, file)
 	}
 
 	units := []map[string]any{}

--- a/internal/provisioner/ignition_test.go
+++ b/internal/provisioner/ignition_test.go
@@ -17,10 +17,13 @@ package provisioner
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vincent-petithory/dataurl"
 )
 
 func normalizeJSON(t *testing.T, in []byte) []byte {
@@ -313,4 +316,172 @@ systemd: [invalid_yaml_here`,
 			}
 		})
 	}
+}
+
+// decodeFirstMergeSource returns the inner Ignition config embedded as the
+// first merge source, so assertions can read as JSON rather than base64.
+func decodeFirstMergeSource(t *testing.T, out []byte) []byte {
+	t.Helper()
+
+	var outer struct {
+		Ignition struct {
+			Config struct {
+				Merge []struct {
+					Source string `json:"source"`
+				} `json:"merge"`
+			} `json:"config"`
+		} `json:"ignition"`
+	}
+	require.NoError(t, json.Unmarshal(out, &outer))
+	require.NotEmpty(t, outer.Ignition.Config.Merge)
+
+	const prefix = "data:application/json;base64,"
+	src := outer.Ignition.Config.Merge[0].Source
+	require.True(t, strings.HasPrefix(src, prefix), "unexpected merge source %q", src)
+
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(src, prefix))
+	require.NoError(t, err)
+	return raw
+}
+
+// fileEntry pulls a single storage.files entry out of the config that
+// ToProvisionData embeds as its first merge source.
+func fileEntry(t *testing.T, out []byte) map[string]any {
+	t.Helper()
+
+	var inner struct {
+		Storage struct {
+			Files []map[string]any `json:"files"`
+		} `json:"storage"`
+	}
+	require.NoError(t, json.Unmarshal(decodeFirstMergeSource(t, out), &inner))
+	require.Len(t, inner.Storage.Files, 1)
+	return inner.Storage.Files[0]
+}
+
+// bodyBytes decodes the data URL that carries a file body, so a test can assert
+// on the bytes the node would actually write.
+func bodyBytes(t *testing.T, resource map[string]any) []byte {
+	t.Helper()
+
+	src, ok := resource["source"].(string)
+	require.True(t, ok, "resource has no source: %v", resource)
+
+	decoded, err := dataurl.DecodeString(src)
+	require.NoError(t, err)
+	return decoded.Data
+}
+
+func TestIgnitionFileOwnerAndAppend(t *testing.T) {
+	t.Run("owner becomes user and group", func(t *testing.T) {
+		out, err := (&IgnitionProvisioner{Variant: "fcos", Version: "1.5.0"}).ToProvisionData(
+			&InputProvisionData{Files: []File{{Path: "/a", Content: "x", Permissions: "0600", Owner: "etcd:etcd"}}})
+		require.NoError(t, err)
+
+		entry := fileEntry(t, out)
+		require.Equal(t, map[string]any{"name": "etcd"}, entry["user"])
+		require.Equal(t, map[string]any{"name": "etcd"}, entry["group"])
+	})
+
+	t.Run("owner without a group sets only user", func(t *testing.T) {
+		out, err := (&IgnitionProvisioner{Variant: "fcos", Version: "1.5.0"}).ToProvisionData(
+			&InputProvisionData{Files: []File{{Path: "/a", Content: "x", Permissions: "0644", Owner: "nobody"}}})
+		require.NoError(t, err)
+
+		entry := fileEntry(t, out)
+		require.Equal(t, map[string]any{"name": "nobody"}, entry["user"])
+		require.NotContains(t, entry, "group")
+	})
+
+	t.Run("append populates the append list and leaves contents unset", func(t *testing.T) {
+		out, err := (&IgnitionProvisioner{Variant: "fcos", Version: "1.5.0"}).ToProvisionData(
+			&InputProvisionData{Files: []File{{Path: "/a", Content: "tail\n", Permissions: "0644", Append: true}}})
+		require.NoError(t, err)
+
+		entry := fileEntry(t, out)
+		require.NotContains(t, entry, "contents")
+
+		list, ok := entry["append"].([]any)
+		require.True(t, ok, "append is not a list: %v", entry["append"])
+		require.Len(t, list, 1)
+		require.Equal(t, "tail\n", string(bodyBytes(t, list[0].(map[string]any))))
+	})
+}
+
+// TestIgnitionAppendContentRoundTrip guards the append path, which is new and
+// carries a data URL, so any byte sequence survives.
+func TestIgnitionAppendContentRoundTrip(t *testing.T) {
+	bodies := map[string]string{
+		"plain":                  "hello world",
+		"trailing newline":       "tail\n",
+		"leading newline":        "\nfoo\n",
+		"only a newline":         "\n",
+		"several newlines":       "\n\n\n",
+		"leading space":          " foo\n",
+		"leading tab":            "\thi\n",
+		"indented yaml fragment": "  extraArgs:\n    foo: bar\n",
+		"systemd drop in":        "\n[Service]\nEnvironment=FOO=bar\n",
+		"hosts comment block":    "\n# added by k0smotron\n10.0.0.1 api\n",
+		"non ascii":              "café München\n",
+		"carriage return":        "a\r\nb\n",
+		"nul and high bytes":     "\x00\xff\x1b",
+	}
+
+	for _, version := range []string{"1.0.0", "1.5.0"} {
+		for name, body := range bodies {
+			t.Run(version+" "+name, func(t *testing.T) {
+				out, err := (&IgnitionProvisioner{Variant: "fcos", Version: version}).ToProvisionData(
+					&InputProvisionData{Files: []File{{Path: "/a", Content: body, Permissions: "0644", Append: true}}})
+				require.NoError(t, err)
+
+				entry := fileEntry(t, out)
+				require.NotContains(t, entry, "contents")
+
+				list, ok := entry["append"].([]any)
+				require.True(t, ok, "append is not a list")
+				require.Len(t, list, 1)
+				require.Equal(t, body, string(bodyBytes(t, list[0].(map[string]any))))
+			})
+		}
+	}
+}
+
+// TestIgnitionReplaceUsesInline pins the existing shape. Butane mangles content
+// whose first line starts with whitespace, which is tracked separately.
+func TestIgnitionReplaceUsesInline(t *testing.T) {
+	out, err := (&IgnitionProvisioner{Variant: "fcos", Version: "1.5.0"}).ToProvisionData(
+		&InputProvisionData{Files: []File{{Path: "/a", Content: "hello world", Permissions: "0644"}}})
+	require.NoError(t, err)
+
+	entry := fileEntry(t, out)
+	require.NotContains(t, entry, "append")
+
+	contents, ok := entry["contents"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "", contents["compression"], "butane sets an empty compression for inline bodies")
+	require.Equal(t, "hello world", string(bodyBytes(t, contents)))
+}
+
+func TestIgnitionEncodedContentIsDecodedOnce(t *testing.T) {
+	plain := "  indented: true\n"
+
+	for name, f := range map[string]File{
+		"base64": {Path: "/a", Permissions: "0644", Encoding: Base64, Content: base64.StdEncoding.EncodeToString([]byte(plain))},
+	} {
+		t.Run(name, func(t *testing.T) {
+			out, err := (&IgnitionProvisioner{Variant: "fcos", Version: "1.5.0"}).ToProvisionData(&InputProvisionData{Files: []File{f}})
+			require.NoError(t, err)
+
+			entry := fileEntry(t, out)
+			require.Equal(t, plain, string(bodyBytes(t, entry["contents"].(map[string]any))))
+		})
+	}
+}
+
+func TestIgnitionRejectsUndecodableContent(t *testing.T) {
+	p := &IgnitionProvisioner{Variant: "fcos", Version: "1.0.0"}
+	_, err := p.ToProvisionData(&InputProvisionData{
+		Files: []File{{Path: "/a", Content: "!!!", Permissions: "0644", Encoding: Base64}},
+	})
+	require.ErrorContains(t, err, "failed to base64 decode")
 }

--- a/internal/provisioner/powershell.go
+++ b/internal/provisioner/powershell.go
@@ -18,9 +18,11 @@ package provisioner
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 )
 
 // PowerShellProvisioner implements the Provisioner interface for cloud-init.
@@ -32,7 +34,9 @@ func (c *PowerShellProvisioner) ToProvisionData(input *InputProvisionData) ([]by
 
 	// ---- write_files ----
 	for _, f := range input.Files {
-		renderWriteFile(&b, f)
+		if err := renderWriteFile(&b, f); err != nil {
+			return nil, err
+		}
 	}
 
 	// ---- runcmd ----
@@ -61,18 +65,46 @@ func (c *PowerShellProvisioner) GetFormat() ProvisioningFormat {
 	return PowershellProvisioningFormat
 }
 
-func renderWriteFile(buf *bytes.Buffer, f File) {
+func renderWriteFile(buf *bytes.Buffer, f File) error {
 	dir := filepath.Dir(strings.Replace(f.Path, `\`, `/`, -1))
 
 	buf.WriteString("\n# --- write_file ---\n")
 
 	// Ensure directory exists
-	buf.WriteString(fmt.Sprintf(
+	fmt.Fprintf(buf,
 		"New-Item -ItemType Directory -Force -Path \"%s\" | Out-Null\n",
 		escapePS(dir),
-	))
+	)
 
-	content := normalizeNewlines(f.Content)
+	// PowerShell has no notion of a content encoding, so decode here.
+	decoded, err := f.DecodedContent()
+	if err != nil {
+		return err
+	}
+
+	// A here string cannot hold bytes outside UTF8, and it drops the newline
+	// before its terminator, so those two cases go through base64 instead.
+	if f.Append || !utf8.Valid(decoded) {
+		fmt.Fprintf(buf, "$bytes = [System.Convert]::FromBase64String(\"%s\")\n",
+			base64.StdEncoding.EncodeToString(decoded))
+
+		if f.Append {
+			fmt.Fprintf(buf, `$stream = [System.IO.File]::Open(
+  "%s",
+  [System.IO.FileMode]::Append
+)
+$stream.Write($bytes, 0, $bytes.Length)
+$stream.Close()`+"\n", escapePS(f.Path))
+
+			return nil
+		}
+
+		fmt.Fprintf(buf, "[System.IO.File]::WriteAllBytes(\"%s\", $bytes)\n", escapePS(f.Path))
+
+		return nil
+	}
+
+	content := normalizeNewlines(string(decoded))
 
 	// Here-string write
 	buf.WriteString("$file = @'\n")
@@ -81,11 +113,13 @@ func renderWriteFile(buf *bytes.Buffer, f File) {
 		buf.WriteString("\n")
 	}
 	buf.WriteString("'@\n")
-	buf.WriteString(fmt.Sprintf(`[System.IO.File]::WriteAllText(
+	fmt.Fprintf(buf, `[System.IO.File]::WriteAllText(
   "%s",
   $file.Trim(),
   [System.Text.Encoding]::ASCII
-)`+"\n", escapePS(f.Path)))
+)`+"\n", escapePS(f.Path))
+
+	return nil
 }
 
 func escapePS(s string) string {

--- a/internal/provisioner/powershell_test.go
+++ b/internal/provisioner/powershell_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"encoding/base64"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var psBytesRe = regexp.MustCompile(`FromBase64String\("([^"]*)"\)`)
+
+// psBody decodes the payload of a script that took the byte path.
+func psBody(t *testing.T, script string) []byte {
+	t.Helper()
+
+	m := psBytesRe.FindStringSubmatch(script)
+	require.Len(t, m, 2, "no base64 payload in script")
+
+	decoded, err := base64.StdEncoding.DecodeString(m[1])
+	require.NoError(t, err)
+	return decoded
+}
+
+func render(t *testing.T, f File) string {
+	t.Helper()
+
+	out, err := (&PowerShellProvisioner{}).ToProvisionData(&InputProvisionData{Files: []File{f}})
+	require.NoError(t, err)
+	return string(out)
+}
+
+// TestPowerShellKeepsHereStringForPlainContent pins the existing output, so a
+// config that worked before this change renders exactly as it did.
+func TestPowerShellKeepsHereStringForPlainContent(t *testing.T) {
+	s := render(t, File{Path: `C:\k\a.conf`, Content: "body", Permissions: "0644"})
+
+	require.Contains(t, s, "$file = @'\nbody\n'@")
+	require.Contains(t, s, "$file.Trim()")
+	require.Contains(t, s, "[System.Text.Encoding]::ASCII")
+	require.NotContains(t, s, "FromBase64String")
+}
+
+func TestPowerShellDecodesBeforeRendering(t *testing.T) {
+	s := render(t, File{
+		Path:     `C:\k\a.conf`,
+		Content:  base64.StdEncoding.EncodeToString([]byte("decoded body")),
+		Encoding: Base64,
+	})
+
+	require.Contains(t, s, "$file = @'\ndecoded body\n'@")
+}
+
+// TestPowerShellUsesBytesWhereAHereStringCannot covers the two cases a here
+// string cannot represent, neither of which an existing config can reach.
+func TestPowerShellUsesBytesWhereAHereStringCannot(t *testing.T) {
+	t.Run("content outside UTF8", func(t *testing.T) {
+		raw := []byte{0x00, 0xff, 0x1b}
+
+		s := render(t, File{
+			Path:     `C:\k\blob.bin`,
+			Content:  base64.StdEncoding.EncodeToString(raw),
+			Encoding: Base64,
+		})
+
+		require.Equal(t, raw, psBody(t, s))
+		require.Contains(t, s, "[System.IO.File]::WriteAllBytes(")
+		require.NotContains(t, s, "$file = @'")
+	})
+
+	t.Run("append keeps its bytes exactly", func(t *testing.T) {
+		// A here string drops the newline before its terminator, which would
+		// run consecutive appends together.
+		s := render(t, File{Path: `C:\k\a.conf`, Content: "\ntail\n", Append: true})
+
+		require.Equal(t, "\ntail\n", string(psBody(t, s)))
+		require.Contains(t, s, "[System.IO.FileMode]::Append")
+		require.NotContains(t, s, "$file.Trim()")
+	})
+}
+
+func TestPowerShellRejectsUndecodableContent(t *testing.T) {
+	_, err := (&PowerShellProvisioner{}).ToProvisionData(&InputProvisionData{
+		Files: []File{{Path: `C:\k\x`, Content: "!!!", Encoding: Base64}},
+	})
+	require.ErrorContains(t, err, "failed to base64 decode")
+	require.ErrorContains(t, err, `C:\k\x`)
+}

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package provisioner
 
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
 // ProvisioningFormat represents the format used for provisioning.
 type ProvisioningFormat string
 
@@ -38,11 +44,63 @@ type InputProvisionData struct {
 	Vars           map[VarName]string `yaml:"-"`
 }
 
+// Encoding specifies the encoding of a file's content.
+// +kubebuilder:validation:Enum=base64
+type Encoding string
+
+const (
+	// Base64 implies the contents of the file are base64 encoded.
+	Base64 Encoding = "base64"
+)
+
 // File represents a file to be created on the target system.
 type File struct {
 	Path        string `yaml:"path" json:"path,omitempty"`
 	Content     string `yaml:"content" json:"content,omitempty"`
 	Permissions string `yaml:"permissions" json:"permissions,omitempty"`
+	// Owner sets file ownership as a user name and an optional group name
+	// separated by a colon. Empty means the file is owned by root.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxLength=256
+	Owner string `yaml:"owner,omitempty" json:"owner,omitempty"`
+	// Encoding specifies how Content is encoded. When empty Content is used
+	// verbatim. Use it to carry bytes that a plain string cannot hold.
+	// +kubebuilder:validation:Optional
+	Encoding Encoding `yaml:"encoding,omitempty" json:"encoding,omitempty"`
+	// Append specifies whether Content is appended to an existing file rather
+	// than replacing it. If the file does not exist it is created either way.
+	// +kubebuilder:validation:Optional
+	Append bool `yaml:"append,omitempty" json:"append,omitempty"`
+}
+
+// OwnerUserAndGroup splits Owner into user and group parts. Group is empty
+// when Owner has no colon separator.
+func (f File) OwnerUserAndGroup() (user, group string) {
+	user, group, _ = strings.Cut(f.Owner, ":")
+	return user, group
+}
+
+func decodeBase64(content, path string) ([]byte, error) {
+	// Tolerate whitespace that survives a round trip through YAML block
+	// scalars and Secret data.
+	b, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(content), ""))
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64 decode content of file %s: %w", path, err)
+	}
+	return b, nil
+}
+
+// DecodedContent returns Content with Encoding reversed. Provisioners whose
+// format has no encoding concept must use this instead of reading Content.
+func (f File) DecodedContent() ([]byte, error) {
+	switch f.Encoding {
+	case "":
+		return []byte(f.Content), nil
+	case Base64:
+		return decodeBase64(f.Content, f.Path)
+	default:
+		return nil, fmt.Errorf("unsupported encoding %q for file %s", f.Encoding, f.Path)
+	}
 }
 
 // Provisioner is the interface that wraps the method for converting input data

--- a/inttest/capi-remote-machine/capi_remote_machine_test.go
+++ b/inttest/capi-remote-machine/capi_remote_machine_test.go
@@ -26,6 +26,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -44,6 +45,15 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+// The bootstrap config declares one file exercising the fields k0smotron has to
+// apply itself on this path rather than hand to cloud init.
+const (
+	testFilePath        = "/etc/k0smotron-file-test.conf"
+	testFileContent     = "owner and encoding work\n"
+	testFileOwner       = "test:test"
+	testFilePermissions = "0640"
 )
 
 type RemoteMachineSuite struct {
@@ -173,6 +183,8 @@ func (s *RemoteMachineSuite) TestCAPIRemoteMachine() {
 	})
 	s.Require().NoError(err)
 
+	s.verifyUploadedFile()
+
 	s.T().Log("deleting node from cluster")
 	s.Require().NoError(s.deleteRemoteMachine("remote-test-0", "default"))
 
@@ -230,13 +242,21 @@ func (s *RemoteMachineSuite) createCluster() {
 	var clusterYamlBuf bytes.Buffer
 
 	err = t.Execute(&clusterYamlBuf, struct {
-		Address    string
-		SSHKey     string
-		K0SVersion string
+		Address         string
+		SSHKey          string
+		K0SVersion      string
+		FilePath        string
+		FileContent     string
+		FileOwner       string
+		FilePermissions string
 	}{
-		Address:    workerIP,
-		SSHKey:     base64.StdEncoding.EncodeToString(s.privateKey),
-		K0SVersion: k0sVersion,
+		Address:         workerIP,
+		SSHKey:          base64.StdEncoding.EncodeToString(s.privateKey),
+		K0SVersion:      k0sVersion,
+		FilePath:        testFilePath,
+		FileContent:     base64.StdEncoding.EncodeToString([]byte(testFileContent)),
+		FileOwner:       testFileOwner,
+		FilePermissions: testFilePermissions,
 	})
 	s.Require().NoError(err)
 	bytes := clusterYamlBuf.Bytes()
@@ -254,14 +274,38 @@ func (s *RemoteMachineSuite) createCluster() {
 }
 
 func (s *RemoteMachineSuite) getWorkerIP() string {
+	return s.execOnWorker("hostname -i")
+}
+
+func (s *RemoteMachineSuite) execOnWorker(cmd string) string {
 	nodeName := s.K0smotronNode(0)
 	ssh, err := s.SSH(s.Context(), nodeName)
 	s.Require().NoError(err)
 	defer ssh.Disconnect()
 
-	ipAddress, err := ssh.ExecWithOutput(s.Context(), "hostname -i")
+	out, err := ssh.ExecWithOutput(s.Context(), cmd)
 	s.Require().NoError(err)
-	return ipAddress
+	return out
+}
+
+// verifyUploadedFile checks the attributes k0smotron applies over ssh itself.
+// The unit tests only assert the command it builds, not the result on disk.
+func (s *RemoteMachineSuite) verifyUploadedFile() {
+	s.T().Log("verifying the uploaded file was decoded and given the declared owner")
+
+	// Compare an encoded form, since ExecWithOutput trims. Fold it too, because
+	// base64 line wraps differently between implementations.
+	encoded := s.execOnWorker("sudo base64 " + testFilePath)
+	s.Require().Equal(
+		base64.StdEncoding.EncodeToString([]byte(testFileContent)),
+		strings.Join(strings.Fields(encoded), ""),
+		"content must be base64 decoded before it is written, byte for byte")
+
+	ownership := s.execOnWorker("sudo stat -c '%U:%G' " + testFilePath)
+	s.Require().Equal(testFileOwner, ownership, "owner must be applied by chown")
+
+	mode := s.execOnWorker("sudo stat -c '%a' " + testFilePath)
+	s.Require().Equal("640", mode, "permissions must be applied")
 }
 
 var clusterYaml = `apiVersion: cluster.x-k8s.io/v1beta1
@@ -330,6 +374,12 @@ metadata:
   namespace: default
 spec:
   version: {{ .K0SVersion }}+k0s.0
+  files:
+  - path: {{ .FilePath }}
+    permissions: "{{ .FilePermissions }}"
+    owner: {{ .FileOwner }}
+    encoding: base64
+    content: {{ .FileContent }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: RemoteMachine

--- a/inttest/capi-remote-machine/manifest_test.go
+++ b/inttest/capi-remote-machine/manifest_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capiremotemachine
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	bootstrap "github.com/k0sproject/k0smotron/v2/api/bootstrap/v1beta1"
+	"github.com/k0sproject/k0smotron/v2/inttest/util"
+)
+
+// TestClusterManifestDeclaresFile renders the suite manifest without needing a
+// host. It is also the only cover for the json tags on the new fields.
+func TestClusterManifestDeclaresFile(t *testing.T) {
+	tpl, err := template.New("cluster").Parse(clusterYaml)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, tpl.Execute(&buf, struct {
+		Address, SSHKey, K0SVersion, FilePath, FileContent, FileOwner, FilePermissions string
+	}{
+		Address:         "10.0.0.1",
+		SSHKey:          "a2V5",
+		K0SVersion:      "v1.30.2",
+		FilePath:        testFilePath,
+		FileContent:     base64.StdEncoding.EncodeToString([]byte(testFileContent)),
+		FileOwner:       testFileOwner,
+		FilePermissions: testFilePermissions,
+	}))
+
+	// Every document must parse, which catches indentation mistakes.
+	resources, err := util.ParseManifests(buf.Bytes())
+	require.NoError(t, err)
+	require.NotEmpty(t, resources)
+
+	// And the file must land on the bootstrap config with the fields intact.
+	var found bool
+	for _, r := range resources {
+		if r.GetKind() != "K0sWorkerConfig" {
+			continue
+		}
+		raw, err := r.MarshalJSON()
+		require.NoError(t, err)
+
+		var cfg bootstrap.K0sWorkerConfig
+		require.NoError(t, yaml.Unmarshal(raw, &cfg))
+		require.Len(t, cfg.Spec.Files, 1)
+
+		f := cfg.Spec.Files[0]
+		require.Equal(t, testFilePath, f.Path)
+		require.Equal(t, testFileOwner, f.Owner)
+		require.Equal(t, testFilePermissions, f.Permissions)
+		require.EqualValues(t, "base64", f.Encoding)
+
+		decoded, err := f.DecodedContent()
+		require.NoError(t, err)
+		require.Equal(t, testFileContent, string(decoded))
+		found = true
+	}
+	require.True(t, found, "no K0sWorkerConfig in the rendered manifest")
+}


### PR DESCRIPTION
Adds three fields to bootstrap files (mirrors `kubeadm`): `owner`, `encoding` and `append`, `encoding` only takes base64.

cloud-init and Ignition use all three. Powershell cannot set an owner, so it
rejects it. RemoteMachine cannot append, so it rejects that.

Additional bug fixes: directories are made 0755 instead of copying the file mode, powershell no longer breaks content that is not UTF-8, and paths are escaped in the CloudInitVars block.