### PR TITLE
Use the shared worker enabled check for the tunneling gate

### DIFF
--- a/api/bootstrap/v1beta2/k0s_types.go
+++ b/api/bootstrap/v1beta2/k0s_types.go
@@ -18,6 +18,7 @@ package v1beta2
 import (
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/k0sproject/version"
@@ -448,8 +449,17 @@ func (kcs *K0sConfigSpec) WorkerEnabled() bool {
 		return false
 	}
 	for _, arg := range kcs.Args {
-		switch arg {
-		case "--enable-worker", "--enable-worker=true", "--single":
+		name, value, hasValue := strings.Cut(arg, "=")
+		if name != "--enable-worker" && name != "--single" {
+			continue
+		}
+
+		// Both are pflag bools, so a bare flag means true and a value is anything
+		// ParseBool accepts rather than only the word true.
+		if !hasValue {
+			return true
+		}
+		if enabled, err := strconv.ParseBool(value); err == nil && enabled {
 			return true
 		}
 	}

--- a/api/bootstrap/v1beta2/k0s_types_test.go
+++ b/api/bootstrap/v1beta2/k0s_types_test.go
@@ -37,6 +37,19 @@ func TestK0sConfigSpecWorkerEnabled(t *testing.T) {
 		{name: "single", args: []string{"--single"}, want: true},
 		{name: "single among others", args: []string{"--no-taints", "--single"}, want: true},
 		{name: "unrelated flag with worker substring", args: []string{"--enable-worker-foo"}, want: false},
+		// pflag parses a bool value with ParseBool, so every one of these is
+		// accepted by k0s and has to mean the same thing here.
+		{name: "enable-worker=1", args: []string{"--enable-worker=1"}, want: true},
+		{name: "enable-worker=t", args: []string{"--enable-worker=t"}, want: true},
+		{name: "enable-worker=TRUE", args: []string{"--enable-worker=TRUE"}, want: true},
+		{name: "single=true", args: []string{"--single=true"}, want: true},
+		{name: "enable-worker=false", args: []string{"--enable-worker=false"}, want: false},
+		{name: "enable-worker=0", args: []string{"--enable-worker=0"}, want: false},
+		{name: "single=False", args: []string{"--single=False"}, want: false},
+		// k0s itself refuses to start on these, so worker mode is unreachable.
+		{name: "value pflag rejects", args: []string{"--enable-worker=yes"}, want: false},
+		{name: "empty value", args: []string{"--enable-worker="}, want: false},
+		{name: "a false value does not mask a later true one", args: []string{"--enable-worker=false", "--single"}, want: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			spec := &K0sConfigSpec{Args: tc.args}

--- a/internal/controller/util/wc_client.go
+++ b/internal/controller/util/wc_client.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	cpv1beta2 "github.com/k0sproject/k0smotron/v2/api/controlplane/v1beta2"
@@ -189,7 +188,7 @@ func isTunneledRestConfigPossible(cp *cpv1beta2.K0sControlPlane) bool {
 	// 2: FRPClient cannot run without a worker machine. It cannot be deployed on controller nodes if `--enable-worker` is not configured.
 	// 3. Infra provider needs to see `controlplane.spec.initialized == true` in order to create a worker machine where FRPClient will run.
 	// 4. BACK TO 1!
-	if !slices.Contains(cp.Spec.K0sConfigSpec.Args, "--enable-worker") {
+	if !cp.WorkerEnabled() {
 		return false
 	}
 

--- a/internal/controller/util/wc_client_test.go
+++ b/internal/controller/util/wc_client_test.go
@@ -74,6 +74,16 @@ func Test_isTunneledRestConfigPossible(t *testing.T) {
 			cp:   kcp(true, "--single", "--enable-worker", "--debug"),
 			want: true,
 		},
+		{
+			name: "the explicit spelling of the worker flag",
+			cp:   kcp(true, "--enable-worker=true"),
+			want: true,
+		},
+		{
+			name: "a single node controller runs a worker",
+			cp:   kcp(true, "--single"),
+			want: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, isTunneledRestConfigPossible(tc.cp))


### PR DESCRIPTION
The check that picks the tunneled kubeconfig matched only the bare --enable-worker flag, so a control plane spelled --enable-worker=true or --single fell back to the direct endpoint a tunneling deployment cannot reach and reported itself unavailable while the tunnel was fine.
