### PR TITLE
Fix/assorted controller bugs

### DIFF
--- a/api/bootstrap/v1beta1/conditions_consts.go
+++ b/api/bootstrap/v1beta1/conditions_consts.go
@@ -42,7 +42,7 @@ const (
 	// waiting for the infrastructure to be initialized.
 	//
 	// NOTE: This is a pre-condition for starting to create controller machines.
-	WaitingForInfrastructureInitializationReason = "WaitingForControlPlaneInitialization"
+	WaitingForInfrastructureInitializationReason = "WaitingForInfrastructureInitialization"
 
 	// InternalErrorReason documents a BootstrapConfig controller detecting
 	// an internal error while processing the BootstrapConfig.

--- a/api/bootstrap/v1beta2/conditions_consts.go
+++ b/api/bootstrap/v1beta2/conditions_consts.go
@@ -42,7 +42,7 @@ const (
 	// waiting for the infrastructure to be initialized.
 	//
 	// NOTE: This is a pre-condition for starting to create controller machines.
-	WaitingForInfrastructureInitializationReason = "WaitingForControlPlaneInitialization"
+	WaitingForInfrastructureInitializationReason = "WaitingForInfrastructureInitialization"
 
 	// InternalErrorReason documents a BootstrapConfig controller detecting
 	// an internal error while processing the BootstrapConfig.

--- a/api/bootstrap/v1beta2/conditions_consts_test.go
+++ b/api/bootstrap/v1beta2/conditions_consts_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWaitingReasonsAreDistinct pins the two values apart. They were the same
+// string, so anything asserting on either one passed for the wrong reason.
+func TestWaitingReasonsAreDistinct(t *testing.T) {
+	require.Equal(t, "WaitingForControlPlaneInitialization", WaitingForControlPlaneInitializationReason)
+	require.Equal(t, "WaitingForInfrastructureInitialization", WaitingForInfrastructureInitializationReason)
+	require.NotEqual(t, WaitingForControlPlaneInitializationReason, WaitingForInfrastructureInitializationReason,
+		"a config blocked on the infrastructure has to be tellable from one blocked on the control plane")
+}

--- a/api/infrastructure/v1beta2/remotecluster_types.go
+++ b/api/infrastructure/v1beta2/remotecluster_types.go
@@ -25,6 +25,13 @@ import (
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 
+const (
+	// RemoteClusterReadyCondition is the condition type that indicates whether the RemoteCluster is ready.
+	RemoteClusterReadyCondition = "Ready"
+	// RemoteClusterReadyReason is the reason used when the RemoteCluster is ready.
+	RemoteClusterReadyReason = "Ready"
+)
+
 func init() {
 	SchemeBuilder.Register(&RemoteCluster{}, &RemoteClusterList{})
 }

--- a/internal/controller/controlplane/remediation.go
+++ b/internal/controller/controlplane/remediation.go
@@ -105,13 +105,15 @@ func (c *K0sController) reconcileUnhealthyMachines(ctx context.Context, scope *c
 		}
 
 		// The cluster MUST have no machines with a deletion timestamp. This rule prevents KCP taking actions while the cluster is in a transitional state.
-		if len(scope.activeMachines.Filter(collections.HasDeletionTimestamp)) > 0 {
+		// activeMachines is built with collections.ActiveMachines, the exact negation
+		// of this filter, so asking it for deleting machines never matched.
+		if scope.deletedMachines.Len() > 0 {
 			log.Info("A control plane machine needs remediation, but there are other control-plane machines being deleted. Skipping remediation")
 			conditions.Set(machineToBeRemediated, metav1.Condition{
 				Type:    string(clusterv1.MachineOwnerRemediatedCondition),
 				Status:  metav1.ConditionFalse,
 				Reason:  clusterv1.MachineOwnerRemediatedWaitingForRemediationReason,
-				Message: "KCP waiting for control plane machine provisioning to complete before triggering remediation",
+				Message: "KCP waiting for control plane machine deletion to complete before triggering remediation",
 			})
 			return nil
 		}

--- a/internal/controller/controlplane/remediation_test.go
+++ b/internal/controller/controlplane/remediation_test.go
@@ -1,0 +1,153 @@
+//go:build !envtest
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	cpv1beta2 "github.com/k0sproject/k0smotron/v2/api/controlplane/v1beta2"
+	"github.com/stretchr/testify/require"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/collections"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func remediationMachine(name string, healthy bool, deleting bool) *clusterv1.Machine {
+	m := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status:     clusterv1.MachineStatus{NodeRef: clusterv1.MachineNodeReference{Name: name}},
+	}
+
+	if healthy {
+		conditions.Set(m, metav1.Condition{
+			Type:               clusterv1.MachineHealthCheckSucceededCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             clusterv1.MachineHealthCheckSucceededReason,
+			LastTransitionTime: metav1.Now(),
+		})
+	} else {
+		// Both conditions false is what marks a machine as needing the owner to
+		// remediate it.
+		for _, t := range []string{clusterv1.MachineHealthCheckSucceededCondition, clusterv1.MachineOwnerRemediatedCondition} {
+			conditions.Set(m, metav1.Condition{
+				Type:               t,
+				Status:             metav1.ConditionFalse,
+				Reason:             clusterv1.MachineHealthCheckHasRemediateAnnotationReason,
+				LastTransitionTime: metav1.Now(),
+			})
+		}
+	}
+
+	if deleting {
+		m.DeletionTimestamp = new(metav1.NewTime(time.Unix(1, 0)))
+		m.Finalizers = []string{"test"}
+	}
+
+	return m
+}
+
+// TestReconcileUnhealthyMachinesWaitsForDeletions covers the guard that holds
+// remediation back while another control plane machine is going away.
+func TestReconcileUnhealthyMachinesWaitsForDeletions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, cpv1beta2.AddToScheme(scheme))
+
+	unhealthy := remediationMachine("cp-0", false, false)
+	healthy := remediationMachine("cp-1", true, false)
+	goingAway := remediationMachine("cp-2", true, true)
+
+	kcp := &cpv1beta2.K0sControlPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "kcp", Namespace: "default"},
+	}
+	kcp.Status.Initialization.ControlPlaneInitialized = new(true)
+
+	scope := &controlplane{
+		cluster:        &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"}},
+		kcp:            kcp,
+		activeMachines: collections.FromMachines(unhealthy, healthy),
+		// retrieveControlPlaneState splits these two sets by deletion timestamp, so
+		// a deleting machine only ever appears here.
+		deletedMachines: collections.FromMachines(goingAway),
+	}
+
+	require.Empty(t, scope.activeMachines.Filter(collections.HasDeletionTimestamp),
+		"the fixture must mirror production, where active machines are never deleting")
+
+	c := &K0sController{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(unhealthy, healthy, kcp).
+			WithStatusSubresource(unhealthy, healthy, kcp).Build(),
+	}
+
+	require.NoError(t, c.reconcileUnhealthyMachines(context.Background(), scope))
+
+	require.NotContains(t, scope.kcp.Annotations, cpv1beta2.RemediationInProgressAnnotation,
+		"remediation must not start while another control plane machine is being deleted")
+
+	got := conditions.Get(unhealthy, string(clusterv1.MachineOwnerRemediatedCondition))
+	require.NotNil(t, got)
+	require.Equal(t, metav1.ConditionFalse, got.Status)
+	require.Contains(t, got.Message, "deletion")
+}
+
+// TestReconcileUnhealthyMachinesRemediatesWhenNothingIsDeleting is the other
+// direction, since a guard that always fires would also pass the test above.
+func TestReconcileUnhealthyMachinesRemediatesWhenNothingIsDeleting(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, cpv1beta2.AddToScheme(scheme))
+
+	unhealthy := remediationMachine("cp-0", false, false)
+	healthy := remediationMachine("cp-1", true, false)
+
+	kcp := &cpv1beta2.K0sControlPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "kcp", Namespace: "default"},
+	}
+	kcp.Status.Initialization.ControlPlaneInitialized = new(true)
+
+	scope := &controlplane{
+		cluster:         &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"}},
+		kcp:             kcp,
+		activeMachines:  collections.FromMachines(unhealthy, healthy),
+		deletedMachines: collections.Machines{},
+	}
+
+	c := &K0sController{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(unhealthy, healthy, kcp).
+			WithStatusSubresource(unhealthy, healthy, kcp).Build(),
+	}
+
+	require.NoError(t, c.reconcileUnhealthyMachines(context.Background(), scope))
+
+	require.Contains(t, scope.kcp.Annotations, cpv1beta2.RemediationInProgressAnnotation,
+		"with nothing being deleted the unhealthy machine has to be remediated")
+
+	err := c.Get(context.Background(), client.ObjectKeyFromObject(unhealthy), &clusterv1.Machine{})
+	require.True(t, apierrors.IsNotFound(err), "the unhealthy machine should have been deleted")
+}

