### PR TITLE
Stop PowerShell file paths and content escaping into script

### DIFF
--- a/internal/provisioner/powershell.go
+++ b/internal/provisioner/powershell.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"unicode/utf8"
 )
 
 // PowerShellProvisioner implements the Provisioner interface for cloud-init.
@@ -82,42 +81,23 @@ func renderWriteFile(buf *bytes.Buffer, f File) error {
 		return err
 	}
 
-	// A here string cannot hold bytes outside UTF8, and it drops the newline
-	// before its terminator, so those two cases go through base64 instead.
-	if f.Append || !utf8.Valid(decoded) {
-		fmt.Fprintf(buf, "$bytes = [System.Convert]::FromBase64String(\"%s\")\n",
-			base64.StdEncoding.EncodeToString(decoded))
+	// Content goes out as base64 rather than as a here string. A here string is
+	// script text, so a line holding its terminator escapes into the script.
+	fmt.Fprintf(buf, "$bytes = [System.Convert]::FromBase64String(%s)\n",
+		quotePS(base64.StdEncoding.EncodeToString(decoded)))
 
-		if f.Append {
-			fmt.Fprintf(buf, `$stream = [System.IO.File]::Open(
+	if f.Append {
+		fmt.Fprintf(buf, `$stream = [System.IO.File]::Open(
   %s,
   [System.IO.FileMode]::Append
 )
 $stream.Write($bytes, 0, $bytes.Length)
 $stream.Close()`+"\n", quotePS(f.Path))
 
-			return nil
-		}
-
-		fmt.Fprintf(buf, "[System.IO.File]::WriteAllBytes(%s, $bytes)\n", quotePS(f.Path))
-
 		return nil
 	}
 
-	content := normalizeNewlines(string(decoded))
-
-	// Here-string write
-	buf.WriteString("$file = @'\n")
-	buf.WriteString(content)
-	if !strings.HasSuffix(content, "\n") {
-		buf.WriteString("\n")
-	}
-	buf.WriteString("'@\n")
-	fmt.Fprintf(buf, `[System.IO.File]::WriteAllText(
-  %s,
-  $file.Trim(),
-  [System.Text.Encoding]::ASCII
-)`+"\n", quotePS(f.Path))
+	fmt.Fprintf(buf, "[System.IO.File]::WriteAllBytes(%s, $bytes)\n", quotePS(f.Path))
 
 	return nil
 }
@@ -126,10 +106,4 @@ $stream.Close()`+"\n", quotePS(f.Path))
 // path cannot expand a variable or run a subexpression.
 func quotePS(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
-}
-
-func normalizeNewlines(s string) string {
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	s = strings.ReplaceAll(s, "\r", "\n")
-	return s
 }

--- a/internal/provisioner/powershell.go
+++ b/internal/provisioner/powershell.go
@@ -72,8 +72,8 @@ func renderWriteFile(buf *bytes.Buffer, f File) error {
 
 	// Ensure directory exists
 	fmt.Fprintf(buf,
-		"New-Item -ItemType Directory -Force -Path \"%s\" | Out-Null\n",
-		escapePS(dir),
+		"New-Item -ItemType Directory -Force -Path %s | Out-Null\n",
+		quotePS(dir),
 	)
 
 	// PowerShell has no notion of a content encoding, so decode here.
@@ -90,16 +90,16 @@ func renderWriteFile(buf *bytes.Buffer, f File) error {
 
 		if f.Append {
 			fmt.Fprintf(buf, `$stream = [System.IO.File]::Open(
-  "%s",
+  %s,
   [System.IO.FileMode]::Append
 )
 $stream.Write($bytes, 0, $bytes.Length)
-$stream.Close()`+"\n", escapePS(f.Path))
+$stream.Close()`+"\n", quotePS(f.Path))
 
 			return nil
 		}
 
-		fmt.Fprintf(buf, "[System.IO.File]::WriteAllBytes(\"%s\", $bytes)\n", escapePS(f.Path))
+		fmt.Fprintf(buf, "[System.IO.File]::WriteAllBytes(%s, $bytes)\n", quotePS(f.Path))
 
 		return nil
 	}
@@ -114,17 +114,18 @@ $stream.Close()`+"\n", escapePS(f.Path))
 	}
 	buf.WriteString("'@\n")
 	fmt.Fprintf(buf, `[System.IO.File]::WriteAllText(
-  "%s",
+  %s,
   $file.Trim(),
   [System.Text.Encoding]::ASCII
-)`+"\n", escapePS(f.Path))
+)`+"\n", quotePS(f.Path))
 
 	return nil
 }
 
-func escapePS(s string) string {
-	// PowerShell double-quoted string escaping
-	return strings.ReplaceAll(s, `"`, `""`)
+// quotePS renders s as a PowerShell single quoted string, which is literal, so a
+// path cannot expand a variable or run a subexpression.
+func quotePS(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 func normalizeNewlines(s string) string {

--- a/internal/provisioner/powershell_test.go
+++ b/internal/provisioner/powershell_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var psBytesRe = regexp.MustCompile(`FromBase64String\("([^"]*)"\)`)
+var psBytesRe = regexp.MustCompile(`FromBase64String\('([^']*)'\)`)
 
 // psBody decodes the payload of a script that took the byte path.
 func psBody(t *testing.T, script string) []byte {
@@ -46,15 +46,15 @@ func render(t *testing.T, f File) string {
 	return string(out)
 }
 
-// TestPowerShellKeepsHereStringForPlainContent pins the existing output, so a
-// config that worked before this change renders exactly as it did.
-func TestPowerShellKeepsHereStringForPlainContent(t *testing.T) {
+// TestPowerShellSendsPlainContentAsBytes covers ordinary content taking the byte path
+// too, so no file body is ever emitted as script text.
+func TestPowerShellSendsPlainContentAsBytes(t *testing.T) {
 	s := render(t, File{Path: `C:\k\a.conf`, Content: "body", Permissions: "0644"})
 
-	require.Contains(t, s, "$file = @'\nbody\n'@")
-	require.Contains(t, s, "$file.Trim()")
-	require.Contains(t, s, "[System.Text.Encoding]::ASCII")
-	require.NotContains(t, s, "FromBase64String")
+	require.Equal(t, "body", string(psBody(t, s)))
+	require.Contains(t, s, "[System.IO.File]::WriteAllBytes(")
+	require.NotContains(t, s, "@'")
+	require.NotContains(t, s, "$file.Trim()")
 }
 
 func TestPowerShellDecodesBeforeRendering(t *testing.T) {
@@ -64,12 +64,12 @@ func TestPowerShellDecodesBeforeRendering(t *testing.T) {
 		Encoding: Base64,
 	})
 
-	require.Contains(t, s, "$file = @'\ndecoded body\n'@")
+	require.Equal(t, "decoded body", string(psBody(t, s)))
 }
 
-// TestPowerShellUsesBytesWhereAHereStringCannot covers the two cases a here
-// string cannot represent, neither of which an existing config can reach.
-func TestPowerShellUsesBytesWhereAHereStringCannot(t *testing.T) {
+// TestPowerShellPreservesContentExactly covers bodies that the old here string
+// mangled or could not represent at all.
+func TestPowerShellPreservesContentExactly(t *testing.T) {
 	t.Run("content outside UTF8", func(t *testing.T) {
 		raw := []byte{0x00, 0xff, 0x1b}
 
@@ -135,9 +135,9 @@ func TestPowerShellQuotesPathsLiterally(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := render(t, File{Path: tc.path, Content: "body", Permissions: "0644"})
 
-			require.Contains(t, s, "WriteAllText(\n  "+tc.want+",")
+			require.Contains(t, s, "WriteAllBytes("+tc.want+", $bytes)")
 			// the old form put the path in a double quoted string, which expands
-			require.NotContains(t, s, `WriteAllText(`+"\n"+`  "`)
+			require.NotContains(t, s, `WriteAllBytes("`)
 		})
 	}
 }
@@ -155,7 +155,21 @@ func TestPowerShellQuotesPathsOnEveryWriteForm(t *testing.T) {
 	require.Contains(t, render(t, File{Path: path, Content: "body", Append: true}),
 		"Open(\n  '"+path+"',")
 
-	// content that a here string cannot hold routes through WriteAllBytes
-	require.Contains(t, render(t, File{Path: path, Content: "\xff\xfe"}),
+	// the plain write form
+	require.Contains(t, render(t, File{Path: path, Content: "body"}),
 		`WriteAllBytes('`+path+`', $bytes)`)
+}
+
+// TestPowerShellContentCannotEscapeIntoScript covers a file body that used to close the
+// here string that carried it, putting everything after the terminator into the script.
+func TestPowerShellContentCannotEscapeIntoScript(t *testing.T) {
+	body := "foo\n'@\nWrite-Host PWNED\n"
+
+	s := render(t, File{Path: `C:\k\a.conf`, Content: body, Permissions: "0644"})
+
+	// the body survives whole rather than being truncated at the terminator
+	require.Equal(t, body, string(psBody(t, s)))
+	// and none of it reaches the script as text
+	require.NotContains(t, s, "Write-Host PWNED")
+	require.NotContains(t, s, "@'")
 }

--- a/internal/provisioner/powershell_test.go
+++ b/internal/provisioner/powershell_test.go
@@ -102,3 +102,60 @@ func TestPowerShellRejectsUndecodableContent(t *testing.T) {
 	require.ErrorContains(t, err, "failed to base64 decode")
 	require.ErrorContains(t, err, `C:\k\x`)
 }
+
+// TestPowerShellQuotesPathsLiterally covers a path reaching the target as data rather
+// than as script. Single quoted PowerShell strings expand nothing.
+func TestPowerShellQuotesPathsLiterally(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "a subexpression stays inert",
+			path: `C:\k\$(ni PWNED).conf`,
+			want: `'C:\k\$(ni PWNED).conf'`,
+		},
+		{
+			name: "a variable is not expanded",
+			path: `C:\k\$env:TEMP.conf`,
+			want: `'C:\k\$env:TEMP.conf'`,
+		},
+		{
+			name: "an embedded quote is doubled",
+			path: `C:\k\a'b.conf`,
+			want: `'C:\k\a''b.conf'`,
+		},
+		{
+			name: "a double quote needs no escaping now",
+			path: `C:\k\a"b.conf`,
+			want: `'C:\k\a"b.conf'`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := render(t, File{Path: tc.path, Content: "body", Permissions: "0644"})
+
+			require.Contains(t, s, "WriteAllText(\n  "+tc.want+",")
+			// the old form put the path in a double quoted string, which expands
+			require.NotContains(t, s, `WriteAllText(`+"\n"+`  "`)
+		})
+	}
+}
+
+// TestPowerShellQuotesPathsOnEveryWriteForm covers the three other places a path is
+// emitted, since each one used to build its own double quoted string.
+func TestPowerShellQuotesPathsOnEveryWriteForm(t *testing.T) {
+	path := `C:\k\$(ni PWNED)\a.conf`
+
+	// New-Item takes the directory, so it is quoted on every render
+	require.Contains(t, render(t, File{Path: path, Content: "body"}),
+		`-Path 'C:/k/$(ni PWNED)' | Out-Null`)
+
+	// append routes through Open
+	require.Contains(t, render(t, File{Path: path, Content: "body", Append: true}),
+		"Open(\n  '"+path+"',")
+
+	// content that a here string cannot hold routes through WriteAllBytes
+	require.Contains(t, render(t, File{Path: path, Content: "\xff\xfe"}),
+		`WriteAllBytes('`+path+`', $bytes)`)
+}

--- a/internal/provisioner/powershell_xml_test.go
+++ b/internal/provisioner/powershell_xml_test.go
@@ -47,12 +47,12 @@ func TestPowerShellAWS(t *testing.T) {
 	assert.Equal(t, `<powershell>
 
 # --- write_file ---
-New-Item -ItemType Directory -Force -Path "/etc" | Out-Null
+New-Item -ItemType Directory -Force -Path '/etc' | Out-Null
 $file = @'
 foobar
 '@
 [System.IO.File]::WriteAllText(
-  "/etc/hosts",
+  '/etc/hosts',
   $file.Trim(),
   [System.Text.Encoding]::ASCII
 )
@@ -90,12 +90,12 @@ func TestCustomPowerShellAWS(t *testing.T) {
 	assert.Equal(t, `<powershell>
 
 # --- write_file ---
-New-Item -ItemType Directory -Force -Path "/etc" | Out-Null
+New-Item -ItemType Directory -Force -Path '/etc' | Out-Null
 $file = @'
 foobar
 '@
 [System.IO.File]::WriteAllText(
-  "/etc/hosts",
+  '/etc/hosts',
   $file.Trim(),
   [System.Text.Encoding]::ASCII
 )

--- a/internal/provisioner/powershell_xml_test.go
+++ b/internal/provisioner/powershell_xml_test.go
@@ -48,14 +48,8 @@ func TestPowerShellAWS(t *testing.T) {
 
 # --- write_file ---
 New-Item -ItemType Directory -Force -Path '/etc' | Out-Null
-$file = @'
-foobar
-'@
-[System.IO.File]::WriteAllText(
-  '/etc/hosts',
-  $file.Trim(),
-  [System.Text.Encoding]::ASCII
-)
+$bytes = [System.Convert]::FromBase64String('Zm9vYmFy')
+[System.IO.File]::WriteAllBytes('/etc/hosts', $bytes)
 
 # --- runcmd ---
 echo 'hello world'
@@ -91,14 +85,8 @@ func TestCustomPowerShellAWS(t *testing.T) {
 
 # --- write_file ---
 New-Item -ItemType Directory -Force -Path '/etc' | Out-Null
-$file = @'
-foobar
-'@
-[System.IO.File]::WriteAllText(
-  '/etc/hosts',
-  $file.Trim(),
-  [System.Text.Encoding]::ASCII
-)
+$bytes = [System.Convert]::FromBase64String('Zm9vYmFy')
+[System.IO.File]::WriteAllBytes('/etc/hosts', $bytes)
 
 # --- runcmd ---
 echo 'hello world'


### PR DESCRIPTION
Paths went into a double quoted string and escapePS escaped only the quote character, so a path like
C:\k\$(ni PWNED).conf ran the subexpression on the target. They are single quoted now, which expands
nothing.

Content went into an @' here string, which is script text, so a body line holding the terminator
closed it and everything after ran as PowerShell. All content now takes the base64 and WriteAllBytes
path that append and non UTF8 bodies already used, at roughly 1.33x user data size.