### PR TITLE
Surface the paused condition on both control plane flavours

### DIFF
--- a/internal/controller/controlplane/k0s_controlplane_controller.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller.go
@@ -48,11 +48,11 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	capiutil "sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/certs"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	"sigs.k8s.io/cluster-api/util/secret"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -187,9 +187,10 @@ func (c *K0sController) Reconcile(ctx context.Context, req ctrl.Request) (res ct
 		return ctrl.Result{}, err
 	}
 
-	if annotations.IsPaused(cluster, kcp) {
-		log.Info("Reconciliation is paused for this object or owning cluster")
-		return ctrl.Result{}, nil
+	// The contract asks for the paused state to be surfaced and not only obeyed, so
+	// the helper patches the condition before reporting whether to stop.
+	if isPaused, requeue, err := paused.EnsurePausedCondition(ctx, c.Client, cluster, kcp); err != nil || isPaused || requeue {
+		return ctrl.Result{}, err
 	}
 
 	controlplane, err := c.retrieveControlPlaneState(ctx, cluster, kcp)

--- a/internal/controller/controlplane/k0s_controlplane_controller_env_test.go
+++ b/internal/controller/controlplane/k0s_controlplane_controller_env_test.go
@@ -122,6 +122,19 @@ func TestReconcileNoK0sControlPlane(t *testing.T) {
 	require.Equal(t, ctrl.Result{}, result)
 }
 
+// requirePausedCondition reads the control plane back and checks the condition the
+// contract asks providers to surface.
+func requirePausedCondition(t *testing.T, kcp *cpv1beta2.K0sControlPlane, want metav1.ConditionStatus) {
+	t.Helper()
+
+	seen := &cpv1beta2.K0sControlPlane{}
+	require.NoError(t, testEnv.Get(ctx, util.ObjectKey(kcp), seen))
+
+	cond := conditions.Get(seen, clusterv1.PausedCondition)
+	require.NotNil(t, cond, "the paused condition is declared, so it has to be set")
+	require.Equal(t, want, cond.Status)
+}
+
 func TestReconcilePausedCluster(t *testing.T) {
 	ns, err := testEnv.CreateNamespace(ctx, "test-reconcile-paused-cluster")
 	require.NoError(t, err)
@@ -157,6 +170,7 @@ func TestReconcilePausedCluster(t *testing.T) {
 	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
 	require.NoError(t, err)
 	require.Equal(t, ctrl.Result{}, result)
+	requirePausedCondition(t, kcp, metav1.ConditionTrue)
 }
 
 func TestReconcilePausedK0sControlPlane(t *testing.T) {
@@ -189,6 +203,28 @@ func TestReconcilePausedK0sControlPlane(t *testing.T) {
 	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
 	require.NoError(t, err)
 	require.Equal(t, ctrl.Result{}, result)
+	requirePausedCondition(t, kcp, metav1.ConditionTrue)
+
+	// Unpausing has to clear it, or the object stays paused in status forever.
+	require.NoError(t, testEnv.Get(ctx, util.ObjectKey(kcp), kcp))
+	kcp.Annotations = nil
+	require.NoError(t, testEnv.Update(ctx, kcp))
+
+	require.Eventually(t, func() bool {
+		seen := &cpv1beta2.K0sControlPlane{}
+		if err := testEnv.Get(ctx, util.ObjectKey(kcp), seen); err != nil {
+			return false
+		}
+
+		return len(seen.Annotations) == 0
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// The helper patches the flip and asks to be called again, so this reconcile
+	// stops right after clearing the condition rather than going on.
+	result, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+	requirePausedCondition(t, kcp, metav1.ConditionFalse)
 }
 
 func TestReconcileTunneling(t *testing.T) {
@@ -1045,6 +1081,11 @@ func TestReconcileInitializeControlPlanes(t *testing.T) {
 		ClusterCache:              clustercache.NewFakeClusterCache(fake.NewClientBuilder().Build(), client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}),
 	}
 
+	// The first pass records the paused condition and asks to be called again, which
+	// a watch on the object does for a controller that is actually running.
+	_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
+	require.NoError(t, err)
+
 	_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
 	require.NoError(t, err)
 	require.NoError(t, testEnv.GetAPIReader().Get(ctx, client.ObjectKey{Name: kcp.Name, Namespace: kcp.Namespace}, kcp))
@@ -1486,7 +1527,9 @@ func TestReconcileArmsTheAvailabilityRequeue(t *testing.T) {
 	require.Eventually(t, func() bool {
 		res, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
 
-		return err == nil
+		// The pass that records the paused condition returns early with a zero
+		// result, so wait for one that reached the deferred block.
+		return err == nil && !res.IsZero()
 	}, 20*time.Second, 200*time.Millisecond, "the reconcile never got far enough to arm a requeue")
 
 	// Not available here, since nothing serves the workload API, so this is the

--- a/internal/controller/controlplane/k0smotron_controlplane_controller.go
+++ b/internal/controller/controlplane/k0smotron_controlplane_controller.go
@@ -55,6 +55,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	"sigs.k8s.io/cluster-api/util/secret"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -162,9 +163,10 @@ func (c *K0smotronController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	log = log.WithValues("cluster", cluster.Name)
 
-	if annotations.IsPaused(cluster, kcp) {
-		log.Info("Reconciliation is paused for this object")
-		return ctrl.Result{}, nil
+	// The contract asks for the paused state to be surfaced and not only obeyed, so
+	// the helper patches the condition before reporting whether to stop.
+	if isPaused, requeue, err := paused.EnsurePausedCondition(ctx, c.Client, cluster, kcp); err != nil || isPaused || requeue {
+		return ctrl.Result{}, err
 	}
 
 	kmcScope, err := c.getKmcScope(ctx, kcp)

--- a/internal/controller/controlplane/status_test.go
+++ b/internal/controller/controlplane/status_test.go
@@ -1823,9 +1823,14 @@ func TestHostedReconcileKeepsBothErrors(t *testing.T) {
 		ClusterCache: stubClusterCache{err: errors.New("connection refused")},
 	}
 
-	_, err := c.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: client.ObjectKey{Namespace: "default", Name: "test"},
-	})
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "test"}}
+
+	// The first pass records the paused condition and asks to be called again, so the
+	// body it is meant to reach runs on the second one.
+	_, err := c.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	_, err = c.Reconcile(context.Background(), req)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "body boom",
@@ -1847,11 +1852,15 @@ func TestHostedReconcilePersistsAvailabilityOnAStatusError(t *testing.T) {
 		ClusterCache: stubClusterCache{err: errors.New("connection refused")},
 	}
 
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "test"}}
+
+	// The first pass records the paused condition and asks to be called again.
+	_, err := c.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
 	// The status computation fails here, which is the point. What matters is what the
 	// deferred block persisted on the way out.
-	res, err := c.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: client.ObjectKey{Namespace: "default", Name: "test"},
-	})
+	res, err := c.Reconcile(context.Background(), req)
 
 	// Handed back, or nothing brings the control plane round again and the grace
 	// period never advances, so the outage is never reported.
