### PR TITLE
Trust the cluster CA instead of skipping TLS verification in detectJoinHost

### DIFF
--- a/internal/controller/bootstrap/controlplane_bootstrap_controller.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller.go
@@ -19,6 +19,7 @@ package bootstrap
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -464,7 +465,7 @@ func (c *ControlPlaneController) genControlPlaneJoinFiles(ctx context.Context, s
 		return nil, err
 	}
 
-	host, err := c.detectJoinHost(ctx, scope, firstControllerMachine)
+	host, err := c.detectJoinHost(ctx, scope, firstControllerMachine, ca)
 	if err != nil {
 		log.Error(err, "Failed to detect join controller host")
 		return nil, err
@@ -671,11 +672,17 @@ func mergeControllerExtraArgs(scope *ControllerScope) []string {
 	return mergeExtraArgs(scope.installArgs, scope.ConfigOwner, scope.WorkerEnabled, scope.Config.Spec.UseSystemHostname)
 }
 
-func (c *ControlPlaneController) detectJoinHost(ctx context.Context, scope *ControllerScope, firstControllerMachine *clusterv1.Machine) (string, error) {
+func (c *ControlPlaneController) detectJoinHost(ctx context.Context, scope *ControllerScope, firstControllerMachine *clusterv1.Machine, ca *secret.Certificate) (string, error) {
+	caCertPool := x509.NewCertPool()
+	if ca == nil || ca.KeyPair == nil || !caCertPool.AppendCertsFromPEM(ca.KeyPair.Cert) {
+		return "", errors.New("failed to load cluster CA certificate for join host detection")
+	}
+
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tls.Config{
-		// Since we are using self-signed certificates, we need to skip the verification
-		InsecureSkipVerify: true,
+		// The join API serves a certificate signed by the cluster CA, so we
+		// trust it explicitly instead of skipping verification.
+		RootCAs: caCertPool,
 	}
 	httpClient := &http.Client{
 		Transport: transport,

--- a/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
@@ -19,14 +19,29 @@ limitations under the License.
 package bootstrap
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/k0sproject/k0smotron/v2/internal/controller/util"
 	"github.com/k0sproject/version"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	bsutil "sigs.k8s.io/cluster-api/bootstrap/util"
+	"sigs.k8s.io/cluster-api/util/certs"
+	"sigs.k8s.io/cluster-api/util/secret"
 
 	bootstrapv2 "github.com/k0sproject/k0smotron/v2/api/bootstrap/v1beta2"
 )
@@ -163,4 +178,96 @@ func TestController_genK0sCommands(t *testing.T) {
 			require.Equal(t, tt.want, commands)
 		})
 	}
+}
+
+func TestControlPlaneController_detectJoinHost(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	port, err := strconv.ParseInt(serverURL.Port(), 10, 64)
+	require.NoError(t, err)
+
+	trustedCACert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	untrustedCACert := selfSignedCertPEM(t)
+
+	scope := &ControllerScope{
+		Cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
+				ControlPlaneEndpoint: clusterv1.APIEndpoint{Host: serverURL.Hostname()},
+			},
+		},
+		Config: &bootstrapv2.K0sControllerConfig{
+			Spec: bootstrapv2.K0sControllerConfigSpec{
+				K0sConfigSpec: &bootstrapv2.K0sConfigSpec{
+					K0s: &unstructured.Unstructured{Object: map[string]any{
+						"spec": map[string]any{
+							"api": map[string]any{
+								"k0sApiPort": port,
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	firstControllerMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "first-controller"},
+		Status: clusterv1.MachineStatus{
+			Addresses: clusterv1.MachineAddresses{
+				{Type: clusterv1.MachineExternalIP, Address: "203.0.113.10"},
+			},
+		},
+	}
+
+	c := &ControlPlaneController{}
+
+	t.Run("trusted CA reaches the control plane endpoint", func(t *testing.T) {
+		ca := &secret.Certificate{KeyPair: &certs.KeyPair{Cert: trustedCACert}}
+
+		host, err := c.detectJoinHost(context.Background(), scope, firstControllerMachine, ca)
+
+		require.NoError(t, err)
+		require.Equal(t, server.URL, host)
+	})
+
+	t.Run("CA that did not sign the endpoint falls back to the first controller", func(t *testing.T) {
+		ca := &secret.Certificate{KeyPair: &certs.KeyPair{Cert: untrustedCACert}}
+
+		host, err := c.detectJoinHost(context.Background(), scope, firstControllerMachine, ca)
+
+		require.NoError(t, err)
+		require.Equal(t, "https://203.0.113.10:"+serverURL.Port(), host)
+	})
+
+	t.Run("missing CA is an error", func(t *testing.T) {
+		_, err := c.detectJoinHost(context.Background(), scope, firstControllerMachine, nil)
+
+		require.Error(t, err)
+	})
+}
+
+func selfSignedCertPEM(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "untrusted-test-ca"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }


### PR DESCRIPTION
Motivation:
detectJoinHost (internal/controller/bootstrap/controlplane_bootstrap_controller.go)
probes a newly-provisioned control-plane machine's k0s join API
(https://<control-plane-endpoint>:<port>/v1beta1/ca) to pick the host used to
build the join token, falling back to the first controller's IP if the probe
fails. The HTTP client set InsecureSkipVerify: true unconditionally, with no
way to opt out, so the probe never actually validated the server it was
talking to.

detectJoinHost is only called from genControlPlaneJoinFiles, which is used
when joining additional control-plane nodes to an already-initialized
cluster. By that point the function has already fetched the cluster CA via
getCerts (the same CA k0smotron writes to /var/lib/k0s/pki on every node),
and unconditionally dereferences ca.KeyPair.Cert a few lines later to build
the join token. k0s signs the join API's serving certificate (k0s-api) with
this same cluster CA, so it is the correct trust anchor for this probe.

This is a hardening change, not a fix for a demonstrated exploit: the probe
runs from the management cluster to a freshly-provisioned node, typically
over the private network CAPI infrastructure providers set up for
bootstrapping, which already limits who can sit on that path. Skipping
verification still meant the probe could not detect a mismatched or spoofed
endpoint, which is what this closes.

Approach:
- detectJoinHost now takes the cluster CA (*secret.Certificate) and builds
  an x509.CertPool from it, using RootCAs instead of InsecureSkipVerify.
  If the CA is missing or unparsable, it returns an error immediately
  instead of silently trusting an unverified endpoint. This does not
  introduce a new panic risk: the existing code already dereferences
  ca.KeyPair.Cert unconditionally later in the same call chain, so a nil
  KeyPair was already fatal to this code path before this change.
- The single call site in genControlPlaneJoinFiles passes the ca value it
  already had in scope.

Validation:
- go build ./... and go vet ./internal/controller/bootstrap/... pass.
- gofmt -l reports no formatting issues.
- golangci-lint run --config .golangci.yml ./internal/controller/bootstrap/...
  reports 0 issues.
- make test and make envtest (envtest run with real etcd/kube-apiserver
  binaries) both pass across the repo. Note: make envtest's bootstrap
  controller scenarios only exercise the single-machine
  genInitialControlPlaneFiles path, not genControlPlaneJoinFiles, so this
  does not directly exercise detectJoinHost; it only confirms no regression
  elsewhere in the package.
- Added TestControlPlaneController_detectJoinHost, a targeted unit test
  using an httptest.NewTLSServer: a CA pool containing the server's own
  certificate succeeds and returns the control-plane endpoint; a CA pool
  containing an unrelated certificate causes the probe to fail closed and
  fall back to the first controller's address; a nil CA returns an error.
  I confirmed this test is a genuine regression check by temporarily
  reverting just the TLS behavior back to InsecureSkipVerify (keeping the
  new function signature): the "falls back" subtest failed as expected
  (the probe wrongly succeeded against the wrong CA), then passed again
  once the fix was restored.

Report: https://github.com/k0sproject/k0smotron/issues/1582
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #1582