### PR TITLE
Ensure an in place update trigger completes before another starts

### DIFF
--- a/internal/controller/controlplane/inplace.go
+++ b/internal/controller/controlplane/inplace.go
@@ -345,21 +345,9 @@ func (c *K0sController) updateMachineVersion(ctx context.Context, machine *clust
 	return nil
 }
 
+// triggerCAPIInplaceVersionUpdate marks a Machine and the objects it points at as being
+// updated in place. The pending hook has to come after the other two are marked.
 func triggerCAPIInplaceVersionUpdate(ctx context.Context, c client.Client, desiredVersion string, desiredMachine *clusterv1.Machine, desiredInfraMachine *unstructured.Unstructured, desiredBootstrapConfig *bootstrapv2.K0sControllerConfig) error {
-	if _, ok := desiredMachine.Annotations[clusterv1.UpdateInProgressAnnotation]; !ok {
-		orig := desiredMachine.DeepCopy()
-		desiredMachine.Spec.Version = desiredVersion
-		if desiredMachine.Annotations == nil {
-			desiredMachine.Annotations = map[string]string{}
-		}
-		desiredMachine.Annotations[clusterv1.UpdateInProgressAnnotation] = ""
-		desiredMachine.Annotations[runtimev1.PendingHooksAnnotation] = runtimecatalog.HookName(runtimehooksv1.UpdateMachine)
-		if err := c.Patch(ctx, desiredMachine, client.MergeFrom(orig)); err != nil {
-			return fmt.Errorf("failed to trigger in-place update for Machine %s by setting the %s annotation: %w",
-				klog.KObj(desiredMachine), clusterv1.UpdateInProgressAnnotation, err)
-		}
-	}
-
 	if _, ok := desiredInfraMachine.GetAnnotations()[clusterv1.UpdateInProgressAnnotation]; !ok {
 		origInfra := desiredInfraMachine.DeepCopy()
 		infraMachineAnnotations := desiredInfraMachine.GetAnnotations()
@@ -383,6 +371,22 @@ func triggerCAPIInplaceVersionUpdate(ctx context.Context, c client.Client, desir
 		if err := c.Patch(ctx, desiredBootstrapConfig, client.MergeFrom(origBootstrap)); err != nil {
 			return fmt.Errorf("failed to trigger in-place update for BootstrapConfig %s by setting the %s annotation: %w",
 				klog.KObj(desiredBootstrapConfig), clusterv1.UpdateInProgressAnnotation, err)
+		}
+	}
+
+	// Last, so the pending hook becomes visible only once the two objects above are
+	// marked. Both annotations go in one MergeFrom patch, which is atomic.
+	if _, ok := desiredMachine.Annotations[clusterv1.UpdateInProgressAnnotation]; !ok {
+		orig := desiredMachine.DeepCopy()
+		desiredMachine.Spec.Version = desiredVersion
+		if desiredMachine.Annotations == nil {
+			desiredMachine.Annotations = map[string]string{}
+		}
+		desiredMachine.Annotations[clusterv1.UpdateInProgressAnnotation] = ""
+		desiredMachine.Annotations[runtimev1.PendingHooksAnnotation] = runtimecatalog.HookName(runtimehooksv1.UpdateMachine)
+		if err := c.Patch(ctx, desiredMachine, client.MergeFrom(orig)); err != nil {
+			return fmt.Errorf("failed to trigger in-place update for Machine %s by setting the %s annotation: %w",
+				klog.KObj(desiredMachine), clusterv1.UpdateInProgressAnnotation, err)
 		}
 	}
 

--- a/internal/controller/controlplane/inplace_test.go
+++ b/internal/controller/controlplane/inplace_test.go
@@ -24,12 +24,19 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
+	bootstrapv2 "github.com/k0sproject/k0smotron/v2/api/bootstrap/v1beta2"
 	cpv1beta2 "github.com/k0sproject/k0smotron/v2/api/controlplane/v1beta2"
 	"github.com/stretchr/testify/require"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	runtimev1 "sigs.k8s.io/cluster-api/api/runtime/v1beta2"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // TestReconcileInplaceK0sVersionUpdateWhenUnavailable covers the gate that runs
@@ -147,4 +154,63 @@ func TestReconcileInplaceK0sVersionUpdateHoldsOnlyTheRollout(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, res.IsZero(), "an operator has to be able to remove a machine")
 	})
+}
+
+// TestTriggerCAPIInplaceVersionUpdateOrdering pins the order the contract requires, so a
+// pending hook is never observed against objects that do not yet know about the update.
+func TestTriggerCAPIInplaceVersionUpdateOrdering(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, bootstrapv2.AddToScheme(scheme))
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp-0", Namespace: "default"},
+		Spec:       clusterv1.MachineSpec{Version: "v1.31.0+k0s.0", ClusterName: "c"},
+	}
+	bootstrapConfig := &bootstrapv2.K0sControllerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp-0", Namespace: "default"},
+	}
+	infraMachine := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta2",
+		"kind":       "RemoteMachine",
+		"metadata":   map[string]any{"name": "cp-0", "namespace": "default"},
+	}}
+
+	// Never delegates, because the fake client panics applying a merge patch to a
+	// K0sControllerConfig, whose spec embeds a pointer.
+	var patched []string
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(_ context.Context, _ client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				var label string
+				switch obj.(type) {
+				case *unstructured.Unstructured:
+					label = "infraMachine"
+				case *bootstrapv2.K0sControllerConfig:
+					label = "bootstrapConfig"
+				case *clusterv1.Machine:
+					label = "machine"
+				default:
+					return fmt.Errorf("unexpected patch on %T", obj)
+				}
+				// Recorded per patch, so the hook cannot hide on an earlier one.
+				if _, ok := obj.GetAnnotations()[runtimev1.PendingHooksAnnotation]; ok {
+					label += "+hook"
+				}
+				patched = append(patched, label)
+
+				return nil
+			},
+		}).Build()
+
+	require.NoError(t, triggerCAPIInplaceVersionUpdate(
+		context.Background(), cl, "v1.32.0+k0s.0", machine, infraMachine, bootstrapConfig))
+
+	require.Equal(t, []string{"infraMachine", "bootstrapConfig", "machine+hook"}, patched)
+
+	require.Contains(t, machine.Annotations, runtimev1.PendingHooksAnnotation)
+	require.Contains(t, machine.Annotations, clusterv1.UpdateInProgressAnnotation)
+	require.Contains(t, infraMachine.GetAnnotations(), clusterv1.UpdateInProgressAnnotation)
+	require.Contains(t, bootstrapConfig.Annotations, clusterv1.UpdateInProgressAnnotation)
+	require.Equal(t, "v1.32.0+k0s.0", machine.Spec.Version)
 }


### PR DESCRIPTION
The Machine was patched with the pending UpdateMachine hook before the objects it applies to were marked, so a restart in between left the version bumped and the hook stranded. The latch now goes on first and the hook last, and a Machine carrying the latch without the hook has its trigger finished before a new one starts.