### PR TITLE
Declare the RemediationFailed condition reason as a constant

### DIFF
--- a/api/controlplane/v1beta2/conditions_consts.go
+++ b/api/controlplane/v1beta2/conditions_consts.go
@@ -32,6 +32,11 @@ const (
 	// ControlPlaneAvailableUnknownReason surfaces while the workload cluster API has
 	// not been reached even once, so nothing can be said about its availability.
 	ControlPlaneAvailableUnknownReason = clusterv1.AvailableUnknownReason
+
+	// K0sControlPlaneMachineRemediationFailedReason surfaces on a Machine whose
+	// remediation failed. A local string, since upstream only has a v1beta1 one.
+	K0sControlPlaneMachineRemediationFailedReason = "RemediationFailed"
+
 	// K0sControlPlaneScalingUpCondition is true if actual replicas < desired replicas.
 	// Note: In case a K0sControlPlane preflight check is preventing scale up, this will surface in the condition message.
 	K0sControlPlaneScalingUpCondition = clusterv1.ScalingUpCondition

--- a/internal/controller/controlplane/remediation.go
+++ b/internal/controller/controlplane/remediation.go
@@ -125,7 +125,7 @@ func (c *K0sController) reconcileUnhealthyMachines(ctx context.Context, scope *c
 		conditions.Set(machineToBeRemediated, metav1.Condition{
 			Type:    string(clusterv1.MachineOwnerRemediatedCondition),
 			Status:  metav1.ConditionFalse,
-			Reason:  "RemediationFailed",
+			Reason:  cpv1beta2.K0sControlPlaneMachineRemediationFailedReason,
 			Message: err.Error(),
 		})
 		return errors.Wrapf(err, "failed to delete unhealthy machine %s", machineToBeRemediated.Name)


### PR DESCRIPTION
The reason was an inline string literal at its only call site, and the value is unchanged so nothing a client reads is any different.