### PR TITLE
Count every machine in the control plane replica total

### DIFF
--- a/internal/controller/controlplane/status.go
+++ b/internal/controller/controlplane/status.go
@@ -62,8 +62,6 @@ func (c *K0sController) updateStatus(ctx context.Context, controlplane *controlp
 }
 
 func computeReplicas(controlplane *controlplane) error {
-	controlplane.kcp.Status.Replicas = new(int32(len(controlplane.activeMachines)))
-
 	var allReplicas []*clusterv1.Machine
 	allReplicas = append(allReplicas, controlplane.activeMachines.UnsortedList()...)
 	allReplicas = append(allReplicas, controlplane.deletedMachines.UnsortedList()...)
@@ -81,6 +79,9 @@ func computeReplicas(controlplane *controlplane) error {
 		}
 	}
 
+	// One collection feeds all four, so a machine that is deleting but still ready
+	// cannot be counted by one of them and left out of the total.
+	controlplane.kcp.Status.Replicas = new(int32(len(allReplicas)))
 	controlplane.kcp.Status.ReadyReplicas = new(int32(readyReplicas))
 	controlplane.kcp.Status.UpToDateReplicas = new(int32(upToDateReplicas))
 	controlplane.kcp.Status.AvailableReplicas = new(int32(availableReplicas))

--- a/internal/controller/controlplane/status_test.go
+++ b/internal/controller/controlplane/status_test.go
@@ -143,6 +143,43 @@ func Test_machineStatusCompute(t *testing.T) {
 		require.Equal(t, "v1.30.0", kcp.Status.Version)
 	})
 
+	t.Run("test a deleting machine counts in the total as well as the counters", func(t *testing.T) {
+		// The counters run over active and deleted machines together, so the total has
+		// to as well. Otherwise the v1beta1 conversion publishes a negative
+		// unavailableReplicas, computed as replicas minus availableReplicas.
+		ready := []metav1.Condition{
+			{Type: clusterv1.MachineReadyCondition, Status: metav1.ConditionTrue},
+			{Type: clusterv1.MachineAvailableCondition, Status: metav1.ConditionTrue},
+			{Type: clusterv1.MachineUpToDateCondition, Status: metav1.ConditionTrue},
+		}
+		kcp := &cpv1beta2.K0sControlPlane{
+			Spec: cpv1beta2.K0sControlPlaneSpec{Version: "v1.31.0", Replicas: 3},
+		}
+
+		scope := &controlplane{
+			kcp: kcp,
+			activeMachines: collections.Machines{
+				"machine1": &clusterv1.Machine{
+					Spec:   clusterv1.MachineSpec{Version: "v1.31.0"},
+					Status: clusterv1.MachineStatus{Conditions: ready},
+				},
+			},
+			deletedMachines: collections.Machines{
+				"machine2": &clusterv1.Machine{
+					Spec:   clusterv1.MachineSpec{Version: "v1.31.0"},
+					Status: clusterv1.MachineStatus{Conditions: ready},
+				},
+			},
+		}
+		err := computeReplicas(scope)
+
+		require.NoError(t, err)
+		require.Equal(t, int32(2), *kcp.Status.Replicas)
+		require.Equal(t, int32(2), *kcp.Status.ReadyReplicas)
+		require.Equal(t, int32(2), *kcp.Status.AvailableReplicas)
+		require.Equal(t, int32(2), *kcp.Status.UpToDateReplicas)
+	})
+
 	t.Run("test all ready and available are ready but not using suffix", func(t *testing.T) {
 		kcp := &cpv1beta2.K0sControlPlane{
 			Spec: cpv1beta2.K0sControlPlaneSpec{


### PR DESCRIPTION
The three condition counters ran over the active and the deleting machines while the total counted only the active ones, so a machine that is deleting but still available made the v1beta1 conversion publish a negative unavailableReplicas.