--- a/internal/controller/controlplane/scale.go
+++ b/internal/controller/controlplane/scale.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/failuredomains"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -186,6 +187,16 @@ func calculateMaxSurge(scope *controlplane) int {
 	return int(scope.kcp.Spec.Replicas) + 1
 }
 
+// nextFailureDomain picks the failure domain for a new control plane machine.
+// A deleting machine still occupies one, so it counts toward the total.
+func nextFailureDomain(ctx context.Context, scope *controlplane) string {
+	allMachines := collections.FromMachines(append(scope.activeMachines.UnsortedList(), scope.deletedMachines.UnsortedList()...)...)
+
+	// The last argument is the priority signal, which upstream fills with the up
+	// to date machines so a rollout spreads them evenly.
+	return failuredomains.PickFewest(ctx, filterControlPlaneFailureDomains(*scope.cluster), allMachines, scope.upToDateMachines)
+}
+
 func (c *K0sController) scaleUp(ctx context.Context, scope *controlplane) error {
 	logger := log.FromContext(ctx)
 	newMachineName := names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", scope.kcp.Name))
@@ -201,7 +212,7 @@ func (c *K0sController) scaleUp(ctx context.Context, scope *controlplane) error 
 		APIGroup: clusterv1.GroupVersionInfrastructure.Group,
 	}
 
