### PR TITLE
Report waiting for the first controller as an error

### DIFF
--- a/internal/controller/bootstrap/controlplane_bootstrap_controller.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller.go
@@ -365,7 +365,9 @@ func (c *ControlPlaneController) generateBootstrapDataForController(ctx context.
 		oldest := getFirstRunningMachineExcludingMachineToBootstrap(scope)
 		if oldest == nil {
 			log.Info("wait for initial control plane provisioning")
-			return nil, err
+			// A nil error here would be read as success, and the caller would publish a
+			// bootstrap secret with a null value that is never regenerated.
+			return nil, errInitialControllerMachineNotInitialize
 		}
 		files, err = c.genControlPlaneJoinFiles(ctx, scope, files, oldest)
 		if err != nil {

--- a/internal/controller/bootstrap/controlplane_bootstrap_controller.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller.go
@@ -54,7 +54,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/go-logr/logr"
 	bootstrapv2 "github.com/k0sproject/k0smotron/v2/api/bootstrap/v1beta2"
 	"github.com/k0sproject/k0smotron/v2/internal/controller/util"
 	"github.com/k0sproject/k0smotron/v2/internal/provisioner"
@@ -253,7 +252,7 @@ func (c *ControlPlaneController) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	scope.machines = machines
 
-	bootstrapData, err := c.generateBootstrapDataForController(ctx, log, scope)
+	bootstrapData, err := c.generateBootstrapDataForController(ctx, scope)
 	if err != nil {
 		// if the bootstrap data generation corresponds to a controller that is not the initial one, it is common to try to obtain
 		// the IP of the first controller when has not yet been surfaced. This is required to create a join token. It is needed to
@@ -334,7 +333,7 @@ func (c *ControlPlaneController) Reconcile(ctx context.Context, req ctrl.Request
 	return ctrl.Result{}, nil
 }
 
-func (c *ControlPlaneController) generateBootstrapDataForController(ctx context.Context, log logr.Logger, scope *ControllerScope) ([]byte, error) {
+func (c *ControlPlaneController) generateBootstrapDataForController(ctx context.Context, scope *ControllerScope) ([]byte, error) {
 	var (
 		files      []provisioner.File
 		installCmd string
@@ -362,14 +361,7 @@ func (c *ControlPlaneController) generateBootstrapDataForController(ctx context.
 		}
 		installCmd = createCPInstallCmd(scope)
 	} else {
-		oldest := getFirstRunningMachineExcludingMachineToBootstrap(scope)
-		if oldest == nil {
-			log.Info("wait for initial control plane provisioning")
-			// A nil error here would be read as success, and the caller would publish a
-			// bootstrap secret with a null value that is never regenerated.
-			return nil, errInitialControllerMachineNotInitialize
-		}
-		files, err = c.genControlPlaneJoinFiles(ctx, scope, files, oldest)
+		files, err = c.genControlPlaneJoinFiles(ctx, scope, files)
 		if err != nil {
 			return nil, err
 		}
@@ -435,7 +427,7 @@ func (c *ControlPlaneController) genInitialControlPlaneFiles(ctx context.Context
 	return files, nil
 }
 
-func (c *ControlPlaneController) genControlPlaneJoinFiles(ctx context.Context, scope *ControllerScope, files []provisioner.File, firstControllerMachine *clusterv1.Machine) ([]provisioner.File, error) {
+func (c *ControlPlaneController) genControlPlaneJoinFiles(ctx context.Context, scope *ControllerScope, files []provisioner.File) ([]provisioner.File, error) {
 	log := log.FromContext(ctx).WithValues("K0sControllerConfig cluster", scope.Cluster.Name)
 
 	_, ca, err := c.getCerts(ctx, scope)
@@ -467,7 +459,7 @@ func (c *ControlPlaneController) genControlPlaneJoinFiles(ctx context.Context, s
 		return nil, err
 	}
 
-	host, err := c.detectJoinHost(ctx, scope, firstControllerMachine, ca)
+	host, err := c.detectJoinHost(ctx, scope, ca)
 	if err != nil {
 		log.Error(err, "Failed to detect join controller host")
 		return nil, err
@@ -674,7 +666,7 @@ func mergeControllerExtraArgs(scope *ControllerScope) []string {
 	return mergeExtraArgs(scope.installArgs, scope.ConfigOwner, scope.WorkerEnabled, scope.Config.Spec.UseSystemHostname)
 }
 
-func (c *ControlPlaneController) detectJoinHost(ctx context.Context, scope *ControllerScope, firstControllerMachine *clusterv1.Machine, ca *secret.Certificate) (string, error) {
+func (c *ControlPlaneController) detectJoinHost(ctx context.Context, scope *ControllerScope, ca *secret.Certificate) (string, error) {
 	caCertPool := x509.NewCertPool()
 	if ca == nil || ca.KeyPair == nil || !caCertPool.AppendCertsFromPEM(ca.KeyPair.Cert) {
 		return "", errors.New("failed to load cluster CA certificate for join host detection")
@@ -706,7 +698,7 @@ func (c *ControlPlaneController) detectJoinHost(ctx context.Context, scope *Cont
 		return host, nil
 	}
 
-	firstControllerIP, err := c.findFirstControllerIP(ctx, firstControllerMachine)
+	firstControllerIP, err := c.findFirstControllerIP(ctx, scope)
 	if err != nil {
 		return "", fmt.Errorf("failed to get first controller IP: %w", err)
 	}
@@ -714,7 +706,12 @@ func (c *ControlPlaneController) detectJoinHost(ctx context.Context, scope *Cont
 	return fmt.Sprintf("https://%s:%s", firstControllerIP, port), nil
 }
 
-func (c *ControlPlaneController) findFirstControllerIP(ctx context.Context, firstControllerMachine *clusterv1.Machine) (string, error) {
+func (c *ControlPlaneController) findFirstControllerIP(ctx context.Context, scope *ControllerScope) (string, error) {
+	firstControllerMachine := getFirstRunningMachineExcludingMachineToBootstrap(scope)
+	if firstControllerMachine == nil {
+		return "", fmt.Errorf("no running controller machine to join: %w", errInitialControllerMachineNotInitialize)
+	}
+
 	extAddr, intIPv4Addr, intAddr := "", "", ""
 	for _, addr := range firstControllerMachine.Status.Addresses {
 		if addr.Type == clusterv1.MachineExternalIP {

--- a/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/k0sproject/k0smotron/v2/internal/controller/util"
 	"github.com/k0sproject/version"
 	"github.com/stretchr/testify/require"
@@ -217,21 +216,21 @@ func TestControlPlaneController_detectJoinHost(t *testing.T) {
 		},
 	}
 
-	firstControllerMachine := &clusterv1.Machine{
+	scope.machines = collections.FromMachines(&clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{Name: "first-controller"},
 		Status: clusterv1.MachineStatus{
 			Addresses: clusterv1.MachineAddresses{
 				{Type: clusterv1.MachineExternalIP, Address: "203.0.113.10"},
 			},
 		},
-	}
+	})
 
 	c := &ControlPlaneController{}
 
 	t.Run("trusted CA reaches the control plane endpoint", func(t *testing.T) {
 		ca := &secret.Certificate{KeyPair: &certs.KeyPair{Cert: trustedCACert}}
 
-		host, err := c.detectJoinHost(context.Background(), scope, firstControllerMachine, ca)
+		host, err := c.detectJoinHost(context.Background(), scope, ca)
 
 		require.NoError(t, err)
 		require.Equal(t, server.URL, host)
@@ -240,14 +239,14 @@ func TestControlPlaneController_detectJoinHost(t *testing.T) {
 	t.Run("CA that did not sign the endpoint falls back to the first controller", func(t *testing.T) {
 		ca := &secret.Certificate{KeyPair: &certs.KeyPair{Cert: untrustedCACert}}
 
-		host, err := c.detectJoinHost(context.Background(), scope, firstControllerMachine, ca)
+		host, err := c.detectJoinHost(context.Background(), scope, ca)
 
 		require.NoError(t, err)
 		require.Equal(t, "https://203.0.113.10:"+serverURL.Port(), host)
 	})
 
 	t.Run("missing CA is an error", func(t *testing.T) {
-		_, err := c.detectJoinHost(context.Background(), scope, firstControllerMachine, nil)
+		_, err := c.detectJoinHost(context.Background(), scope, nil)
 
 		require.Error(t, err)
 	})
@@ -274,9 +273,9 @@ func selfSignedCertPEM(t *testing.T) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }
 
-// TestGenerateBootstrapDataForControllerWaitsWithAnError covers the join path finding no
-// running controller to point at. A nil error there would read as success.
-func TestGenerateBootstrapDataForControllerWaitsWithAnError(t *testing.T) {
+// TestFindFirstControllerIPWaitsWithAnError covers finding no running controller to
+// point at. A nil error there would read as success further up.
+func TestFindFirstControllerIPWaitsWithAnError(t *testing.T) {
 	machine := func(name string, age time.Duration, phase clusterv1.MachinePhase) *clusterv1.Machine {
 		return &clusterv1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
@@ -287,8 +286,7 @@ func TestGenerateBootstrapDataForControllerWaitsWithAnError(t *testing.T) {
 		}
 	}
 
-	// The oldest machine is not the one being bootstrapped, so this takes the join
-	// path, and it is still Pending, so there is no join target yet.
+	// The only other machine is still Pending, so there is no join target yet.
 	scope := &ControllerScope{
 		Config: &bootstrapv2.K0sControllerConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "cp-1"},
@@ -303,8 +301,8 @@ func TestGenerateBootstrapDataForControllerWaitsWithAnError(t *testing.T) {
 	}
 
 	c := &ControlPlaneController{}
-	data, err := c.generateBootstrapDataForController(context.TODO(), logr.Discard(), scope)
+	host, err := c.findFirstControllerIP(context.TODO(), scope)
 
 	require.ErrorIs(t, err, errInitialControllerMachineNotInitialize)
-	require.Nil(t, data)
+	require.Empty(t, host)
 }

--- a/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/k0sproject/k0smotron/v2/internal/controller/util"
 	"github.com/k0sproject/version"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	bsutil "sigs.k8s.io/cluster-api/bootstrap/util"
 	"sigs.k8s.io/cluster-api/util/certs"
+	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/secret"
 
 	bootstrapv2 "github.com/k0sproject/k0smotron/v2/api/bootstrap/v1beta2"
@@ -270,4 +272,39 @@ func selfSignedCertPEM(t *testing.T) []byte {
 	require.NoError(t, err)
 
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// TestGenerateBootstrapDataForControllerWaitsWithAnError covers the join path finding no
+// running controller to point at. A nil error there would read as success.
+func TestGenerateBootstrapDataForControllerWaitsWithAnError(t *testing.T) {
+	machine := func(name string, age time.Duration, phase clusterv1.MachinePhase) *clusterv1.Machine {
+		return &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+			},
+			Status: clusterv1.MachineStatus{Phase: string(phase)},
+		}
+	}
+
+	// The oldest machine is not the one being bootstrapped, so this takes the join
+	// path, and it is still Pending, so there is no join target yet.
+	scope := &ControllerScope{
+		Config: &bootstrapv2.K0sControllerConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "cp-1"},
+			Spec: bootstrapv2.K0sControllerConfigSpec{
+				K0sConfigSpec: &bootstrapv2.K0sConfigSpec{},
+			},
+		},
+		machines: collections.FromMachines(
+			machine("cp-0", time.Hour, clusterv1.MachinePhasePending),
+			machine("cp-1", time.Minute, clusterv1.MachinePhaseProvisioning),
+		),
+	}
+
+	c := &ControlPlaneController{}
+	data, err := c.generateBootstrapDataForController(context.TODO(), logr.Discard(), scope)
+
+	require.ErrorIs(t, err, errInitialControllerMachineNotInitialize)
+	require.Nil(t, data)
 }


### PR DESCRIPTION
The join path returned a nil error while waiting for a running controller to point at, so Reconcile read it as success, applied a bootstrap secret whose value key was null and never regenerated the config.
