### PR TITLE
Fall back to 0644 when an Ignition file has no permissions

### DIFF
--- a/internal/provisioner/ignition.go
+++ b/internal/provisioner/ignition.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"text/template"
 
 	butaneutil "github.com/coreos/butane/base/util"
@@ -55,9 +54,11 @@ type IgnitionProvisioner struct {
 func (i *IgnitionProvisioner) ToProvisionData(input *InputProvisionData) ([]byte, error) {
 	files := []map[string]any{}
 	for _, f := range input.Files {
-		mi, err := strconv.ParseInt(f.Permissions, 8, 32)
+		// Permissions is optional and nothing defaults it, so parse through the
+		// helper that falls back rather than failing the whole render.
+		mi, err := f.PermissionsAsInt()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse permissions of file %s: %w", f.Path, err)
 		}
 
 		// Ignition has no notion of a content encoding, so decode here rather

--- a/internal/provisioner/ignition_test.go
+++ b/internal/provisioner/ignition_test.go
@@ -485,3 +485,23 @@ func TestIgnitionRejectsUndecodableContent(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "failed to base64 decode")
 }
+
+// TestIgnitionDefaultsEmptyPermissions covers files with no permissions set. k0smotron
+// generates three such files itself for a worker that has ingress enabled.
+func TestIgnitionDefaultsEmptyPermissions(t *testing.T) {
+	out, err := (&IgnitionProvisioner{Variant: "fcos", Version: "1.5.0"}).ToProvisionData(
+		&InputProvisionData{Files: []File{{Path: "/etc/haproxy/certs/ca.crt", Content: "cert"}}})
+	require.NoError(t, err)
+
+	entry := fileEntry(t, out)
+	require.Equal(t, float64(0o644), entry["mode"])
+	require.Equal(t, "cert", string(bodyBytes(t, entry["contents"].(map[string]any))))
+}
+
+// TestIgnitionRejectsUnparseablePermissions keeps the fallback from swallowing a value
+// the user did set and got wrong.
+func TestIgnitionRejectsUnparseablePermissions(t *testing.T) {
+	_, err := (&IgnitionProvisioner{Variant: "fcos", Version: "1.5.0"}).ToProvisionData(
+		&InputProvisionData{Files: []File{{Path: "/a", Content: "x", Permissions: "not-a-mode"}}})
+	require.ErrorContains(t, err, "failed to parse permissions of file /a")
+}


### PR DESCRIPTION
Permissions is optional and nothing defaults it, so an empty value aborted the whole render. k0smotron writes three haproxy files with no mode set, so an ingress enabled worker failed with no user files at all.