### PR TITLE
Report a failed bootstrap secret write as unavailable

### DIFF
--- a/internal/controller/bootstrap/worker_bootstrap_controller.go
+++ b/internal/controller/bootstrap/worker_bootstrap_controller.go
@@ -252,7 +252,7 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		log.Error(err, "Failed to patch bootstrap secret")
 		conditions.Set(config, metav1.Condition{
 			Type:    string(bootstrapv2.DataSecretAvailableCondition),
-			Status:  metav1.ConditionTrue,
+			Status:  metav1.ConditionFalse,
 			Reason:  bootstrapv2.InternalErrorReason,
 			Message: err.Error(),
 		})


### PR DESCRIPTION
The patch failure path set DataSecretAvailable to true with an internal error reason, so for one reconcile the config advertised a secret that was never written.