### PR TITLE
Report scaling from machine totals and add the RollingOut condition

### DIFF
--- a/api/controlplane/v1beta2/conditions_consts.go
+++ b/api/controlplane/v1beta2/conditions_consts.go
@@ -51,4 +51,14 @@ const (
 
 	// K0sControlPlaneNotScalingDownReason surfaces when actual replicas <= desired replicas.
 	K0sControlPlaneNotScalingDownReason = clusterv1.NotScalingDownReason
+
+	// K0sControlPlaneRollingOutCondition is true while a machine still has to be
+	// replaced or updated to match the spec, which scaling does not report.
+	K0sControlPlaneRollingOutCondition = clusterv1.RollingOutCondition
+
+	// K0sControlPlaneRollingOutReason surfaces when at least one machine is not up to date.
+	K0sControlPlaneRollingOutReason = clusterv1.RollingOutReason
+
+	// K0sControlPlaneNotRollingOutReason surfaces when every machine is up to date.
+	K0sControlPlaneNotRollingOutReason = clusterv1.NotRollingOutReason
 )

--- a/internal/controller/controlplane/status.go
+++ b/internal/controller/controlplane/status.go
@@ -113,8 +113,32 @@ func computeReplicas(controlplane *controlplane) error {
 	}
 
 	setScalingConditions(controlplane)
+	setRollingOutCondition(controlplane)
 
 	return nil
