### PR TITLE
Send Ignition file content as a data URL so YAML cannot mangle it

### DIFF
--- a/internal/provisioner/ignition.go
+++ b/internal/provisioner/ignition.go
@@ -72,22 +72,23 @@ func (i *IgnitionProvisioner) ToProvisionData(input *InputProvisionData) ([]byte
 			"mode": int(mi),
 		}
 
-		// An Ignition file entry carries either contents or append, never both.
-		// Append is new, so it can use a data URL, which holds any byte.
+		// A data URL is opaque to the YAML emitter, which cannot carry a leading
+		// newline in a block scalar and emits a tab that Butane then fails to parse.
+		uri, compression, err := butaneutil.MakeDataURL(content, nil, false)
+		if err != nil {
+			return nil, fmt.Errorf("error encoding contents of file %s: %w", f.Path, err)
+		}
+
+		body := map[string]string{"source": uri}
+		if compression != nil {
+			body["compression"] = *compression
+		}
+
+		// An entry carries either contents or append, never both.
 		if f.Append {
-			uri, compression, err := butaneutil.MakeDataURL(content, nil, false)
-			if err != nil {
-				return nil, fmt.Errorf("error encoding contents of file %s: %w", f.Path, err)
-			}
-
-			body := map[string]string{"source": uri}
-			if compression != nil {
-				body["compression"] = *compression
-			}
-
 			file["append"] = []map[string]string{body}
 		} else {
-			file["contents"] = map[string]string{"inline": string(content)}
+			file["contents"] = body
 		}
 
 		if user, group := f.OwnerUserAndGroup(); user != "" || group != "" {
@@ -135,8 +136,7 @@ func (i *IgnitionProvisioner) ToProvisionData(input *InputProvisionData) ([]byte
 	initIgn, _, err := config.TranslateBytes(
 		butaneYaml,
 		bcommon.TranslateBytesOptions{
-			TranslateOptions: bcommon.TranslateOptions{NoResourceAutoCompression: true},
-			Pretty:           true,
+			Pretty: true,
 		},
 	)
 	if err != nil {
@@ -165,6 +165,8 @@ func (i *IgnitionProvisioner) ToProvisionData(input *InputProvisionData) ([]byte
 
 	if i.AdditionalConfig != "" {
 		// translate additional Butane YAML to Ignition JSON
+		// User supplied Butane can still use inline contents, so auto compression has
+		// to stay off here or their file bodies come out gzipped.
 		addIgn, _, err := config.TranslateBytes(
 			[]byte(i.AdditionalConfig),
 			bcommon.TranslateBytesOptions{

--- a/internal/provisioner/ignition_test.go
+++ b/internal/provisioner/ignition_test.go
@@ -59,7 +59,7 @@ func TestToProvisionData(t *testing.T) {
           "config": {
             "merge": [
               {
-                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL3Rlc3QuY29uZiIsCiAgICAgICAgImNvbnRlbnRzIjogewogICAgICAgICAgInNvdXJjZSI6ICJkYXRhOixoZWxsbyUyMHdvcmxkIgogICAgICAgIH0sCiAgICAgICAgIm1vZGUiOiA0MjAKICAgICAgfQogICAgXQogIH0KfQ=="
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL3Rlc3QuY29uZiIsCiAgICAgICAgImNvbnRlbnRzIjogewogICAgICAgICAgImNvbXByZXNzaW9uIjogIiIsCiAgICAgICAgICAic291cmNlIjogImRhdGE6LGhlbGxvJTIwd29ybGQiCiAgICAgICAgfSwKICAgICAgICAibW9kZSI6IDQyMAogICAgICB9CiAgICBdCiAgfQp9"
               }
             ]
           },
@@ -108,7 +108,7 @@ func TestToProvisionData(t *testing.T) {
           "config": {
             "merge": [
               {
-                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL2NvbWJpbmVkLmNvbmYiLAogICAgICAgICJjb250ZW50cyI6IHsKICAgICAgICAgICJzb3VyY2UiOiAiZGF0YTosY29tYm8iCiAgICAgICAgfSwKICAgICAgICAibW9kZSI6IDQyMAogICAgICB9CiAgICBdCiAgfSwKICAic3lzdGVtZCI6IHsKICAgICJ1bml0cyI6IFsKICAgICAgewogICAgICAgICJjb250ZW50cyI6ICJbVW5pdF1cbkRlc2NyaXB0aW9uPUswcyBCb290c3RyYXAgQ29tbWFuZHNcbkFmdGVyPW5ldHdvcmstb25saW5lLnRhcmdldFxuXG5bU2VydmljZV1cblR5cGU9b25lc2hvdFxuRXhlY1N0YXJ0PS9iaW4vc2ggLWMgJ2VjaG8gY29tYm8nXG5SZW1haW5BZnRlckV4aXQ9dHJ1ZVxuXG5bSW5zdGFsbF1cbldhbnRlZEJ5PW11bHRpLXVzZXIudGFyZ2V0IiwKICAgICAgICAiZW5hYmxlZCI6IHRydWUsCiAgICAgICAgIm5hbWUiOiAiazBzLWJvb3RzdHJhcC5zZXJ2aWNlIgogICAgICB9CiAgICBdCiAgfQp9"
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL2NvbWJpbmVkLmNvbmYiLAogICAgICAgICJjb250ZW50cyI6IHsKICAgICAgICAgICJjb21wcmVzc2lvbiI6ICIiLAogICAgICAgICAgInNvdXJjZSI6ICJkYXRhOixjb21ibyIKICAgICAgICB9LAogICAgICAgICJtb2RlIjogNDIwCiAgICAgIH0KICAgIF0KICB9LAogICJzeXN0ZW1kIjogewogICAgInVuaXRzIjogWwogICAgICB7CiAgICAgICAgImNvbnRlbnRzIjogIltVbml0XVxuRGVzY3JpcHRpb249SzBzIEJvb3RzdHJhcCBDb21tYW5kc1xuQWZ0ZXI9bmV0d29yay1vbmxpbmUudGFyZ2V0XG5cbltTZXJ2aWNlXVxuVHlwZT1vbmVzaG90XG5FeGVjU3RhcnQ9L2Jpbi9zaCAtYyAnZWNobyBjb21ibydcblJlbWFpbkFmdGVyRXhpdD10cnVlXG5cbltJbnN0YWxsXVxuV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXQiLAogICAgICAgICJlbmFibGVkIjogdHJ1ZSwKICAgICAgICAibmFtZSI6ICJrMHMtYm9vdHN0cmFwLnNlcnZpY2UiCiAgICAgIH0KICAgIF0KICB9Cn0="
               }
             ]
           },
@@ -237,7 +237,7 @@ storage:
           "config": {
             "merge": [
               {
-                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL3Rlc3QuY29uZiIsCiAgICAgICAgImNvbnRlbnRzIjogewogICAgICAgICAgInNvdXJjZSI6ICJkYXRhOixoZWxsbyUyMHdvcmxkIgogICAgICAgIH0sCiAgICAgICAgIm1vZGUiOiA0MjAKICAgICAgfQogICAgXQogIH0KfQ=="
+                "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL3Rlc3QuY29uZiIsCiAgICAgICAgImNvbnRlbnRzIjogewogICAgICAgICAgImNvbXByZXNzaW9uIjogIiIsCiAgICAgICAgICAic291cmNlIjogImRhdGE6LGhlbGxvJTIwd29ybGQiCiAgICAgICAgfSwKICAgICAgICAibW9kZSI6IDQyMAogICAgICB9CiAgICBdCiAgfQp9"
               },
               {
                 "source": "data:application/json;base64,ewogICJpZ25pdGlvbiI6IHsKICAgICJ2ZXJzaW9uIjogIjMuMC4wIgogIH0sCiAgInN0b3JhZ2UiOiB7CiAgICAiZmlsZXMiOiBbCiAgICAgIHsKICAgICAgICAicGF0aCI6ICIvZXRjL2V4dHJhLmNvbmYiLAogICAgICAgICJtb2RlIjogNDIwCiAgICAgIH0KICAgIF0KICB9Cn0="
@@ -446,9 +446,9 @@ func TestIgnitionAppendContentRoundTrip(t *testing.T) {
 	}
 }
 
-// TestIgnitionReplaceUsesInline pins the existing shape. Butane mangles content
-// whose first line starts with whitespace, which is tracked separately.
-func TestIgnitionReplaceUsesInline(t *testing.T) {
+// TestIgnitionReplaceUsesContents pins the shape of a plain replace, a contents
+// entry with no append and no compression requested.
+func TestIgnitionReplaceUsesContents(t *testing.T) {
 	out, err := (&IgnitionProvisioner{Variant: "fcos", Version: "1.5.0"}).ToProvisionData(
 		&InputProvisionData{Files: []File{{Path: "/a", Content: "hello world", Permissions: "0644"}}})
 	require.NoError(t, err)
@@ -458,7 +458,7 @@ func TestIgnitionReplaceUsesInline(t *testing.T) {
 
 	contents, ok := entry["contents"].(map[string]any)
 	require.True(t, ok)
-	require.Equal(t, "", contents["compression"], "butane sets an empty compression for inline bodies")
+	require.Equal(t, "", contents["compression"], "no compression is requested for a file body")
 	require.Equal(t, "hello world", string(bodyBytes(t, contents)))
 }
 
@@ -478,10 +478,65 @@ func TestIgnitionEncodedContentIsDecodedOnce(t *testing.T) {
 	}
 }
 
+// TestIgnitionOpenshiftVariantCannotRender records that the API accepts a variant the
+// provisioner can never translate, since openshift wants a MachineConfig wrapper.
+func TestIgnitionOpenshiftVariantCannotRender(t *testing.T) {
+	_, err := (&IgnitionProvisioner{Variant: "openshift", Version: "4.19.0"}).ToProvisionData(
+		&InputProvisionData{Files: []File{{Path: "/a", Content: "x", Permissions: "0644"}}})
+
+	require.ErrorContains(t, err, "error translating butane config")
+}
+
 func TestIgnitionRejectsUndecodableContent(t *testing.T) {
 	p := &IgnitionProvisioner{Variant: "fcos", Version: "1.0.0"}
 	_, err := p.ToProvisionData(&InputProvisionData{
 		Files: []File{{Path: "/a", Content: "!!!", Permissions: "0644", Encoding: Base64}},
 	})
 	require.ErrorContains(t, err, "failed to base64 decode")
+}
+
+// TestIgnitionPreservesContentYAMLCannotCarry covers what the old inline scalar got
+// wrong, a leading newline and a leading tab. The rest round tripped and stay as guards.
+func TestIgnitionPreservesContentYAMLCannotCarry(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+	}{
+		{"a leading newline", "\nfoo\n"},
+		{"nothing but a newline", "\n"},
+		{"a leading tab", "\tindented\n"},
+		{"a leading space", "  indented\n"},
+		{"trailing whitespace", "foo   \n"},
+		{"crlf", "a\r\nb\r\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := (&IgnitionProvisioner{Variant: "fcos", Version: "1.5.0"}).ToProvisionData(
+				&InputProvisionData{Files: []File{{Path: "/a", Content: tc.content, Permissions: "0644"}}})
+			require.NoError(t, err)
+
+			entry := fileEntry(t, out)
+			require.Equal(t, tc.content, string(bodyBytes(t, entry["contents"].(map[string]any))))
+		})
+	}
+}
+
+// TestIgnitionPreservesContentAcrossSpecVersions covers the same body on every stable
+// variant and version Butane registers, apart from openshift, which cannot render here.
+func TestIgnitionPreservesContentAcrossSpecVersions(t *testing.T) {
+	for _, v := range []struct{ variant, version string }{
+		{"fcos", "1.0.0"}, {"fcos", "1.1.0"}, {"fcos", "1.2.0"}, {"fcos", "1.3.0"},
+		{"fcos", "1.4.0"}, {"fcos", "1.5.0"}, {"fcos", "1.6.0"},
+		{"flatcar", "1.0.0"}, {"flatcar", "1.1.0"},
+		{"fiot", "1.0.0"},
+		{"r4e", "1.0.0"}, {"r4e", "1.1.0"},
+	} {
+		t.Run(v.variant+" "+v.version, func(t *testing.T) {
+			out, err := (&IgnitionProvisioner{Variant: v.variant, Version: v.version}).ToProvisionData(
+				&InputProvisionData{Files: []File{{Path: "/a", Content: "\n\tboth\n", Permissions: "0644"}}})
+			require.NoError(t, err)
+
+			entry := fileEntry(t, out)
+			require.Equal(t, "\n\tboth\n", string(bodyBytes(t, entry["contents"].(map[string]any))))
+		})
+	}
 }


### PR DESCRIPTION
Content went out as a Butane inline scalar, which is YAML, so a leading newline was dropped, a body of just a newline produced an empty file, and a leading tab failed the whole render. A data URL holds any byte, and the append branch already used one.