-	selectedFailureDomain := failuredomains.PickFewest(ctx, filterControlPlaneFailureDomains(*scope.cluster), scope.activeMachines, scope.deletedMachines)
+	selectedFailureDomain := nextFailureDomain(ctx, scope)
 
 	logger.Info("Creating new control plane machine", "name", newMachineName, "failureDomain", selectedFailureDomain)
 

--- a/internal/controller/controlplane/scale_test.go
+++ b/internal/controller/controlplane/scale_test.go
@@ -1,0 +1,159 @@
+//go:build !envtest
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/require"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/collections"
+)
+
+func failureDomainMachine(name, domain string) *clusterv1.Machine {
+	return &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       clusterv1.MachineSpec{FailureDomain: domain},
+	}
+}
+
+// TestNextFailureDomain covers where a new control plane machine is placed. The
+// signal that matters is how the up to date machines are spread.
+func TestNextFailureDomain(t *testing.T) {
+	clusterWithDomains := func(names ...string) *clusterv1.Cluster {
+		cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"}}
+		for _, name := range names {
+			cluster.Status.FailureDomains = append(cluster.Status.FailureDomains,
+				clusterv1.FailureDomain{Name: name, ControlPlane: new(true)})
+		}
+
+		return cluster
+	}
+
+	t.Run("an empty control plane can go anywhere", func(t *testing.T) {
+		scope := &controlplane{
+			cluster:          clusterWithDomains("fd-a"),
+			activeMachines:   collections.Machines{},
+			deletedMachines:  collections.Machines{},
+			upToDateMachines: collections.Machines{},
+		}
+
+		require.Equal(t, "fd-a", nextFailureDomain(context.Background(), scope))
+	})
+
+	t.Run("no failure domains means no choice to make", func(t *testing.T) {
+		scope := &controlplane{
+			cluster:          &clusterv1.Cluster{},
+			activeMachines:   collections.Machines{},
+			deletedMachines:  collections.Machines{},
+			upToDateMachines: collections.Machines{},
+		}
+
+		require.Empty(t, nextFailureDomain(context.Background(), scope))
+	})
+
+	// A domain holding only a machine on its way out has no up to date machine, so
+	// it is where the replacement belongs.
+	t.Run("a domain losing its machine is preferred over one already up to date", func(t *testing.T) {
+		upToDate := failureDomainMachine("cp-a", "fd-a")
+		goingAway := failureDomainMachine("cp-b", "fd-b")
+
+		scope := &controlplane{
+			cluster:          clusterWithDomains("fd-a", "fd-b"),
+			activeMachines:   collections.FromMachines(upToDate),
+			deletedMachines:  collections.FromMachines(goingAway),
+			upToDateMachines: collections.FromMachines(upToDate),
+		}
+
+		require.Equal(t, "fd-b", nextFailureDomain(context.Background(), scope),
+			"counting deleting machines as the priority signal would pick fd-a here")
+	})
+
+	// This one pins the machine total rather than the spread, since a domain is
+	// still occupied until its machine is really gone.
+	t.Run("machines on their way out still occupy their domain", func(t *testing.T) {
+		leaving := failureDomainMachine("cp-a", "fd-a")
+		alsoLeaving := failureDomainMachine("cp-b", "fd-a")
+		outdated := failureDomainMachine("cp-c", "fd-b")
+
+		scope := &controlplane{
+			cluster:          clusterWithDomains("fd-a", "fd-b"),
+			activeMachines:   collections.FromMachines(outdated),
+			deletedMachines:  collections.FromMachines(leaving, alsoLeaving),
+			upToDateMachines: collections.Machines{},
+		}
+
+		require.Equal(t, "fd-b", nextFailureDomain(context.Background(), scope),
+			"counting only the active machines would pick fd-a and put a third machine there")
+	})
+
+	// Guards against the two collections being passed the other way round, which
+	// the helper cannot detect for us.
+	t.Run("the spread signal is not the machine total", func(t *testing.T) {
+		outdatedOne := failureDomainMachine("cp-a", "fd-a")
+		outdatedTwo := failureDomainMachine("cp-b", "fd-a")
+		current := failureDomainMachine("cp-c", "fd-b")
+
+		scope := &controlplane{
+			cluster:          clusterWithDomains("fd-a", "fd-b"),
+			activeMachines:   collections.FromMachines(outdatedOne, outdatedTwo, current),
+			deletedMachines:  collections.Machines{},
+			upToDateMachines: collections.FromMachines(current),
+		}
+
+		require.Equal(t, "fd-a", nextFailureDomain(context.Background(), scope),
+			"fd-a holds no up to date machine, so the next one belongs there")
+	})
+
+	// Worker only domains are not eligible, however empty they look.
+	t.Run("a domain that is not for control planes is never chosen", func(t *testing.T) {
+		occupied := failureDomainMachine("cp-a", "fd-a")
+
+		cluster := clusterWithDomains("fd-a")
+		cluster.Status.FailureDomains = append(cluster.Status.FailureDomains,
+			clusterv1.FailureDomain{Name: "fd-workers", ControlPlane: new(false)})
+
+		scope := &controlplane{
+			cluster:          cluster,
+			activeMachines:   collections.FromMachines(occupied),
+			deletedMachines:  collections.Machines{},
+			upToDateMachines: collections.FromMachines(occupied),
+		}
+
+		require.Equal(t, "fd-a", nextFailureDomain(context.Background(), scope),
+			"skipping the control plane filter would pick the emptier worker domain")
+	})
+
+	t.Run("with the same spread the emptier domain wins", func(t *testing.T) {
+		first := failureDomainMachine("cp-a", "fd-a")
+		second := failureDomainMachine("cp-b", "fd-a")
+
+		scope := &controlplane{
+			cluster:          clusterWithDomains("fd-a", "fd-b"),
+			activeMachines:   collections.FromMachines(first, second),
+			deletedMachines:  collections.Machines{},
+			upToDateMachines: collections.Machines{},
+		}
+
+		require.Equal(t, "fd-b", nextFailureDomain(context.Background(), scope))
+	})
+}