@@ -1904,11 +1913,16 @@ func TestHostedReconcileDeletePersistsFinalizerRemoval(t *testing.T) {
 	// map that was empty all along.
 	c.availabilityFailures.Store(availabilityKey(kcp), availabilityFailures{since: time.Now(), seen: 1})
 
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "test"}}
+
+	// The first pass records the paused condition and asks to be called again, which
+	// happens for a deleting object too.
+	_, err := c.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
 	// The infrastructure patch at the end of the defer has nothing to patch here and
 	// errors, which is fine. What matters is that the patch before it ran.
-	_, _ = c.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: client.ObjectKey{Namespace: "default", Name: "test"},
-	})
+	_, _ = c.Reconcile(context.Background(), req)
 
 	_, ok := c.availabilityFailures.Load(availabilityKey(kcp))
 	require.False(t, ok,
@@ -1916,7 +1930,7 @@ func TestHostedReconcileDeletePersistsFinalizerRemoval(t *testing.T) {
 
 	// Gone entirely once the last finalizer is dropped, which is the whole point.
 	persisted := &cpv1beta2.K0smotronControlPlane{}
-	err := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "test"}, persisted)
+	err = c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "test"}, persisted)
 	if err == nil {
 		require.NotContains(t, persisted.Finalizers, cpv1beta2.K0smotronControlPlaneFinalizer,
 			"the finalizer removal has to be persisted, or the object never goes away")


### PR DESCRIPTION
The condition was declared in both API versions and never set, so a paused control plane looked identical to a running one. Both controllers now call the upstream helper, which patches the condition and reports whether to stop, and the first pass of a reconcile records it and comes back.