### PR TITLE
Reject etcd upgrades that skip a minor version in the Cluster webhook

### DIFF
--- a/api/k0smotron.io/v1beta2/k0smotroncluster_webhook.go
+++ b/api/k0smotron.io/v1beta2/k0smotroncluster_webhook.go
@@ -79,44 +79,48 @@ func (c ClusterValidator) ValidateClusterSpecUpdate(oldKCS, kcs *ClusterSpec) (w
 
 	if (kcs.Storage.Type == "" || kcs.Storage.Type == StorageTypeEtcd) &&
 		oldKCS.Storage.Etcd.Image != kcs.Storage.Etcd.Image {
-		if err := validateEtcdVersionUpgrade(oldKCS.Storage.Etcd.Image, kcs.Storage.Etcd.Image); err != nil {
+		warn, err := validateEtcdVersionUpgrade(oldKCS.Storage.Etcd.Image, kcs.Storage.Etcd.Image)
+		warnings = append(warnings, warn...)
+		if err != nil {
 			return warnings, err
 		}
 	}
 
-	return c.ValidateClusterSpec(kcs)
+	specWarnings, err := c.ValidateClusterSpec(kcs)
+	warnings = append(warnings, specWarnings...)
+	return warnings, err
 }
 
 // validateEtcdVersionUpgrade rejects etcd upgrades that skip a minor version. etcd only
 // supports upgrading one minor version at a time; skipping one is likely to leave etcd
 // unable to start on its existing data (see https://etcd.io/docs/v3.6/upgrades/upgrading-etcd/).
 // If either image's tag cannot be parsed as a version (e.g. a custom image or a non-semver
-// tag), the check is skipped rather than blocking the update.
-func validateEtcdVersionUpgrade(oldImage, newImage string) error {
-	oldV, err := etcdImageVersion(oldImage)
+// tag), the check is skipped and a warning is returned instead of blocking the update.
+func validateEtcdVersionUpgrade(oldImage, newImage string) (admission.Warnings, error) {
+	oldV, err := imageVersion(oldImage)
 	if err != nil {
-		return nil
+		return admission.Warnings{fmt.Sprintf("could not determine etcd version from image %q, skipping etcd upgrade path validation", oldImage)}, nil
 	}
-	newV, err := etcdImageVersion(newImage)
+	newV, err := imageVersion(newImage)
 	if err != nil {
-		return nil
+		return admission.Warnings{fmt.Sprintf("could not determine etcd version from image %q, skipping etcd upgrade path validation", newImage)}, nil
 	}
 
 	if newV.LessThanOrEqual(oldV) {
-		return nil
+		return nil, nil
 	}
 
 	if newV.Core().Segments()[1]-oldV.Core().Segments()[1] > 1 {
-		return fmt.Errorf("upgrading etcd image from %q to %q is not allowed: etcd does not support skipping a minor "+
+		return nil, fmt.Errorf("upgrading etcd image from %q to %q is not allowed: etcd does not support skipping a minor "+
 			"version when upgrading, please upgrade to an intermediate version first", oldImage, newImage)
 	}
 
-	return nil
+	return nil, nil
 }
 
-// etcdImageVersion extracts the version from an etcd container image reference, e.g.
+// imageVersion extracts the version from a container image reference, e.g.
 // "quay.io/k0sproject/etcd:v3.7.1" returns the version "v3.7.1".
-func etcdImageVersion(image string) (*version.Version, error) {
+func imageVersion(image string) (*version.Version, error) {
 	ref := image
 	if idx := strings.LastIndex(ref, "/"); idx != -1 {
 		ref = ref[idx+1:]

--- a/api/k0smotron.io/v1beta2/k0smotroncluster_webhook.go
+++ b/api/k0smotron.io/v1beta2/k0smotroncluster_webhook.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/k0sproject/version"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -76,7 +77,57 @@ func (c ClusterValidator) ValidateClusterSpecUpdate(oldKCS, kcs *ClusterSpec) (w
 			kcs.Replicas)
 	}
 
+	if (kcs.Storage.Type == "" || kcs.Storage.Type == StorageTypeEtcd) &&
+		oldKCS.Storage.Etcd.Image != kcs.Storage.Etcd.Image {
+		if err := validateEtcdVersionUpgrade(oldKCS.Storage.Etcd.Image, kcs.Storage.Etcd.Image); err != nil {
+			return warnings, err
+		}
+	}
+
 	return c.ValidateClusterSpec(kcs)
+}
+
+// validateEtcdVersionUpgrade rejects etcd upgrades that skip a minor version. etcd only
+// supports upgrading one minor version at a time; skipping one is likely to leave etcd
+// unable to start on its existing data (see https://etcd.io/docs/v3.6/upgrades/upgrading-etcd/).
+// If either image's tag cannot be parsed as a version (e.g. a custom image or a non-semver
+// tag), the check is skipped rather than blocking the update.
+func validateEtcdVersionUpgrade(oldImage, newImage string) error {
+	oldV, err := etcdImageVersion(oldImage)
+	if err != nil {
+		return nil
+	}
+	newV, err := etcdImageVersion(newImage)
+	if err != nil {
+		return nil
+	}
+
+	if newV.LessThanOrEqual(oldV) {
+		return nil
+	}
+
+	if newV.Core().Segments()[1]-oldV.Core().Segments()[1] > 1 {
+		return fmt.Errorf("upgrading etcd image from %q to %q is not allowed: etcd does not support skipping a minor "+
+			"version when upgrading, please upgrade to an intermediate version first", oldImage, newImage)
+	}
+
+	return nil
+}
+
+// etcdImageVersion extracts the version from an etcd container image reference, e.g.
+// "quay.io/k0sproject/etcd:v3.7.1" returns the version "v3.7.1".
+func etcdImageVersion(image string) (*version.Version, error) {
+	ref := image
+	if idx := strings.LastIndex(ref, "/"); idx != -1 {
+		ref = ref[idx+1:]
+	}
+
+	_, tag, found := strings.Cut(ref, ":")
+	if !found {
+		return nil, fmt.Errorf("no tag found in image %q", image)
+	}
+
+	return version.NewVersion(tag)
 }
 
 // ValidateClusterSpec validates the ClusterSpec and returns any warnings or errors.

--- a/api/k0smotron.io/v1beta2/k0smotroncluster_webhook_test.go
+++ b/api/k0smotron.io/v1beta2/k0smotroncluster_webhook_test.go
@@ -61,10 +61,11 @@ func TestClusterValidator_validateVersionSuffix(t *testing.T) {
 
 func TestValidateEtcdVersionUpgrade(t *testing.T) {
 	tests := []struct {
-		name      string
-		oldImage  string
-		newImage  string
-		wantError bool
+		name        string
+		oldImage    string
+		newImage    string
+		wantError   bool
+		wantWarning bool
 	}{
 		{
 			name:     "same version",
@@ -93,28 +94,36 @@ func TestValidateEtcdVersionUpgrade(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name:     "unparsable old tag skips the check",
-			oldImage: "quay.io/k0sproject/etcd:latest",
-			newImage: "quay.io/k0sproject/etcd:v3.7.1",
+			name:        "unparsable old tag skips the check with a warning",
+			oldImage:    "quay.io/k0sproject/etcd:latest",
+			newImage:    "quay.io/k0sproject/etcd:v3.7.1",
+			wantWarning: true,
 		},
 		{
-			name:     "unparsable new tag skips the check",
-			oldImage: "quay.io/k0sproject/etcd:v3.5.13",
-			newImage: "quay.io/k0sproject/etcd:latest",
+			name:        "unparsable new tag skips the check with a warning",
+			oldImage:    "quay.io/k0sproject/etcd:v3.5.13",
+			newImage:    "quay.io/k0sproject/etcd:latest",
+			wantWarning: true,
 		},
 		{
-			name:     "custom image without a tag skips the check",
-			oldImage: "myregistry.example.com:5000/etcd",
-			newImage: "myregistry.example.com:5000/etcd",
+			name:        "custom image without a tag skips the check with a warning",
+			oldImage:    "myregistry.example.com:5000/etcd",
+			newImage:    "myregistry.example.com:5000/etcd",
+			wantWarning: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateEtcdVersionUpgrade(tt.oldImage, tt.newImage)
+			warnings, err := validateEtcdVersionUpgrade(tt.oldImage, tt.newImage)
 			if tt.wantError {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+			}
+			if tt.wantWarning {
+				require.NotEmpty(t, warnings)
+			} else {
+				require.Empty(t, warnings)
 			}
 		})
 	}

--- a/api/k0smotron.io/v1beta2/k0smotroncluster_webhook_test.go
+++ b/api/k0smotron.io/v1beta2/k0smotroncluster_webhook_test.go
@@ -58,3 +58,64 @@ func TestClusterValidator_validateVersionSuffix(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateEtcdVersionUpgrade(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldImage  string
+		newImage  string
+		wantError bool
+	}{
+		{
+			name:     "same version",
+			oldImage: "quay.io/k0sproject/etcd:v3.5.13",
+			newImage: "quay.io/k0sproject/etcd:v3.5.13",
+		},
+		{
+			name:     "one minor version upgrade",
+			oldImage: "quay.io/k0sproject/etcd:v3.5.13",
+			newImage: "quay.io/k0sproject/etcd:v3.6.0",
+		},
+		{
+			name:     "patch version upgrade",
+			oldImage: "quay.io/k0sproject/etcd:v3.5.13",
+			newImage: "quay.io/k0sproject/etcd:v3.5.14",
+		},
+		{
+			name:     "downgrade is not blocked by this check",
+			oldImage: "quay.io/k0sproject/etcd:v3.6.0",
+			newImage: "quay.io/k0sproject/etcd:v3.5.13",
+		},
+		{
+			name:      "skipping a minor version is rejected",
+			oldImage:  "quay.io/k0sproject/etcd:v3.5.13",
+			newImage:  "quay.io/k0sproject/etcd:v3.7.1",
+			wantError: true,
+		},
+		{
+			name:     "unparsable old tag skips the check",
+			oldImage: "quay.io/k0sproject/etcd:latest",
+			newImage: "quay.io/k0sproject/etcd:v3.7.1",
+		},
+		{
+			name:     "unparsable new tag skips the check",
+			oldImage: "quay.io/k0sproject/etcd:v3.5.13",
+			newImage: "quay.io/k0sproject/etcd:latest",
+		},
+		{
+			name:     "custom image without a tag skips the check",
+			oldImage: "myregistry.example.com:5000/etcd",
+			newImage: "myregistry.example.com:5000/etcd",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEtcdVersionUpgrade(tt.oldImage, tt.newImage)
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Motivation:
etcd only supports upgrading one minor version at a time; skipping a
minor version (e.g. 3.5 straight to 3.7) leaves etcd unable to read
its own data on startup and crash-loops. This was observed after a
k0smotron-hosted control plane was upgraded across an etcd minor-version
gap, per the report below.

Approach:
Add a check to ClusterValidator.ValidateClusterSpecUpdate, in
api/k0smotron.io/v1beta2/k0smotroncluster_webhook.go, that runs
whenever Storage.Etcd.Image changes on an etcd-backed cluster. It
extracts the version tag from the old and new etcd image references
and, using the same github.com/k0sproject/version helper already used
for the analogous k0s minor-version-skew check in
K0sControlPlaneValidator, rejects the update if the new minor version
is more than one greater than the old one. If either image tag can't
be parsed as a version (custom image, non-semver tag), the check is
skipped rather than blocking the update, since Storage.Etcd.Image is a
free-form image reference. This is a validating-webhook check only: it
prevents users from applying a bad spec update via k0smotron, it does
not touch etcd or a running control plane.

K0smotronControlPlaneValidator.ValidateUpdate delegates to this same
function, so hosted control planes managed through K0smotronControlPlane
are covered as well as the Cluster CRD directly.

Validation:
- go build ./api/... passes.
- go test ./api/k0smotron.io/v1beta2/... passes, including new test
  TestValidateEtcdVersionUpgrade covering: same version, one-minor
  upgrade, patch upgrade, downgrade (not blocked), skipping a minor
  version (rejected), and unparsable/missing tags (skipped).
- make test (full unit test suite) passes.
- golangci-lint run --config .golangci.yml ./api/k0smotron.io/v1beta2/...
  reports 0 issues.
- No CRD/type files changed, so no codegen diff is expected from
  make generate-all.
- Not run: envtest/e2e/smoke tests requiring a live cluster; this
  change is pure admission-webhook logic validated at the unit level.

Report: https://github.com/k0sproject/k0smotron/issues/1579
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #1579