+}
+
+// setRollingOutCondition reports whether a machine still has to be replaced or
+// updated, which is the progress the scaling conditions must not carry.
+func setRollingOutCondition(controlplane *controlplane) {
+	rollingOutReplicas := controlplane.notUpToDateMachines.Len()
+
+	if rollingOutReplicas == 0 {
+		conditions.Set(controlplane.kcp, metav1.Condition{
+			Type:   string(cpv1beta2.K0sControlPlaneRollingOutCondition),
+			Status: metav1.ConditionFalse,
+			Reason: cpv1beta2.K0sControlPlaneNotRollingOutReason,
+		})
+
+		return
+	}
+
+	conditions.Set(controlplane.kcp, metav1.Condition{
+		Type:    string(cpv1beta2.K0sControlPlaneRollingOutCondition),
+		Status:  metav1.ConditionTrue,
+		Reason:  cpv1beta2.K0sControlPlaneRollingOutReason,
+		Message: fmt.Sprintf("Rolling out %d not up-to-date replicas", rollingOutReplicas),
+	})
 }
 
 func setScalingConditions(controlplane *controlplane) {

--- a/internal/controller/controlplane/status.go
+++ b/internal/controller/controlplane/status.go
@@ -118,15 +118,17 @@ func computeReplicas(controlplane *controlplane) error {
 }
 
 func setScalingConditions(controlplane *controlplane) {
-	upToDateReplicas := controlplane.upToDateMachines.Len()
+	// Scaling is about how many machines exist, not how many are up to date. Deleting
+	// machines count too, so a scale down stays true until they are gone.
+	replicas := controlplane.activeMachines.Len() + controlplane.deletedMachines.Len()
 
-	if upToDateReplicas < int(controlplane.kcp.Spec.Replicas) {
+	if replicas < int(controlplane.kcp.Spec.Replicas) {
 		conditions.Set(controlplane.kcp, metav1.Condition{
 			Type:   string(cpv1beta2.K0sControlPlaneScalingUpCondition),
 			Status: metav1.ConditionTrue,
 			Reason: cpv1beta2.K0sControlPlaneScalingUpReason,
 			Message: fmt.Sprintf("Control plane is scaling up: %d/%d",
-				upToDateReplicas, controlplane.kcp.Spec.Replicas),
+				replicas, controlplane.kcp.Spec.Replicas),
 		})
 	} else {
 		conditions.Set(controlplane.kcp, metav1.Condition{
@@ -136,13 +138,13 @@ func setScalingConditions(controlplane *controlplane) {
 		})
 	}
 
-	if upToDateReplicas > int(controlplane.kcp.Spec.Replicas) {
+	if replicas > int(controlplane.kcp.Spec.Replicas) {
 		conditions.Set(controlplane.kcp, metav1.Condition{
 			Type:   string(cpv1beta2.K0sControlPlaneScalingDownCondition),
 			Status: metav1.ConditionTrue,
 			Reason: cpv1beta2.K0sControlPlaneScalingDownReason,
 			Message: fmt.Sprintf("Control plane is scaling down: %d/%d",
-				upToDateReplicas, controlplane.kcp.Spec.Replicas),
+				replicas, controlplane.kcp.Spec.Replicas),
 		})
 	} else {
 		conditions.Set(controlplane.kcp, metav1.Condition{

--- a/internal/controller/controlplane/status_test.go
+++ b/internal/controller/controlplane/status_test.go
@@ -1821,6 +1821,94 @@ func hostedReconcileFixture() (*clusterv1.Cluster, *cpv1beta2.K0smotronControlPl
 	return cluster, kcp, kmc
 }
 
+// machineWithConditions builds a machine carrying the given condition types as true.
+func machineWithConditions(name string, deleting bool, trueConditions ...string) *clusterv1.Machine {
+	m := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       clusterv1.MachineSpec{Version: "v1.31.0"},
+	}
+	if deleting {
+		m.DeletionTimestamp = &metav1.Time{Time: time.Unix(1, 0)}
+	}
+	for _, t := range trueConditions {
+		m.Status.Conditions = append(m.Status.Conditions, metav1.Condition{Type: t, Status: metav1.ConditionTrue})
+	}
+
+	return m
+}
+
+// scalingScope builds a scope with the given machine counts, all of them active
+// unless deleting, and none of them up to date unless said so.
+func scalingScope(desired int32, active, deleting, upToDate int) *controlplane {
+	scope := &controlplane{
+		kcp:              &cpv1beta2.K0sControlPlane{Spec: cpv1beta2.K0sControlPlaneSpec{Version: "v1.31.0", Replicas: desired}},
+		activeMachines:   collections.New(),
+		deletedMachines:  collections.New(),
+		upToDateMachines: collections.New(),
+	}
+	for i := 0; i < active; i++ {
+		m := machineWithConditions(fmt.Sprintf("active%d", i), false)
+		scope.activeMachines.Insert(m)
+		if i < upToDate {
+			scope.upToDateMachines.Insert(m)
+		}
+	}
+	for i := 0; i < deleting; i++ {
+		scope.deletedMachines.Insert(machineWithConditions(fmt.Sprintf("deleting%d", i), true))
+	}
+	scope.notUpToDateMachines = scope.activeMachines.Difference(scope.upToDateMachines)
+
+	return scope
+}
+
+func scalingStatus(t *testing.T, scope *controlplane) (up, down *metav1.Condition) {
+	t.Helper()
+
+	setScalingConditions(scope)
+
+	return conditions.Get(scope.kcp, string(cpv1beta2.K0sControlPlaneScalingUpCondition)),
+		conditions.Get(scope.kcp, string(cpv1beta2.K0sControlPlaneScalingDownCondition))
+}
+
+// TestSetScalingConditionsCountsMachines covers scaling being reported from the
+// machine total rather than from how many of them are up to date.
+func TestSetScalingConditionsCountsMachines(t *testing.T) {
+	t.Run("a rollout is not a scale up", func(t *testing.T) {
+		// Three machines wanted, three exist, one already replaced. The default
+		// InPlace strategy creates no machine at all, so nothing is scaling.
+		up, down := scalingStatus(t, scalingScope(3, 3, 0, 1))
+
+		require.Equal(t, metav1.ConditionFalse, up.Status, "a rollout must not report as scaling up")
+		require.Equal(t, metav1.ConditionFalse, down.Status)
+	})
+
+	t.Run("a missing machine is a scale up", func(t *testing.T) {
+		up, down := scalingStatus(t, scalingScope(3, 2, 0, 2))
+
+		require.Equal(t, metav1.ConditionTrue, up.Status)
+		require.Contains(t, up.Message, "2/3")
+		require.Equal(t, metav1.ConditionFalse, down.Status)
+	})
+
+	t.Run("a lowered replica count is a scale down", func(t *testing.T) {
+		up, down := scalingStatus(t, scalingScope(1, 3, 0, 3))
+
+		require.Equal(t, metav1.ConditionFalse, up.Status)
+		require.Equal(t, metav1.ConditionTrue, down.Status)
+		require.Contains(t, down.Message, "3/1")
+	})
+
+	t.Run("a deleting machine still counts", func(t *testing.T) {
+		// The surge machine is up, the outdated one is draining. Reporting the
+		// total keeps ScalingDown true until it is really gone.
+		up, down := scalingStatus(t, scalingScope(3, 3, 1, 3))
+
+		require.Equal(t, metav1.ConditionFalse, up.Status)
+		require.Equal(t, metav1.ConditionTrue, down.Status)
+		require.Contains(t, down.Message, "4/3")
+	})
+}
+
 // failPodList is what makes computeStatus fail hard while the reconcile body succeeds.
 func failPodList() interceptor.Funcs {
 	return interceptor.Funcs{

--- a/internal/controller/controlplane/status_test.go
+++ b/internal/controller/controlplane/status_test.go
@@ -1846,14 +1846,14 @@ func scalingScope(desired int32, active, deleting, upToDate int) *controlplane {
 		deletedMachines:  collections.New(),
 		upToDateMachines: collections.New(),
 	}
-	for i := 0; i < active; i++ {
+	for i := range active {
 		m := machineWithConditions(fmt.Sprintf("active%d", i), false)
 		scope.activeMachines.Insert(m)
 		if i < upToDate {
 			scope.upToDateMachines.Insert(m)
 		}
 	}
-	for i := 0; i < deleting; i++ {
+	for i := range deleting {
 		scope.deletedMachines.Insert(machineWithConditions(fmt.Sprintf("deleting%d", i), true))
 	}
 	scope.notUpToDateMachines = scope.activeMachines.Difference(scope.upToDateMachines)
@@ -1906,6 +1906,48 @@ func TestSetScalingConditionsCountsMachines(t *testing.T) {
 		require.Equal(t, metav1.ConditionFalse, up.Status)
 		require.Equal(t, metav1.ConditionTrue, down.Status)
 		require.Contains(t, down.Message, "4/3")
+	})
+}
+
+// TestSetRollingOutCondition covers the signal the scaling conditions no longer
+// carry, so rollout progress is still visible somewhere.
+func TestSetRollingOutCondition(t *testing.T) {
+	rollingOut := func(scope *controlplane) *metav1.Condition {
+		setRollingOutCondition(scope)
+
+		return conditions.Get(scope.kcp, string(cpv1beta2.K0sControlPlaneRollingOutCondition))
+	}
+
+	t.Run("every machine up to date", func(t *testing.T) {
+		cond := rollingOut(scalingScope(3, 3, 0, 3))
+
+		require.NotNil(t, cond)
+		require.Equal(t, metav1.ConditionFalse, cond.Status)
+		require.Equal(t, cpv1beta2.K0sControlPlaneNotRollingOutReason, cond.Reason)
+	})
+
+	t.Run("a machine left to replace", func(t *testing.T) {
+		cond := rollingOut(scalingScope(3, 3, 0, 1))
+
+		require.NotNil(t, cond)
+		require.Equal(t, metav1.ConditionTrue, cond.Status)
+		require.Equal(t, cpv1beta2.K0sControlPlaneRollingOutReason, cond.Reason)
+		require.Contains(t, cond.Message, "2 not up-to-date")
+	})
+
+	t.Run("no machines at all", func(t *testing.T) {
+		cond := rollingOut(scalingScope(3, 0, 0, 0))
+
+		require.NotNil(t, cond)
+		require.Equal(t, metav1.ConditionFalse, cond.Status)
+	})
+
+	t.Run("the status path sets it", func(t *testing.T) {
+		scope := scalingScope(3, 3, 0, 1)
+		require.NoError(t, computeReplicas(scope))
+
+		require.NotNil(t, conditions.Get(scope.kcp, string(cpv1beta2.K0sControlPlaneRollingOutCondition)),
+			"the condition has to come from the status path, not only from its own function")
 	})
 }
 


### PR DESCRIPTION
Two defects in how control plane progress is reported:

- Report scaling from the machine total rather than the up to date count
- Add the RollingOut condition so rollout progress is still reported