--- a/internal/controller/infrastructure/cluster_controller.go
+++ b/internal/controller/infrastructure/cluster_controller.go
@@ -60,9 +60,9 @@ func (r *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (re
 	if c.ObjectMeta.DeletionTimestamp.IsZero() {
 		c.Status.Initialization.Provisioned = new(true)
 		conditions.Set(c, metav1.Condition{
-			Type:   "Ready",
+			Type:   infrastructure.RemoteClusterReadyCondition,
 			Status: metav1.ConditionTrue,
-			Reason: "Ready",
+			Reason: infrastructure.RemoteClusterReadyReason,
 		})
 		if err := r.Status().Update(ctx, c); err != nil {
 			log.Error(err, "Failed to update RemoteCluster status")

--- a/internal/controller/infrastructure/remote_machine_controller.go
+++ b/internal/controller/infrastructure/remote_machine_controller.go
@@ -333,6 +333,22 @@ func (r *RemoteMachineController) Reconcile(ctx context.Context, req ctrl.Reques
 	return ctrl.Result{}, nil
 }
 
+// mergedMap copies src over dst and allocates dst when it is nil, since copying
+// into a nil map panics.
+func mergedMap(dst, src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return dst
+	}
+
+	if dst == nil {
+		dst = make(map[string]string, len(src))
+	}
+
+	maps.Copy(dst, src)
+
+	return dst
+}
+
 // reservePooledMachineAndPopulateRemoteMachine finds a free machine from the pool specified in the RemoteMachine spec, reserves it, and populates
 // the RemoteMachine spec with the details of the reserved machine.
 func (r *RemoteMachineController) reservePooledMachineAndPopulateRemoteMachine(ctx context.Context, rm *infrastructure.RemoteMachine) error {
@@ -381,8 +397,8 @@ func (r *RemoteMachineController) reservePooledMachineAndPopulateRemoteMachine(c
 		}
 	}
 
-	maps.Copy(rm.Labels, foundPooledMachine.Labels)
-	maps.Copy(rm.Annotations, foundPooledMachine.Annotations)
+	rm.Labels = mergedMap(rm.Labels, foundPooledMachine.Labels)
+	rm.Annotations = mergedMap(rm.Annotations, foundPooledMachine.Annotations)
 	rm.Spec.Address = foundPooledMachine.Spec.Machine.Address
 	rm.Spec.Port = foundPooledMachine.Spec.Machine.Port
 	rm.Spec.User = foundPooledMachine.Spec.Machine.User

--- a/internal/controller/infrastructure/remote_machine_controller_test.go
+++ b/internal/controller/infrastructure/remote_machine_controller_test.go
@@ -1,0 +1,121 @@
+//go:build !envtest
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrastructure "github.com/k0sproject/k0smotron/v2/api/infrastructure/v1beta2"
+)
+
+// TestMergedMap covers a RemoteMachine authored without labels or annotations,
+// which is the standalone path where the destination map is nil.
+func TestMergedMap(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		dst  map[string]string
+		src  map[string]string
+		want map[string]string
+	}{
+		{
+			name: "a nil destination takes the source instead of panicking",
+			src:  map[string]string{"a": "1"},
+			want: map[string]string{"a": "1"},
+		},
+		{
+			name: "nothing to copy leaves a nil destination alone",
+			want: nil,
+		},
+		{
+			name: "nothing to copy leaves an existing destination alone",
+			dst:  map[string]string{"a": "1"},
+			want: map[string]string{"a": "1"},
+		},
+		{
+			name: "the source wins on a shared key",
+			dst:  map[string]string{"a": "1", "b": "2"},
+			src:  map[string]string{"a": "9"},
+			want: map[string]string{"a": "9", "b": "2"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, mergedMap(tc.dst, tc.src))
+		})
+	}
+
+	t.Run("the result never shares storage with the source", func(t *testing.T) {
+		src := map[string]string{"a": "1"}
+
+		got := mergedMap(nil, src)
+		got["b"] = "2"
+
+		require.Equal(t, map[string]string{"a": "1"}, src,
+			"handing back the source would let a later write reach the pooled machine")
+	})
+}
+
+// TestReservePooledMachineCopiesMetadataOntoBareRemoteMachine covers a hand
+// authored RemoteMachine, which carries no labels or annotations to copy into.
+func TestReservePooledMachineCopiesMetadataOntoBareRemoteMachine(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, infrastructure.AddToScheme(scheme))
+
+	pooled := &infrastructure.PooledRemoteMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pooled",
+			Namespace:   "default",
+			Labels:      map[string]string{"pool": "a"},
+			Annotations: map[string]string{"note": "from the pool"},
+		},
+		Spec: infrastructure.PooledRemoteMachineSpec{
+			Pool: "a",
+			Machine: infrastructure.PooledMachineSpec{
+				Address: "10.0.0.1",
+				Port:    22,
+				User:    "root",
+			},
+		},
+	}
+
+	// A RemoteMachine created by hand rather than by CAPI, so both metadata maps
+	// are nil.
+	rm := &infrastructure.RemoteMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "rm", Namespace: "default"},
+		Spec:       infrastructure.RemoteMachineSpec{Pool: "a"},
+	}
+	require.Nil(t, rm.Labels, "the fixture must have no labels or this proves nothing")
+	require.Nil(t, rm.Annotations, "the fixture must have no annotations or this proves nothing")
+
+	c := &RemoteMachineController{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(pooled, rm).WithStatusSubresource(pooled).Build(),
+	}
+
+	require.NoError(t, c.reservePooledMachineAndPopulateRemoteMachine(context.Background(), rm))
+
+	require.Equal(t, "10.0.0.1", rm.Spec.Address)
+	require.Equal(t, map[string]string{"pool": "a"}, rm.Labels)
+	require.Equal(t, map[string]string{"note": "from the pool"}, rm.Annotations)
+}


### PR DESCRIPTION
Five unrelated small fixes, one commit each.

- nil map panic when reserving a pooled machine
- remediation deletion guard never fired
- new control plane machines placed by deletions, not by spread
- WaitingForInfrastructureInitialization held the control plane value
- RemoteCluster ready condition used inline literals