### PR TITLE
Pin the CAPI version in tests

### DIFF
--- a/.github/workflows/capi-smoke-tests.yml
+++ b/.github/workflows/capi-smoke-tests.yml
@@ -72,7 +72,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export CLUSTERCTL_REPOSITORY_PATH="$GITHUB_WORKSPACE"
-          CLUSTER_TOPOLOGY=true clusterctl init --control-plane k0sproject-k0smotron --bootstrap k0sproject-k0smotron --infrastructure k0sproject-k0smotron,docker --config ./hack/capi-ci/config.yaml --wait-providers
+          CLUSTER_TOPOLOGY=true clusterctl init --core cluster-api:v1.12.1 --control-plane k0sproject-k0smotron --bootstrap k0sproject-k0smotron --infrastructure k0sproject-k0smotron,docker:v1.12.1 --config ./hack/capi-ci/config.yaml --wait-providers
           kubectl wait --for=condition=available -n cert-manager deployment/cert-manager-webhook --timeout=300s
       - name: Install PVC provider
         run: |


### PR DESCRIPTION
Pin the CAPI version to the same version as the clusterctl binary and go.mod.  FIxes test failures like https://github.com/k0sproject/k0smotron/actions/runs/33166903414/job/99404441053