### PR TITLE
Pick the join target with the shared oldest first ordering

### DIFF
--- a/internal/controller/bootstrap/controlplane_bootstrap_controller.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"net/netip"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -961,20 +960,12 @@ exit 0`,
 }
 
 func getFirstRunningMachineExcludingMachineToBootstrap(scope *ControllerScope) *clusterv1.Machine {
-	res := make(machinesByVersionAndCreationTimestamp, 0, len(scope.machines))
-	// Assuming configs and machines have the same name
-	machineNameToBootstrap := scope.Config.Name
-	for _, value := range scope.machines {
-		if value.Status.Phase == string(clusterv1.MachinePhasePending) || machineNameToBootstrap == value.Name {
-			continue
-		}
-		res = append(res, value)
-	}
-	if len(res) == 0 {
-		return nil
-	}
-	sort.Sort(res)
-	return res[0]
+	// Oldest sorts by creation timestamp then name, so the pick is stable even though
+	// the candidates come out of a map. Any non pending controller is a valid target.
+	return scope.machines.Filter(func(m *clusterv1.Machine) bool {
+		// Assuming configs and machines have the same name
+		return m.Name != scope.Config.Name && m.Status.Phase != string(clusterv1.MachinePhasePending)
+	}).Oldest()
 }
 
 func getShutdownFilesDir(configuredWorkingDir string) string {
@@ -983,17 +974,4 @@ func getShutdownFilesDir(configuredWorkingDir string) string {
 		return "/etc/k0s"
 	}
 	return configuredWorkingDir
-}
-
-// machinesByCreationTimestamp sorts a list of Machine by creation timestamp, using their names as a tie breaker.
-type machinesByVersionAndCreationTimestamp []*clusterv1.Machine
-
-func (o machinesByVersionAndCreationTimestamp) Len() int      { return len(o) }
-func (o machinesByVersionAndCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
-func (o machinesByVersionAndCreationTimestamp) Less(i, j int) bool {
-
-	if o[i].CreationTimestamp.Equal(&o[j].CreationTimestamp) {
-		return o[i].Name < o[j].Name
-	}
-	return o[i].Spec.Version < o[j].Spec.Version && o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
 }

--- a/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
+++ b/internal/controller/bootstrap/controlplane_bootstrap_controller_test.go
@@ -306,3 +306,57 @@ func TestFindFirstControllerIPWaitsWithAnError(t *testing.T) {
 	require.ErrorIs(t, err, errInitialControllerMachineNotInitialize)
 	require.Empty(t, host)
 }
+
+// TestGetFirstRunningMachineIsDeterministic covers the join target being picked by a real
+// ordering rather than by the iteration order of the map the candidates come from.
+func TestGetFirstRunningMachineIsDeterministic(t *testing.T) {
+	// One base instant, so an age of 0 really is the same timestamp on both sides.
+	base := time.Now()
+	machine := func(name string, age time.Duration) *clusterv1.Machine {
+		return &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				CreationTimestamp: metav1.NewTime(base.Add(-age)),
+			},
+			Status: clusterv1.MachineStatus{Phase: string(clusterv1.MachinePhaseRunning)},
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		machines []*clusterv1.Machine
+		want     string
+	}{
+		{
+			name: "the oldest candidate wins",
+			machines: []*clusterv1.Machine{
+				machine("cp-young", time.Minute),
+				machine("cp-old", time.Hour),
+				machine("cp-middle", 30*time.Minute),
+			},
+			want: "cp-old",
+		},
+		{
+			name: "an identical age falls back to the name",
+			machines: []*clusterv1.Machine{
+				machine("cp-b", 0),
+				machine("cp-a", 0),
+			},
+			want: "cp-a",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scope := &ControllerScope{
+				Config:   &bootstrapv2.K0sControllerConfig{ObjectMeta: metav1.ObjectMeta{Name: "bootstrapping"}},
+				machines: collections.FromMachines(tc.machines...),
+			}
+
+			// Repeated because the input is a map and one pass can agree by luck.
+			for range 32 {
+				got := getFirstRunningMachineExcludingMachineToBootstrap(scope)
+				require.NotNil(t, got)
+				require.Equal(t, tc.want, got.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The comparator required both a lower version and an earlier timestamp, which is not an ordering, so machines of the same version kept the random order of the map they came from. The version key served no purpose, so it goes and Filter and Oldest from the collections package do the work.