### PR TITLE
Probe Cluster API v1beta2 to gate CAPI controllers, not v1beta1

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -253,19 +254,13 @@ func main() {
 	}
 
 	// Absent CAPI Machine kind means we are not running in a CAPI environment, so we don't need to run CAPI controllers.
-	var runCAPIControllers bool
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
 	if err != nil {
 		setupLog.Error(err, "unable to create discovery client")
 		os.Exit(1)
 	}
 
-	resources, err := discoveryClient.ServerResourcesForGroupVersion(schema.GroupVersion{Group: "cluster.x-k8s.io", Version: "v1beta1"}.String())
-	if err == nil && len(resources.APIResources) > 0 {
-		runCAPIControllers = true
-	} else {
-		mgr.GetLogger().Info("Cluster API v1beta1 not installed, skipping cluster-api controllers setup")
-	}
+	runCAPIControllers := shouldRunCAPIControllers(discoveryClient, mgr.GetLogger())
 
 	//+kubebuilder:scaffold:builder
 	ctrlOptions := capictrl.Options{
@@ -430,6 +425,19 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+// shouldRunCAPIControllers reports whether the Cluster API core CRDs (the version
+// this manager's scheme and clustercache watch, v1beta2) are installed and served
+// by the API server. CAPI controllers must stay disabled otherwise, since watching
+// a Cluster API version the server doesn't serve makes the cache never sync.
+func shouldRunCAPIControllers(discoveryClient discovery.DiscoveryInterface, log logr.Logger) bool {
+	resources, err := discoveryClient.ServerResourcesForGroupVersion(schema.GroupVersion{Group: "cluster.x-k8s.io", Version: "v1beta2"}.String())
+	if err == nil && len(resources.APIResources) > 0 {
+		return true
+	}
+	log.Info("Cluster API v1beta2 not installed, skipping cluster-api controllers setup")
+	return false
 }
 
 func newCacheOptions(namespace, watchFilter string) (cache.Options, error) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	clienttesting "k8s.io/client-go/testing"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestShouldRunCAPIControllers(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []*metav1.APIResourceList
+		want      bool
+	}{
+		{
+			name:      "no cluster-api resources installed",
+			resources: nil,
+			want:      false,
+		},
+		{
+			// Reproduces the bug reported for a standalone install where only
+			// outdated v1beta1 Cluster API CRDs are present: the manager only
+			// watches v1beta2 types, so it must not enable the CAPI controllers.
+			name: "only outdated v1beta1 cluster-api CRDs installed",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "cluster.x-k8s.io/v1beta1",
+					APIResources: []metav1.APIResource{{Name: "clusters", Kind: "Cluster"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "v1beta2 cluster-api CRDs installed",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "cluster.x-k8s.io/v1beta2",
+					APIResources: []metav1.APIResource{{Name: "clusters", Kind: "Cluster"}},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			discoveryClient := &fakediscovery.FakeDiscovery{
+				Fake: &clienttesting.Fake{Resources: tt.resources},
+			}
+
+			got := shouldRunCAPIControllers(discoveryClient, logf.Log)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Motivation:
cmd/main.go decides whether to enable the CAPI controllers (bootstrap,
control-plane, infrastructure) and start the clustercache by probing
via discovery whether "cluster.x-k8s.io/v1beta1" resources are served.
That probe predates the switch of this manager's clusterv1 import to
"sigs.k8s.io/cluster-api/api/core/v1beta2" and was never updated: every
controller, the scheme registration, and clustercache.SetupWithManager
now use v1beta2 types exclusively.

When a cluster has stale/partial Cluster API remnants that still serve
v1beta1 but not v1beta2 for the "cluster.x-k8s.io" group (e.g. an old
CRD installed by another tool, with no CAPI actually running), the
v1beta1 probe returns true, the CAPI controllers and clustercache start,
clustercache tries to watch "*v1beta2.Cluster", the API server doesn't
serve that kind, and the cache never syncs. The manager then crash-loops
with "failed to wait for clustercache caches to sync kind source:
*v1beta2.Cluster: timed out waiting for cache to be synced". This is
not limited to standalone installs; any install hitting that CRD state
hits the same crash loop, but standalone users (who never intend to run
CAPI controllers at all) are the ones most likely to have only such
stray CRDs and no working CAPI otherwise.

Approach:
Change the discovery probe to check "cluster.x-k8s.io/v1beta2" instead
of "v1beta1", matching the API version the manager's scheme and
clustercache actually watch. Extract the probe into a small
"shouldRunCAPIControllers" helper so it is unit-testable, and add a
table-driven test in cmd/main_test.go using a fake discovery client
covering: no CAPI resources installed, only-v1beta1 installed
(reproduces the reported crash-loop precondition), and v1beta2
installed.

Cluster API v1.12.x (this repo's sigs.k8s.io/cluster-api dependency)
serves both v1beta1 (via conversion, not storage) and v1beta2 for the
core Cluster CRD, so any properly installed current CAPI environment
continues to pass the new probe unaffected.

Validation:
- go build ./... and make build (the CI build target) both pass.
- make test (repo's CI unittest command: go test ./api/... ./cmd/...
  ./internal/... -run '' -coverprofile cover.out) passes for all
  packages, including the new cmd/main_test.go table:
  TestShouldRunCAPIControllers/only_outdated_v1beta1_cluster-api_CRDs_installed
  fails against the old v1beta1 probe (that function did not exist
  before this change) and passes after this change, directly
  reproducing and proving the fix for the reported precondition.
- golangci-lint run --config .golangci.yml ./cmd/... reports 0 issues.
- Not run: envtest and the e2e/smoke-test suites, since they require a
  live cluster/docker and do not exercise cmd/main.go's discovery
  gating logic; the change is fully covered by the new unit test.

Report: https://github.com/k0sproject/k0smotron/issues/1585
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #1585