### PR TITLE
Fix unexpected controlplane rollout when etcd image is upgraded

### DIFF
--- a/api/k0smotron.io/v1beta2/k0smotroncluster_types.go
+++ b/api/k0smotron.io/v1beta2/k0smotroncluster_types.go
@@ -99,6 +99,10 @@ const (
 
 	// NotFoundReason surfaces when a resource is not found.
 	NotFoundReason = "NotFound"
+
+	// AnnotationKeyClusterSpecHash is the annotation key used to store the hash of the desired cluster specification. This
+	// is used to detect changes in the specification.
+	AnnotationKeyClusterSpecHash = "k0smotron.io/cluster-spec-hash"
 )
 
 // ClusterSpec defines the desired state of K0smotronCluster

--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -74,10 +74,6 @@ const (
 
 	// AnnotationValueManagedByK0smotron is the value for the managed-by annotation
 	AnnotationValueManagedByK0smotron = "k0smotron"
-
-	// AnnotationKeyClusterSpecHash is the annotation key used to store the hash of the desired cluster specification. This
-	// is used to detect changes in the specification.
-	AnnotationKeyClusterSpecHash = "k0smotron.io/cluster-spec-hash"
 )
 
 var currentSpec kapi.ClusterSpec
@@ -366,7 +362,7 @@ func (c *K0smotronController) reconcile(ctx context.Context, cluster *clusterv1.
 				clusterv1.ClusterNameLabel: cluster.Name,
 			},
 			Annotations: map[string]string{
-				AnnotationKeyClusterSpecHash: generateClusterSpecHashWithoutExternalAddress(kcp.Spec),
+				kapi.AnnotationKeyClusterSpecHash: generateClusterSpecHashWithoutExternalAddress(kcp.Spec),
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -410,7 +406,7 @@ func (c *K0smotronController) reconcile(ctx context.Context, cluster *clusterv1.
 		if foundCluster.Annotations == nil {
 			foundCluster.Annotations = make(map[string]string)
 		}
-		foundCluster.Annotations[AnnotationKeyClusterSpecHash] = kcpSpecHash
+		foundCluster.Annotations[kapi.AnnotationKeyClusterSpecHash] = kcpSpecHash
 
 		// Modidy current Cluster specification with the desired one.
 		foundCluster.Spec = kcp.Spec
@@ -427,7 +423,7 @@ func (c *K0smotronController) reconcile(ctx context.Context, cluster *clusterv1.
 func isClusterSpecSynced(kmc kapi.Cluster, kcpSpec kapi.ClusterSpec) (isSynced bool, kcpSpecHash string, err error) {
 	kcpSpecHash = generateClusterSpecHashWithoutExternalAddress(kcpSpec)
 	// Use the hash annotation if present, as it is the most reliable way to detect spec changes.
-	if clusterSpecHash, ok := kmc.GetAnnotations()[AnnotationKeyClusterSpecHash]; ok {
+	if clusterSpecHash, ok := kmc.GetAnnotations()[kapi.AnnotationKeyClusterSpecHash]; ok {
 		// Compare separately at the ExternalAddress because it is a field that is expected to be updated by the controller after the creation of the Cluster, so it is not
 		// included in the spec hash.
 		if kmc.Spec.ExternalAddress == kcpSpec.ExternalAddress {

--- a/internal/controller/controlplane/k0smotron_controlplane_controller_test.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller_test.go
@@ -94,7 +94,7 @@ func TestIsClusterSpecSynced(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test",
 			Annotations: map[string]string{
-				AnnotationKeyClusterSpecHash: "86c6b5f8df",
+				kapi.AnnotationKeyClusterSpecHash: "86c6b5f8df",
 			},
 		},
 	}
@@ -318,7 +318,7 @@ func TestIsClusterSpecSynced(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				if mode == withoutAnnotation {
-					delete(kmc.GetAnnotations(), AnnotationKeyClusterSpecHash)
+					delete(kmc.GetAnnotations(), kapi.AnnotationKeyClusterSpecHash)
 				}
 				tc.name = fmt.Sprintf("%s - %s", tc.name, mode)
 				kmc.Spec = tc.kmcSpec
@@ -326,7 +326,7 @@ func TestIsClusterSpecSynced(t *testing.T) {
 				require.NoError(t, err)
 				require.EqualValues(t, tc.expected, result)
 				if mode == withAnnotation {
-					require.EqualValues(t, tc.expected, kcpSpecHash == kmc.GetAnnotations()[AnnotationKeyClusterSpecHash])
+					require.EqualValues(t, tc.expected, kcpSpecHash == kmc.GetAnnotations()[kapi.AnnotationKeyClusterSpecHash])
 				}
 			})
 		}

--- a/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
+++ b/internal/controller/k0smotron.io/k0smotroncluster_statefulset.go
@@ -49,8 +49,8 @@ import (
 var entrypointDefaultMode = int32(0744)
 
 const (
-	clusterLabel          = "k0smotron.io/cluster"
-	statefulSetAnnotation = "k0smotron.io/statefulset-hash"
+	clusterLabel              = "k0smotron.io/cluster"
+	statefulSetHashAnnotation = "k0smotron.io/statefulset-hash"
 )
 
 var versionRegex = regexp.MustCompile(`v\d+.\d+.\d+-k0s.\d+`)
@@ -69,6 +69,9 @@ func (scope *kmcScope) generateStatefulSet(ctx context.Context, kmc *km.Cluster)
 	maps.Copy(labels, selectorLabels)
 	labels[util.ComponentLabel] = util.ComponentControlPlane
 	annotations := util.AnnotationsForK0smotronCluster(kmc)
+	// Remove the cluster spec hash annotation from the statefulset annotations, as it can contain data not related to the
+	// controlplane statefulset and can trigger unnecessary rollouts of it.
+	delete(annotations, km.AnnotationKeyClusterSpecHash)
 
 	statefulSet := apps.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
@@ -434,10 +437,10 @@ data:
 	annotationHash := controller.ComputeHash(&previewSts.Spec.Template, previewSts.Status.CollisionCount)
 
 	statefulSet.Annotations = map[string]string{
-		statefulSetAnnotation: annotationHash,
+		statefulSetHashAnnotation: annotationHash,
 	}
 	previewSts.Annotations = map[string]string{
-		statefulSetAnnotation: annotationHash,
+		statefulSetHashAnnotation: annotationHash,
 	}
 	maps.Copy(statefulSet.Annotations, annotations)
 	maps.Copy(previewSts.Annotations, annotations)
@@ -738,7 +741,7 @@ func detectAndSetCurrentClusterVersion(foundStatefulSet *apps.StatefulSet, kmc *
 }
 
 func isStatefulSetsEqual(newSts, oldSts *apps.StatefulSet) bool {
-	if newSts.Annotations[statefulSetAnnotation] != oldSts.Annotations[statefulSetAnnotation] {
+	if newSts.Annotations[statefulSetHashAnnotation] != oldSts.Annotations[statefulSetHashAnnotation] {
 		return false
 	}
 


### PR DESCRIPTION
An upgrade in etcd image should not trigger an upgrade for the controlplane pods. This bug is because the hash used to decide if the k0smotron cluster requires an update includes the etcd image reference.