### PR TITLE
Page through the node list when matching a machine to a node

### DIFF
--- a/internal/controller/bootstrap/providerid_controller.go
+++ b/internal/controller/bootstrap/providerid_controller.go
@@ -39,6 +39,10 @@ import (
 	k0smoutil "github.com/k0sproject/k0smotron/v2/internal/controller/util"
 )
 
+// nodeListPageSize bounds one node list request. The client carries a request
+// timeout, which a whole large cluster in a single response can outlast.
+const nodeListPageSize = 500
+
 // ProviderIDController is responsible for reconciling the ProviderID field of the Machine resource.
 type ProviderIDController struct {
 	client.Client
@@ -89,39 +93,12 @@ func (p *ProviderIDController) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, fmt.Errorf("can't get kube client for cluster %s/%s: %w. may not be created yet", machine.Namespace, machine.Spec.ClusterName, err)
 	}
 
-	nodes, err := childClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	node, providerIDSet, err := nodeForMachine(ctx, childClient.CoreV1().Nodes().List, machine)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list nodes in cluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
 	}
-
-	var node *corev1.Node
-	for _, n := range nodes.Items {
-		if n.Spec.ProviderID == machine.Spec.ProviderID {
-			// ProviderID is already set on the node
-			return ctrl.Result{}, nil
-		}
-
-		// If node name matches machine name, we have found our node
-		if n.Name == machine.GetName() {
-			node = &n
-			break
-		}
-
-		// Check k0smotron.io/machine-name node label
-		if val, ok := n.Labels[machineNameNodeLabel]; ok && val == machine.GetName() {
-			node = &n
-			break
-		}
-
-		// Check node addresses against machine addresses
-		for _, addr := range machine.Status.Addresses {
-			for _, nodeAddr := range n.Status.Addresses {
-				if addr.Address == nodeAddr.Address && !net.ParseIP(nodeAddr.Address).IsLoopback() {
-					node = &n
-					break
-				}
-			}
-		}
+	if providerIDSet {
+		return ctrl.Result{}, nil
 	}
 
 	if node == nil {
@@ -145,6 +122,56 @@ func (p *ProviderIDController) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// listNodes is the node list call, which a test can stand in for.
+type listNodes func(ctx context.Context, opts metav1.ListOptions) (*corev1.NodeList, error)
+
+// nodeForMachine finds the node the machine's providerID belongs on, a page at a
+// time. The bool reports the providerID already being on a node.
+func nodeForMachine(ctx context.Context, list listNodes, machine *clusterv1.Machine) (*corev1.Node, bool, error) {
+	opts := metav1.ListOptions{Limit: nodeListPageSize}
+
+	for {
+		nodes, err := list(ctx, opts)
+		if err != nil {
+			return nil, false, err
+		}
+
+		for i := range nodes.Items {
+			n := &nodes.Items[i]
+
+			if n.Spec.ProviderID == machine.Spec.ProviderID {
+				// ProviderID is already set on the node
+				return nil, true, nil
+			}
+
+			// If node name matches machine name, we have found our node
+			if n.Name == machine.GetName() {
+				return n, false, nil
+			}
+
+			// Check k0smotron.io/machine-name node label
+			if val, ok := n.Labels[machineNameNodeLabel]; ok && val == machine.GetName() {
+				return n, false, nil
+			}
+
+			// Check node addresses against machine addresses
+			for _, addr := range machine.Status.Addresses {
+				for _, nodeAddr := range n.Status.Addresses {
+					if addr.Address == nodeAddr.Address && !net.ParseIP(nodeAddr.Address).IsLoopback() {
+						return n, false, nil
+					}
+				}
+			}
+		}
+
+		if nodes.Continue == "" {
+			return nil, false, nil
+		}
+
+		opts.Continue = nodes.Continue
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/bootstrap/providerid_controller_test.go
+++ b/internal/controller/bootstrap/providerid_controller_test.go
@@ -1,0 +1,188 @@
+//go:build !envtest
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+)
+
+// pagedNodes serves the given pages in order and records the options it was called
+// with, so a test can see both the page size and the continue token.
+func pagedNodes(pages ...[]corev1.Node) (listNodes, *[]metav1.ListOptions) {
+	seen := &[]metav1.ListOptions{}
+	call := 0
+
+	return func(_ context.Context, opts metav1.ListOptions) (*corev1.NodeList, error) {
+		*seen = append(*seen, opts)
+
+		list := &corev1.NodeList{Items: pages[call]}
+		if call < len(pages)-1 {
+			list.Continue = "next"
+		}
+		call++
+
+		return list, nil
+	}, seen
+}
+
+func node(name string, mutate func(*corev1.Node)) corev1.Node {
+	n := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if mutate != nil {
+		mutate(&n)
+	}
+
+	return n
+}
+
+func machineWithProviderID(name, providerID string, addresses ...string) *clusterv1.Machine {
+	m := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       clusterv1.MachineSpec{ProviderID: providerID},
+	}
+	for _, a := range addresses {
+		m.Status.Addresses = append(m.Status.Addresses, clusterv1.MachineAddress{Address: a})
+	}
+
+	return m
+}
+
+func TestNodeForMachineMatching(t *testing.T) {
+	machine := machineWithProviderID("machine1", "test://1", "10.0.0.1")
+
+	t.Run("by name", func(t *testing.T) {
+		list, _ := pagedNodes([]corev1.Node{node("other", nil), node("machine1", nil)})
+
+		found, providerIDSet, err := nodeForMachine(context.Background(), list, machine)
+		require.NoError(t, err)
+		require.False(t, providerIDSet)
+		require.NotNil(t, found)
+		require.Equal(t, "machine1", found.Name)
+	})
+
+	t.Run("by machine name label", func(t *testing.T) {
+		list, _ := pagedNodes([]corev1.Node{node("node1", func(n *corev1.Node) {
+			n.Labels = map[string]string{machineNameNodeLabel: "machine1"}
+		})})
+
+		found, _, err := nodeForMachine(context.Background(), list, machine)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		require.Equal(t, "node1", found.Name)
+	})
+
+	t.Run("by address", func(t *testing.T) {
+		list, _ := pagedNodes([]corev1.Node{node("node1", func(n *corev1.Node) {
+			n.Status.Addresses = []corev1.NodeAddress{{Address: "10.0.0.1"}}
+		})})
+
+		found, _, err := nodeForMachine(context.Background(), list, machine)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		require.Equal(t, "node1", found.Name)
+	})
+
+	t.Run("a loopback address is not a match", func(t *testing.T) {
+		loopback := machineWithProviderID("machine1", "test://1", "127.0.0.1")
+		list, _ := pagedNodes([]corev1.Node{node("node1", func(n *corev1.Node) {
+			n.Status.Addresses = []corev1.NodeAddress{{Address: "127.0.0.1"}}
+		})})
+
+		found, providerIDSet, err := nodeForMachine(context.Background(), list, loopback)
+		require.NoError(t, err)
+		require.False(t, providerIDSet)
+		require.Nil(t, found)
+	})
+
+	t.Run("the providerID already being set reports nothing to do", func(t *testing.T) {
+		list, _ := pagedNodes([]corev1.Node{node("node1", func(n *corev1.Node) {
+			n.Spec.ProviderID = "test://1"
+		}), node("machine1", nil)})
+
+		found, providerIDSet, err := nodeForMachine(context.Background(), list, machine)
+		require.NoError(t, err)
+		require.True(t, providerIDSet)
+		require.Nil(t, found)
+	})
+
+	t.Run("the first match wins and the rest are left alone", func(t *testing.T) {
+		// Both match by address, so scanning on would hand back the later one.
+		byAddress := func(n *corev1.Node) {
+			n.Status.Addresses = []corev1.NodeAddress{{Address: "10.0.0.1"}}
+		}
+		list, seen := pagedNodes(
+			[]corev1.Node{node("node1", byAddress), node("node2", byAddress)},
+			[]corev1.Node{node("node3", byAddress)},
+		)
+
+		found, _, err := nodeForMachine(context.Background(), list, machine)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		require.Equal(t, "node1", found.Name)
+		require.Len(t, *seen, 1, "a match on the first page must not ask for the second")
+	})
+}
+
+func TestNodeForMachinePaging(t *testing.T) {
+	machine := machineWithProviderID("machine1", "test://1")
+
+	t.Run("the continue token is followed", func(t *testing.T) {
+		list, seen := pagedNodes(
+			[]corev1.Node{node("node1", nil)},
+			[]corev1.Node{node("node2", nil)},
+			[]corev1.Node{node("machine1", nil)},
+		)
+
+		found, _, err := nodeForMachine(context.Background(), list, machine)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		require.Equal(t, "machine1", found.Name)
+
+		require.Len(t, *seen, 3)
+		require.Equal(t, int64(nodeListPageSize), (*seen)[0].Limit, "the list has to be bounded")
+		require.Empty(t, (*seen)[0].Continue)
+		require.Equal(t, "next", (*seen)[1].Continue)
+		require.Equal(t, "next", (*seen)[2].Continue)
+	})
+
+	t.Run("no match anywhere", func(t *testing.T) {
+		list, seen := pagedNodes([]corev1.Node{node("node1", nil)}, []corev1.Node{node("node2", nil)})
+
+		found, providerIDSet, err := nodeForMachine(context.Background(), list, machine)
+		require.NoError(t, err)
+		require.False(t, providerIDSet)
+		require.Nil(t, found)
+		require.Len(t, *seen, 2, "every page has to be read before giving up")
+	})
+
+	t.Run("a failed page is reported", func(t *testing.T) {
+		list := func(_ context.Context, _ metav1.ListOptions) (*corev1.NodeList, error) {
+			return nil, errors.New("boom")
+		}
+
+		_, _, err := nodeForMachine(context.Background(), list, machine)
+		require.ErrorContains(t, err, "boom")
+	})
+}


### PR DESCRIPTION
The list asked for every node in the workload cluster in one request, which a large cluster cannot answer inside the timeout the client carries. The matching moved into a helper that takes the list call and follows the continue token, and it now returns on the first match rather than scanning on.